### PR TITLE
Player-facing wired chest server (Scrigno) — currency + furni storage

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -77,6 +77,8 @@ import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariable
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableTextConnector;
 import com.eu.habbo.habbohotel.items.interactions.wired.selector.*;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.*;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestCurrency;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestFurni;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
@@ -370,6 +372,12 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_cnd_neg_has_var", WiredConditionNotHasVariable.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_var_val_match", WiredConditionVariableValueMatch.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_var_age_match", WiredConditionVariableAgeMatch.class));
+        // Player-facing wired chest (Scrigno) — currency + furni storage
+        this.interactionsList.add(new ItemInteraction("wf_storage_coins1", InteractionWiredChestCurrency.class));
+        this.interactionsList.add(new ItemInteraction("wf_storage_coins2", InteractionWiredChestCurrency.class));
+        this.interactionsList.add(new ItemInteraction("wf_storage_furni1", InteractionWiredChestFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_storage_furni2", InteractionWiredChestFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_storage_furni_starter", InteractionWiredChestFurni.class));
 
 
         this.interactionsList.add(new ItemInteraction("wf_xtra_random", WiredExtraRandom.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestStorage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestStorage.java
@@ -1,0 +1,296 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * State of a player-facing wired chest (Scrigno). Holds the stored CONTENTS (a list of {@link Entry}
+ * rows — currency {@link #KIND_CURRENCY} or furni base-types {@link #KIND_FURNI}) PLUS the chest's
+ * player-facing CONFIG (name / description / access flags / capacity / appearance / notification prefs).
+ * Persisted as JSON in the chest furni's own {@code items.wired_data}, serialized via
+ * {@link WiredManager#getGson()}. Old payloads ({@code {entries:[...]}}) still load — the config fields
+ * just default.
+ *
+ * <p>Pure model — no room/DB access — so it stays unit-testable.</p>
+ */
+public class ChestStorage {
+    public static final int KIND_CURRENCY = 0;
+    public static final int KIND_FURNI = 1;
+
+    public static final int DEFAULT_CAPACITY = 5000;
+    public static final int CAPACITY_STEP = 5000;
+    public static final int MAX_CAPACITY = 1_000_000;
+
+    /** A single chest row. {@code type} is the currency type (KIND_CURRENCY) or base item id (KIND_FURNI). */
+    public static class Entry {
+        public int kind;
+        public int type;
+        public int quantity;
+
+        public Entry() {
+        }
+
+        public Entry(int kind, int type, int quantity) {
+            this.kind = kind;
+            this.type = type;
+            this.quantity = quantity;
+        }
+    }
+
+    public static final int MAX_LOG = 50;
+
+    /** A transaction-log row (deposit / withdraw), newest first. */
+    public static class LogEntry {
+        public String type;      // "deposit" | "withdraw"
+        public long timestamp;   // epoch millis
+        public String userName;
+        public int withdrawn;
+        public int deposited;
+
+        public LogEntry() {
+        }
+
+        public LogEntry(String type, long timestamp, String userName, int withdrawn, int deposited) {
+            this.type = type;
+            this.timestamp = timestamp;
+            this.userName = userName;
+            this.withdrawn = withdrawn;
+            this.deposited = deposited;
+        }
+    }
+
+    private final List<Entry> entries = new ArrayList<>();
+    private final List<LogEntry> log = new ArrayList<>();
+
+    // --- player-facing config ---
+    private String name = "";
+    private String description = "";
+    private boolean accessOpen = true;       // everyone can open
+    private boolean accessDonate = false;    // everyone can donate
+    private int capacityMax = DEFAULT_CAPACITY;
+    private int appearanceState = 0;         // 0 = open when someone looks inside
+    private boolean notifyFull = false;
+    private boolean notifyDonation = false;
+    private boolean notifyWithdraw = false;
+    private boolean notifyEmpty = false;
+    private boolean notifyWired = false;
+    private int notifyMode = 0;              // 0 = always
+
+    public List<Entry> entries() {
+        return this.entries;
+    }
+
+    public boolean isEmpty() {
+        return this.entries.isEmpty();
+    }
+
+    /** Total quantity across every entry of a kind. */
+    public int total(int kind) {
+        int sum = 0;
+        for (Entry e : this.entries) {
+            if (e.kind == kind) {
+                sum += Math.max(0, e.quantity);
+            }
+        }
+        return sum;
+    }
+
+    /** Quantity held for a specific kind+type. */
+    public int count(int kind, int type) {
+        int sum = 0;
+        for (Entry e : this.entries) {
+            if (e.kind == kind && e.type == type) {
+                sum += Math.max(0, e.quantity);
+            }
+        }
+        return sum;
+    }
+
+    public boolean has(int kind, int type, int quantity) {
+        return this.count(kind, type) >= quantity;
+    }
+
+    /** Distinct types present for a kind, in insertion order. */
+    public List<Integer> distinctTypes(int kind) {
+        Set<Integer> seen = new LinkedHashSet<>();
+        for (Entry e : this.entries) {
+            if (e.kind == kind && e.quantity > 0) {
+                seen.add(e.type);
+            }
+        }
+        return new ArrayList<>(seen);
+    }
+
+    /** Add quantity to a kind+type, merging into the existing entry if present. No-op for quantity &lt;= 0. */
+    public void add(int kind, int type, int quantity) {
+        if (quantity <= 0) {
+            return;
+        }
+        for (Entry e : this.entries) {
+            if (e.kind == kind && e.type == type) {
+                e.quantity += quantity;
+                return;
+            }
+        }
+        this.entries.add(new Entry(kind, type, quantity));
+    }
+
+    /**
+     * Remove up to {@code quantity} of a specific kind+type. Returns how many were actually removed
+     * (capped by what's available). Entries that reach zero are dropped. Never goes negative.
+     */
+    public int take(int kind, int type, int quantity) {
+        if (quantity <= 0) {
+            return 0;
+        }
+        int taken = 0;
+        var it = this.entries.iterator();
+        while (it.hasNext() && taken < quantity) {
+            Entry e = it.next();
+            if (e.kind != kind || e.type != type || e.quantity <= 0) {
+                continue;
+            }
+            int remove = Math.min(e.quantity, quantity - taken);
+            e.quantity -= remove;
+            taken += remove;
+            if (e.quantity <= 0) {
+                it.remove();
+            }
+        }
+        return taken;
+    }
+
+    // --- config getters/setters ---
+    public String getName() { return this.name == null ? "" : this.name; }
+    public void setName(String value) { this.name = (value == null) ? "" : value; }
+
+    public String getDescription() { return this.description == null ? "" : this.description; }
+    public void setDescription(String value) { this.description = (value == null) ? "" : value; }
+
+    public boolean isAccessOpen() { return this.accessOpen; }
+    public void setAccessOpen(boolean value) { this.accessOpen = value; }
+
+    public boolean isAccessDonate() { return this.accessDonate; }
+    public void setAccessDonate(boolean value) { this.accessDonate = value; }
+
+    public int getCapacityMax() { return this.capacityMax <= 0 ? DEFAULT_CAPACITY : this.capacityMax; }
+    public void setCapacityMax(int value) { this.capacityMax = Math.max(DEFAULT_CAPACITY, Math.min(MAX_CAPACITY, value)); }
+
+    public int getAppearanceState() { return this.appearanceState; }
+    public void setAppearanceState(int value) { this.appearanceState = value; }
+
+    public boolean isNotifyFull() { return this.notifyFull; }
+    public boolean isNotifyDonation() { return this.notifyDonation; }
+    public boolean isNotifyWithdraw() { return this.notifyWithdraw; }
+    public boolean isNotifyEmpty() { return this.notifyEmpty; }
+    public boolean isNotifyWired() { return this.notifyWired; }
+    public int getNotifyMode() { return this.notifyMode; }
+
+    public void setNotifications(boolean full, boolean donation, boolean withdraw, boolean empty, boolean wired, int mode) {
+        this.notifyFull = full;
+        this.notifyDonation = donation;
+        this.notifyWithdraw = withdraw;
+        this.notifyEmpty = empty;
+        this.notifyWired = wired;
+        this.notifyMode = mode;
+    }
+
+    public List<LogEntry> getLog() {
+        return this.log;
+    }
+
+    /** Record a transaction at the head of the log, keeping at most {@link #MAX_LOG} rows. */
+    public void addLog(LogEntry entry) {
+        if (entry == null) return;
+        this.log.add(0, entry);
+        while (this.log.size() > MAX_LOG) {
+            this.log.remove(this.log.size() - 1);
+        }
+    }
+
+    public String toJson() {
+        JsonData data = new JsonData(this.entries);
+        data.name = this.name;
+        data.description = this.description;
+        data.accessOpen = this.accessOpen;
+        data.accessDonate = this.accessDonate;
+        data.capacityMax = this.capacityMax;
+        data.appearanceState = this.appearanceState;
+        data.notifyFull = this.notifyFull;
+        data.notifyDonation = this.notifyDonation;
+        data.notifyWithdraw = this.notifyWithdraw;
+        data.notifyEmpty = this.notifyEmpty;
+        data.notifyWired = this.notifyWired;
+        data.notifyMode = this.notifyMode;
+        data.log = this.log;
+        return WiredManager.getGson().toJson(data);
+    }
+
+    /** Parse from a wired_data JSON string. Null / blank / malformed → an empty chest (never throws). */
+    public static ChestStorage fromJson(String json) {
+        ChestStorage chest = new ChestStorage();
+        if (json == null || json.isEmpty() || !json.startsWith("{")) {
+            return chest;
+        }
+        try {
+            JsonData data = WiredManager.getGson().fromJson(json, JsonData.class);
+            if (data != null) {
+                if (data.entries != null) {
+                    for (Entry e : data.entries) {
+                        if (e != null && e.quantity > 0) {
+                            chest.add(e.kind, e.type, e.quantity);
+                        }
+                    }
+                }
+                chest.name = (data.name == null) ? "" : data.name;
+                chest.description = (data.description == null) ? "" : data.description;
+                chest.accessOpen = data.accessOpen;
+                chest.accessDonate = data.accessDonate;
+                chest.capacityMax = (data.capacityMax <= 0) ? DEFAULT_CAPACITY : data.capacityMax;
+                chest.appearanceState = data.appearanceState;
+                chest.notifyFull = data.notifyFull;
+                chest.notifyDonation = data.notifyDonation;
+                chest.notifyWithdraw = data.notifyWithdraw;
+                chest.notifyEmpty = data.notifyEmpty;
+                chest.notifyWired = data.notifyWired;
+                chest.notifyMode = data.notifyMode;
+                if (data.log != null) {
+                    for (LogEntry le : data.log) {
+                        if (le != null) chest.log.add(le);
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+            // malformed payload → empty chest
+        }
+        return chest;
+    }
+
+    static class JsonData {
+        List<Entry> entries;
+        String name = "";
+        String description = "";
+        boolean accessOpen = true;
+        boolean accessDonate = false;
+        int capacityMax = DEFAULT_CAPACITY;
+        int appearanceState = 0;
+        boolean notifyFull = false;
+        boolean notifyDonation = false;
+        boolean notifyWithdraw = false;
+        boolean notifyEmpty = false;
+        boolean notifyWired = false;
+        int notifyMode = 0;
+        List<LogEntry> log;
+
+        JsonData() {
+        }
+
+        JsonData(List<Entry> entries) {
+            this.entries = entries;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChest.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChest.java
@@ -1,0 +1,67 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Base for Phase-2 wired storage chests (config-based v1). A chest is a config-holder furni (it opens
+ * a dialog via the {@link InteractionWiredExtra} channel, but is never applied as a stack add-on — the
+ * engine only matches specific add-on classes) whose contents live as JSON in its own
+ * {@code items.wired_data} ({@link ChestStorage}). The give effects + chest conditions read/mutate the
+ * contents through {@link #getContents()} and persist with {@link #persistContents()}.
+ */
+public abstract class InteractionWiredChest extends InteractionWiredExtra {
+    protected ChestStorage contents = new ChestStorage();
+
+    protected InteractionWiredChest(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    protected InteractionWiredChest(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return this.contents.toJson();
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.contents = ChestStorage.fromJson(set.getString("wired_data"));
+    }
+
+    @Override
+    public void onPickUp() {
+        this.contents = new ChestStorage();
+    }
+
+    @Override
+    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
+
+    }
+
+    @Override
+    public boolean hasConfiguration() {
+        return true;
+    }
+
+    public ChestStorage getContents() {
+        return this.contents;
+    }
+
+    /** Schedule a save of the (mutated) contents to items.wired_data via {@code InteractionWired.run()}. */
+    public void persistContents() {
+        this.needsUpdate(true);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestCurrency.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestCurrency.java
@@ -1,0 +1,86 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Credit Chest (furni classnames {@code wf_storage_coins1} / {@code wf_storage_coins2}). Holds a single
+ * currency pool, configured via its dialog (currency type + amount) and dispensed by
+ * {@code WiredEffectGiveCurrencyFromChest}. Currency type convention: {@code -1} = credits
+ * ({@link com.eu.habbo.habbohotel.users.Habbo#giveCredits}); {@code >= 0} = a points type
+ * ({@code Habbo.givePoints(type, amount)} — e.g. 0 duckets, 5 diamonds).
+ */
+public class InteractionWiredChestCurrency extends InteractionWiredChest {
+    /** Client WiredActionLayoutCode value for the chest dialog. */
+    public static final int CODE = 100;
+    public static final int CURRENCY_CREDITS = -1;
+
+    public InteractionWiredChestCurrency(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionWiredChestCurrency(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    /**
+     * Player-first: clicking the chest opens the player Scrigno UI (balance + deposit/withdraw) instead
+     * of the wired-config dialog. The contents stay a {@link ChestStorage} so contracts / give-from-chest
+     * keep working. Anyone can open; withdraw is gated to room rights server-side (see ChestWithdrawEvent).
+     */
+    @Override
+    public void onClick(GameClient client, Room room, Object[] objects) throws Exception {
+        if (client == null || room == null) return;
+        // "Tutti possono aprire" toggle: anyone if accessOpen, otherwise room rights only.
+        if (!this.contents.isAccessOpen() && !room.hasRights(client.getHabbo())) return;
+        client.sendResponse(new ChestDataComposer(this));
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int[] params = settings.getIntParams();
+        int currencyType = (params.length > 0) ? params[0] : CURRENCY_CREDITS;
+        int amount = (params.length > 1) ? Math.max(0, params[1]) : 0;
+
+        // Re-configuring the chest replaces its pool.
+        this.contents = new ChestStorage();
+        if (amount > 0) {
+            this.contents.add(ChestStorage.KIND_CURRENCY, currencyType, amount);
+        }
+        return true;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        int currencyType = CURRENCY_CREDITS;
+        int amount = 0;
+        for (ChestStorage.Entry e : this.contents.entries()) {
+            if (e.kind == ChestStorage.KIND_CURRENCY) {
+                currencyType = e.type;
+                amount = e.quantity;
+                break;
+            }
+        }
+
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(currencyType);
+        message.appendInt(amount);
+        message.appendInt(0);
+        message.appendInt(CODE);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestFurni.java
@@ -1,0 +1,84 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Furni Chest (classnames {@code wf_storage_furni1/2/_starter}). Config-based v1: holds a single furni
+ * base-type pool (base item id + quantity), set via its dialog and dispensed by
+ * {@code WiredEffectGiveFurniFromChest}. (Multi-type chests are a future extension — the
+ * {@link ChestStorage} model already supports many entries.)
+ */
+public class InteractionWiredChestFurni extends InteractionWiredChest {
+    /** Client WiredActionLayoutCode value for the furni-chest dialog. */
+    public static final int CODE = 101;
+
+    public InteractionWiredChestFurni(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionWiredChestFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    /**
+     * Player-first: clicking the furni chest opens the player Scrigno UI (item grid + withdraw) instead of
+     * the wired-config dialog. Anyone can open if accessOpen; withdraw is gated to room rights server-side
+     * (see ChestWithdrawFurniEvent).
+     */
+    @Override
+    public void onClick(GameClient client, Room room, Object[] objects) throws Exception {
+        if (client == null || room == null) return;
+        if (!this.contents.isAccessOpen() && !room.hasRights(client.getHabbo())) return;
+        client.sendResponse(new ChestDataComposer(this));
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int[] params = settings.getIntParams();
+        int baseItemId = (params.length > 0) ? params[0] : 0;
+        int quantity = (params.length > 1) ? Math.max(0, params[1]) : 0;
+
+        this.contents = new ChestStorage();
+        // Only stock a valid, existing base item.
+        if (baseItemId > 0 && quantity > 0 && Emulator.getGameEnvironment().getItemManager().getItem(baseItemId) != null) {
+            this.contents.add(ChestStorage.KIND_FURNI, baseItemId, quantity);
+        }
+        return true;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        int baseItemId = 0;
+        int quantity = 0;
+        for (ChestStorage.Entry e : this.contents.entries()) {
+            if (e.kind == ChestStorage.KIND_FURNI) {
+                baseItemId = e.type;
+                quantity = e.quantity;
+                break;
+            }
+        }
+
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(baseItemId);
+        message.appendInt(quantity);
+        message.appendInt(0);
+        message.appendInt(CODE);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -459,6 +459,13 @@ public class PacketManager {
         this.registerHandler(Incoming.ClickUserEvent, ClickUserEvent.class);
         this.registerHandler(Incoming.ToggleFloorItemEvent, ToggleFloorItemEvent.class);
         this.registerHandler(Incoming.ToggleWallItemEvent, ToggleWallItemEvent.class);
+        this.registerHandler(Incoming.ChestDepositEvent, ChestDepositEvent.class);
+        this.registerHandler(Incoming.ChestWithdrawEvent, ChestWithdrawEvent.class);
+        this.registerHandler(Incoming.ChestWithdrawFurniEvent, ChestWithdrawFurniEvent.class);
+        this.registerHandler(Incoming.ChestSaveSettingsEvent, ChestSaveSettingsEvent.class);
+        this.registerHandler(Incoming.ChestSaveNotificationsEvent, ChestSaveNotificationsEvent.class);
+        this.registerHandler(Incoming.ChestUpgradeCapacityEvent, ChestUpgradeCapacityEvent.class);
+        this.registerHandler(Incoming.ChestRequestLogEvent, ChestRequestLogEvent.class);
         this.registerHandler(Incoming.RoomBackgroundEvent, RoomBackgroundEvent.class);
         this.registerHandler(Incoming.MannequinSaveNameEvent, MannequinSaveNameEvent.class);
         this.registerHandler(Incoming.MannequinSaveLookEvent, MannequinSaveLookEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -2,6 +2,14 @@ package com.eu.habbo.messages.incoming;
 
 public class Incoming {
     public static final int PongEvent = 2596;
+    // Player-facing wired chest (Scrigno)
+    public static final int ChestDepositEvent = 9313;
+    public static final int ChestWithdrawEvent = 9314;
+    public static final int ChestSaveSettingsEvent = 9315;
+    public static final int ChestSaveNotificationsEvent = 9316;
+    public static final int ChestUpgradeCapacityEvent = 9317;
+    public static final int ChestRequestLogEvent = 9318;
+    public static final int ChestWithdrawFurniEvent = 9320;
     public static final int ChangeNameCheckUsernameEvent = 3950;
     public static final int ConfirmChangeNameEvent = 2977;
     public static final int ActivateEffectEvent = 2959;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositEvent.java
@@ -1,0 +1,55 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Player deposits currency into a wired chest (Scrigno). Reads {@code int itemId, int currencyType,
+ * int amount}; allowed if the chest permits donations or the user has room rights. Debits the user
+ * (if affordable), adds to the pool (capped at the chest's capacity), logs it, pushes back the state.
+ */
+public class ChestDepositEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int currencyType = this.packet.readInt();
+        int amount = this.packet.readInt();
+        if (amount <= 0) return;
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        ChestStorage contents = chest.getContents();
+
+        if (!contents.isAccessDonate() && !room.hasRights(habbo)) return;
+
+        int balance = (currencyType < 0)
+                ? habbo.getHabboInfo().getCredits()
+                : habbo.getHabboInfo().getCurrencyAmount(currencyType);
+        if (balance < amount) return;
+
+        int capacityLeft = contents.getCapacityMax() - contents.total(ChestStorage.KIND_CURRENCY);
+        if (capacityLeft <= 0) return;
+        if (amount > capacityLeft) amount = capacityLeft;
+
+        if (currencyType < 0) habbo.giveCredits(-amount);
+        else habbo.givePoints(currencyType, -amount);
+
+        contents.add(ChestStorage.KIND_CURRENCY, currencyType, amount);
+        contents.addLog(new ChestStorage.LogEntry("deposit", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), 0, amount));
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestRequestLogEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestRequestLogEvent.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestLogComposer;
+
+/**
+ * Requests a wired chest's transaction log: {@code int itemId}. Responds with {@link ChestLogComposer}.
+ */
+public class ChestRequestLogEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        this.client.sendResponse(new ChestLogComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestSaveNotificationsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestSaveNotificationsEvent.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Saves a wired chest's notification prefs (room-rights only): {@code int itemId, bool full,
+ * bool donation, bool withdraw, bool empty, bool wired, int mode}.
+ */
+public class ChestSaveNotificationsEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        boolean full = this.packet.readBoolean();
+        boolean donation = this.packet.readBoolean();
+        boolean withdraw = this.packet.readBoolean();
+        boolean empty = this.packet.readBoolean();
+        boolean wired = this.packet.readBoolean();
+        int mode = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+        if (!room.hasRights(habbo)) return;
+
+        chest.getContents().setNotifications(full, donation, withdraw, empty, wired, mode);
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestSaveSettingsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestSaveSettingsEvent.java
@@ -1,0 +1,50 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Saves a wired chest's settings (room-rights only): {@code int itemId, string name, string description,
+ * bool accessOpen, bool accessDonate, int appearanceState}.
+ */
+public class ChestSaveSettingsEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        String name = this.packet.readString();
+        String description = this.packet.readString();
+        boolean accessOpen = this.packet.readBoolean();
+        boolean accessDonate = this.packet.readBoolean();
+        int appearanceState = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+        if (!room.hasRights(habbo)) return;
+
+        ChestStorage c = chest.getContents();
+        c.setName(bound(name, 60));
+        c.setDescription(bound(description, 255));
+        c.setAccessOpen(accessOpen);
+        c.setAccessDonate(accessDonate);
+        c.setAppearanceState(appearanceState);
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+
+    private static String bound(String value, int max) {
+        if (value == null) return "";
+        return value.length() > max ? value.substring(0, max) : value;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestUpgradeCapacityEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestUpgradeCapacityEvent.java
@@ -1,0 +1,56 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Buys extra chest capacity (room-rights only): {@code int itemId, int quantity}. Each step adds
+ * {@link ChestStorage#CAPACITY_STEP} (+5000) and costs {@link #COST_CREDITS} credits +
+ * {@link #COST_DIAMONDS} diamonds (points type {@link #DIAMOND_TYPE}). All-or-nothing.
+ */
+public class ChestUpgradeCapacityEvent extends MessageHandler {
+    public static final int COST_CREDITS = 10;
+    public static final int COST_DIAMONDS = 10;
+    public static final int DIAMOND_TYPE = 5;
+    private static final int MAX_QUANTITY = 10;
+
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int quantity = this.packet.readInt();
+        if (quantity <= 0) return;
+        quantity = Math.min(quantity, MAX_QUANTITY);
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+        if (!room.hasRights(habbo)) return;
+
+        ChestStorage c = chest.getContents();
+        if (c.getCapacityMax() + (ChestStorage.CAPACITY_STEP * quantity) > ChestStorage.MAX_CAPACITY) return;
+
+        int totalCredits = COST_CREDITS * quantity;
+        int totalDiamonds = COST_DIAMONDS * quantity;
+
+        if (habbo.getHabboInfo().getCredits() < totalCredits) return;
+        if (habbo.getHabboInfo().getCurrencyAmount(DIAMOND_TYPE) < totalDiamonds) return;
+
+        habbo.giveCredits(-totalCredits);
+        habbo.givePoints(DIAMOND_TYPE, -totalDiamonds);
+
+        c.setCapacityMax(c.getCapacityMax() + (ChestStorage.CAPACITY_STEP * quantity));
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawEvent.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Player withdraws currency from a wired chest (Scrigno). Reads {@code int itemId, int currencyType,
+ * int amount} (amount {@code < 0} = withdraw all of that type). Restricted to users with room rights
+ * (anti-theft). Takes from the pool, credits the user, logs it, pushes back the state.
+ */
+public class ChestWithdrawEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int currencyType = this.packet.readInt();
+        int amount = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        if (!room.hasRights(habbo)) return;
+
+        ChestStorage contents = chest.getContents();
+        int available = contents.count(ChestStorage.KIND_CURRENCY, currencyType);
+        if (available <= 0) return;
+
+        int requested = (amount < 0) ? available : Math.min(amount, available);
+        if (requested <= 0) return;
+
+        int taken = contents.take(ChestStorage.KIND_CURRENCY, currencyType, requested);
+        if (taken <= 0) return;
+
+        contents.addLog(new ChestStorage.LogEntry("withdraw", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), taken, 0));
+        chest.persistContents();
+
+        if (currencyType < 0) habbo.giveCredits(taken);
+        else habbo.givePoints(currencyType, taken);
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawFurniEvent.java
@@ -1,0 +1,65 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Player withdraws stored furni from a wired furni chest (Scrigno furni). Reads {@code int itemId,
+ * int baseItemId, int amount} (amount {@code < 0} = withdraw all of that base type). Restricted to users
+ * with room rights (anti-theft). Decrements the chest pool, creates that many items into the player's
+ * inventory, logs it, and pushes back the chest state. Mirrors {@link ChestWithdrawEvent} (currency).
+ */
+public class ChestWithdrawFurniEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int baseItemId = this.packet.readInt();
+        int amount = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        if (!room.hasRights(habbo)) return;
+
+        Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(baseItemId);
+        if (baseItem == null) return;
+
+        ChestStorage contents = chest.getContents();
+        int available = contents.count(ChestStorage.KIND_FURNI, baseItemId);
+        if (available <= 0) return;
+
+        int requested = (amount < 0) ? available : Math.min(amount, available);
+        if (requested <= 0) return;
+
+        int taken = contents.take(ChestStorage.KIND_FURNI, baseItemId, requested);
+        if (taken <= 0) return;
+
+        for (int i = 0; i < taken; i++) {
+            HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getHabboInfo().getId(), baseItem, 0, 0, "");
+            if (created == null) continue;
+            this.client.sendResponse(new AddHabboItemComposer(created));
+            habbo.getInventory().getItemsComponent().addItem(created);
+        }
+        this.client.sendResponse(new InventoryRefreshComposer());
+
+        contents.addLog(new ChestStorage.LogEntry("withdraw", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), taken, 0));
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -4,6 +4,9 @@ public class Outgoing {
     public static final int PetStatusUpdateComposer = 1907;//error 404
 
     public final static int CfhTopicsMessageComposer = 325;
+    // Player-facing wired chest (Scrigno)
+    public final static int ChestDataComposer = 9312;
+    public final static int ChestLogComposer = 9319;
     public final static int FavoriteRoomsCountComposer = 151;
     public final static int UserCurrencyComposer = 2018;
     public final static int RedeemVoucherOKComposer = 3336;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestDataComposer.java
@@ -1,0 +1,86 @@
+package com.eu.habbo.messages.outgoing.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestFurni;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Player-facing wired chest (Scrigno) state push. Sent on open and after every deposit / withdraw /
+ * settings change so the client {@code FurnitureChestView} can render the full window (name, description,
+ * balance, capacity, access flags, appearance, notification prefs). Phase-1 currency-only contents.
+ * Wire layout:
+ * <pre>
+ *   int itemId, string name, string description,
+ *   int capacityMax, int used,
+ *   bool accessOpen, bool accessDonate, int appearanceState,
+ *   bool notifyFull, bool notifyDonation, bool notifyWithdraw, bool notifyEmpty, bool notifyWired, int notifyMode,
+ *   int entryCount, [int currencyType, int amount]*,
+ *   int chestKind (0 = currency, 1 = furni),
+ *   int furniCount, [int baseItemId, int quantity]*
+ * </pre>
+ * For a furni chest, {@code used} is the total stored furni count and the currency entry list is empty;
+ * for a currency chest the furni list is empty.
+ */
+public class ChestDataComposer extends MessageComposer {
+    private final InteractionWiredChest chest;
+
+    public ChestDataComposer(InteractionWiredChest chest) {
+        this.chest = chest;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        ChestStorage c = this.chest.getContents();
+        int chestKind = (this.chest instanceof InteractionWiredChestFurni)
+                ? ChestStorage.KIND_FURNI : ChestStorage.KIND_CURRENCY;
+
+        this.response.init(Outgoing.ChestDataComposer);
+        this.response.appendInt(this.chest.getId());
+        this.response.appendString(c.getName());
+        this.response.appendString(c.getDescription());
+        this.response.appendInt(c.getCapacityMax());
+        this.response.appendInt(c.total(chestKind));
+        this.response.appendBoolean(c.isAccessOpen());
+        this.response.appendBoolean(c.isAccessDonate());
+        this.response.appendInt(c.getAppearanceState());
+        this.response.appendBoolean(c.isNotifyFull());
+        this.response.appendBoolean(c.isNotifyDonation());
+        this.response.appendBoolean(c.isNotifyWithdraw());
+        this.response.appendBoolean(c.isNotifyEmpty());
+        this.response.appendBoolean(c.isNotifyWired());
+        this.response.appendInt(c.getNotifyMode());
+
+        List<ChestStorage.Entry> entries = new ArrayList<>();
+        for (ChestStorage.Entry e : c.entries()) {
+            if (e.kind == ChestStorage.KIND_CURRENCY && e.quantity > 0) entries.add(e);
+        }
+
+        this.response.appendInt(entries.size());
+        for (ChestStorage.Entry e : entries) {
+            this.response.appendInt(e.type);
+            this.response.appendInt(e.quantity);
+        }
+
+        // chest kind + furni contents (base item id + quantity per stored type)
+        this.response.appendInt(chestKind);
+
+        List<ChestStorage.Entry> furni = new ArrayList<>();
+        for (ChestStorage.Entry e : c.entries()) {
+            if (e.kind == ChestStorage.KIND_FURNI && e.quantity > 0) furni.add(e);
+        }
+
+        this.response.appendInt(furni.size());
+        for (ChestStorage.Entry e : furni) {
+            this.response.appendInt(e.type);
+            this.response.appendInt(e.quantity);
+        }
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestLogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestLogComposer.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.outgoing.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+
+/**
+ * Wired chest (Scrigno) transaction log, newest first. Wire layout:
+ * {@code int itemId, int rowCount, [string type, int epochSeconds, string userName, int withdrawn, int deposited]*}.
+ */
+public class ChestLogComposer extends MessageComposer {
+    private final InteractionWiredChest chest;
+
+    public ChestLogComposer(InteractionWiredChest chest) {
+        this.chest = chest;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.ChestLogComposer);
+        this.response.appendInt(this.chest.getId());
+
+        List<ChestStorage.LogEntry> log = this.chest.getContents().getLog();
+        this.response.appendInt(log.size());
+
+        for (ChestStorage.LogEntry e : log) {
+            this.response.appendString(e.type == null ? "" : e.type);
+            this.response.appendInt((int) (e.timestamp / 1000L));
+            this.response.appendString(e.userName == null ? "" : e.userName);
+            this.response.appendInt(e.withdrawn);
+            this.response.appendInt(e.deposited);
+        }
+
+        return this.response;
+    }
+}


### PR DESCRIPTION
**Draft** — server side of the player-facing **wired chest (Scrigno)**. Pairs with the Nitro-V3 client PR and the Nitro_Render_V3 protocol PR.

Clean, focused, Trove-free, based directly on `dev` (mergeable).

## What's here
- **ChestStorage** model — currency + furni entries, capacity, access/appearance/notification config, bounded transaction log; persisted as JSON in the chest furni's own `wired_data` (backward-compatible).
- **InteractionWiredChestCurrency** / **InteractionWiredChestFurni** — clicking the chest opens the player Scrigno UI (gated: anyone if "everyone can open", else room rights).
- Incoming events: deposit, withdraw, **withdraw-furni** (creates items into the player's inventory), save-settings, save-notifications, upgrade-capacity, request-log.
- Outgoing: `ChestDataComposer` (chestKind + currency + furni list) + `ChestLogComposer`.
- Headers `9312`–`9320`; registered in `Incoming`/`Outgoing`/`PacketManager`; furni registered in `ItemManager` (`wf_storage_coins1/2`, `wf_storage_furni1/2/_starter`).

`mvn compile` passes on `dev`.

## Note
This intentionally contains **only the player-chest server**. The broader wired Phase-1/2 work (contracts, quests, place/remove-furni, give-from-chest) and the java25 migration live on a separate branch — they depend on a Trove-based refactor that conflicts with `dev`'s Trove removal, so they're kept out of this PR for a clean, reviewable change.


---
### 🔗 Coordinated PR set — player wired chest + press_keybind
This change is part of one cross-repo feature. **Merge order** (the client type-checks against the published renderer):
**renderer #111 + emu #291 + emu #292 → publish `@nitrots/nitro-renderer` → then client #289.**

| Layer | PR |
|---|---|
| Client (Nitro-V3) | duckietm/Nitro-V3#289 |
| Renderer (Nitro_Render_V3) | duckietm/Nitro_Render_V3#111 |
| Server — chest (Arcturus) | duckietm/Arcturus-Morningstar-Extended#291 |
| Server — press_keybind (Arcturus) | duckietm/Arcturus-Morningstar-Extended#292 |
