### PR TITLE
feat(wired): press_keybind trigger — server (header 9311)

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -259,6 +259,7 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_win", WiredTriggerTeamWins.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_lose", WiredTriggerTeamLoses.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_recv_signal", WiredTriggerReceiveSignal.class));
+        this.interactionsList.add(new ItemInteraction("wf_trg_press_keybind", WiredTriggerPressKeybind.class));
 
 
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_state", WiredEffectToggleFurni.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerPressKeybind.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerPressKeybind.java
@@ -1,0 +1,120 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Fires when a user presses a configured keybind key in the room. The PRESS_KEYBIND event is raised by
+ * the client-&gt;server packet handler {@code PressKeybindEvent} (header 9311) via
+ * {@link WiredManager#triggerKeybind(Room, RoomUnit, int)}; the pressed key code travels on the event's
+ * {@code actionParameter}. One optional int param {@code [keyCode]}: {@code 0} fires for ANY key,
+ * otherwise it fires only when the pressed key code equals it.
+ *
+ * <p>Client side (Nitro): the trigger dialog must map to {@code WiredTriggerLayout} code
+ * {@code PRESS_KEYBIND = 26} (must equal {@link #type}'s {@code code}) and a new outgoing packet must
+ * send the pressed key code to header 9311. See {@code docs/plans/press-keybind-implementation-plan.md}.
+ */
+public class WiredTriggerPressKeybind extends InteractionWiredTrigger {
+    public static final WiredTriggerType type = WiredTriggerType.PRESS_KEYBIND;
+    private static final int ANY_KEY = 0;
+
+    private int keyCode = ANY_KEY;
+
+    public WiredTriggerPressKeybind(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerPressKeybind(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        if (this.keyCode == ANY_KEY) {
+            return true;
+        }
+
+        return event.getActionParameter() == this.keyCode;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.keyCode);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.keyCode = (params.length > 0) ? Math.max(ANY_KEY, params[0]) : ANY_KEY;
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.keyCode));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.keyCode = ANY_KEY;
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData != null && wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            if (data != null) {
+                this.keyCode = Math.max(ANY_KEY, data.keyCode);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.keyCode = ANY_KEY;
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return false;
+    }
+
+    static class JsonData {
+        int keyCode;
+
+        public JsonData(int keyCode) {
+            this.keyCode = keyCode;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredTriggerType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredTriggerType.java
@@ -29,7 +29,8 @@ public enum WiredTriggerType {
     CUSTOM(13),
     STARTS_DANCING(11),
     STOPS_DANCING(11),
-    RECEIVE_SIGNAL(15);
+    RECEIVE_SIGNAL(15),
+    PRESS_KEYBIND(26);
 
     public final int code;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEvent.java
@@ -121,6 +121,9 @@ public final class WiredEvent {
         /** Signal received from a Send Signal effect */
         SIGNAL_RECEIVED(WiredTriggerType.RECEIVE_SIGNAL),
 
+        /** A user pressed a configured keybind key */
+        PRESS_KEYBIND(WiredTriggerType.PRESS_KEYBIND),
+
         /** Custom trigger type for plugins */
         CUSTOM(WiredTriggerType.CUSTOM);
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
@@ -706,6 +706,19 @@ public final class WiredManager {
     }
 
     /**
+     * Trigger when a user presses a configured keybind key (raised by the client-&gt;server
+     * PressKeybindEvent packet). The pressed key code travels on the event's actionParameter.
+     */
+    public static boolean triggerKeybind(Room room, RoomUnit user, int keyCode) {
+        if (!isEnabled() || room == null || user == null) {
+            return false;
+        }
+
+        WiredEvent event = WiredEvents.pressKeybind(room, user, keyCode);
+        return handleEvent(event);
+    }
+
+    /**
      * Trigger when a team wins a game.
      */
     public static boolean triggerTeamWins(Room room, RoomUnit user) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/migrate/WiredEvents.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/migrate/WiredEvents.java
@@ -452,6 +452,17 @@ public final class WiredEvents {
                 .build();
     }
 
+    /**
+     * Create an event for when a user presses a configured keybind key (key code on actionParameter).
+     */
+    public static WiredEvent pressKeybind(Room room, RoomUnit user, int keyCode) {
+        return WiredEvent.builder(WiredEvent.Type.PRESS_KEYBIND, room)
+                .actor(user)
+                .tile(user.getCurrentLocation())
+                .actionParameter(keyCode)
+                .build();
+    }
+
     // ========== Legacy Compatibility ==========
 
     /**

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -488,6 +488,7 @@ public class PacketManager {
         this.registerHandler(Incoming.BotSaveSettingsEvent, BotSaveSettingsEvent.class);
         this.registerHandler(Incoming.BotSettingsEvent, BotSettingsEvent.class);
         this.registerHandler(Incoming.TriggerDiceEvent, TriggerDiceEvent.class);
+        this.registerHandler(Incoming.PressKeybindEvent, com.eu.habbo.messages.incoming.rooms.items.PressKeybindEvent.class);
         this.registerHandler(Incoming.CloseDiceEvent, CloseDiceEvent.class);
         this.registerHandler(Incoming.TriggerColorWheelEvent, TriggerColorWheelEvent.class);
         this.registerHandler(Incoming.RedeemItemEvent, RedeemItemEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -504,6 +504,7 @@ public class Incoming {
     public static final int RequestEarningsCenterEvent = 9308;
     public static final int ClaimEarningsRewardEvent = 9309;
     public static final int ClaimAllEarningsRewardsEvent = 9310;
+    public static final int PressKeybindEvent = 9311;
     public static final int RequestMentionsEvent = 4803;
     public static final int MarkMentionsReadEvent = 4804;
     public static final int DeleteMentionEvent = 4805;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PressKeybindEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/PressKeybindEvent.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.incoming.MessageHandler;
+
+/**
+ * Client -&gt; server: a user pressed a configured keybind key in the room (header 9311).
+ * Payload: one int, the pressed key code. Raises the wired PRESS_KEYBIND trigger via
+ * {@link WiredManager#triggerKeybind(Room, com.eu.habbo.habbohotel.rooms.RoomUnit, int)}.
+ */
+public class PressKeybindEvent extends MessageHandler {
+    @Override
+    public int getRatelimit() {
+        return 100;
+    }
+
+    @Override
+    public void handle() throws Exception {
+        int keyCode = this.packet.readInt();
+
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) {
+            return;
+        }
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null || habbo.getRoomUnit() == null) {
+            return;
+        }
+
+        WiredManager.triggerKeybind(room, habbo.getRoomUnit(), keyCode);
+    }
+}


### PR DESCRIPTION
Adds the **server** side of the `press_keybind` wired trigger, completing the cross-repo feature whose client + renderer sides are already in review. Ported onto `dev` (Trove-free), purely **additive**.

## What
A wired trigger that fires when a user presses a configured keyboard key in the room.

- `WiredTriggerType.PRESS_KEYBIND(26)` + `WiredEvent.Type.PRESS_KEYBIND`
- `WiredEvents.pressKeybind(room, user, keyCode)` factory + `WiredManager.triggerKeybind(...)`
- `WiredTriggerPressKeybind` — stores the configured key code (`0` = any key) and matches on it
- incoming `PressKeybindEvent` (**header 9311**) — reads the pressed key code, resolves habbo + room, raises the trigger
- registered in `Incoming` + `PacketManager`; `ItemManager` binds `wf_trg_press_keybind`

## Companion PRs (same feature, across all layers)
- Client: duckietm/Nitro-V3#289 (RoomKeybindView sends header 9311)
- Renderer: duckietm/Nitro_Render_V3#111 (`PressKeybindComposer`, header 9311)

## Notes
- `mvn clean compile`: **BUILD SUCCESS** on `dev`.
- Runtime needs a `wf_trg_press_keybind` furni row in `items_base`.
- Kept **draft** until the companion client/renderer PRs land.