### PR TITLE
feat(wired): dice_rolled + user_gets_handitem triggers (server)

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -259,6 +259,8 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_win", WiredTriggerTeamWins.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_lose", WiredTriggerTeamLoses.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_recv_signal", WiredTriggerReceiveSignal.class));
+        this.interactionsList.add(new ItemInteraction("wf_trg_user_gets_handitem", WiredTriggerUserGetsHandItem.class));
+        this.interactionsList.add(new ItemInteraction("wf_trg_dice_rolled", WiredTriggerDiceRolled.class));
 
 
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_state", WiredEffectToggleFurni.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerDiceRolled.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerDiceRolled.java
@@ -1,0 +1,125 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Fires when a dice furni is rolled (its face value finalized). The DICE_ROLLED event is raised by
+ * {@code RandomDiceNumber#run()} (guarded to {@code InteractionDice}) and routed by the engine via
+ * {@link WiredTriggerType#DICE_ROLLED}. The event's source item is the dice, whose extradata holds the
+ * rolled value. One optional int param {@code [requiredValue]}: {@code 0} fires for any roll; otherwise
+ * it fires only when the rolled value equals it.
+ */
+public class WiredTriggerDiceRolled extends InteractionWiredTrigger {
+    public static final WiredTriggerType type = WiredTriggerType.DICE_ROLLED;
+    private static final int ANY_VALUE = 0;
+
+    private int requiredValue = ANY_VALUE;
+
+    public WiredTriggerDiceRolled(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerDiceRolled(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        HabboItem dice = event.getSourceItem().orElse(null);
+        if (dice == null) {
+            return false;
+        }
+
+        if (this.requiredValue == ANY_VALUE) {
+            return true;
+        }
+
+        try {
+            return Integer.parseInt(dice.getExtradata()) == this.requiredValue;
+        } catch (NumberFormatException exception) {
+            return false;
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.requiredValue);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.requiredValue = (params.length > 0) ? Math.max(ANY_VALUE, params[0]) : ANY_VALUE;
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.requiredValue));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.requiredValue = ANY_VALUE;
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData != null && wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            if (data != null) {
+                this.requiredValue = Math.max(ANY_VALUE, data.requiredValue);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.requiredValue = ANY_VALUE;
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return false;
+    }
+
+    static class JsonData {
+        int requiredValue;
+
+        public JsonData(int requiredValue) {
+            this.requiredValue = requiredValue;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerUserGetsHandItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerUserGetsHandItem.java
@@ -1,0 +1,127 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Fires when a room unit receives a hand item. The matching {@code USER_GETS_HANDITEM} event is raised
+ * by {@code RoomUnitManager#giveHandItem(RoomUnit, int)} — the single funnel every hand-item grant
+ * (the {@code WiredEffectGiveHandItem} effect, the {@code :handitem} command, butler bots, etc.) flows
+ * through — and routed by the engine to this trigger via {@link WiredTriggerType#USER_GETS_HANDITEM}.
+ *
+ * <p>The dialog carries one optional int param {@code [handItemId]}: when {@code 0} the trigger fires
+ * for <em>any</em> hand item; otherwise it only fires when the freshly-granted item id matches. The
+ * actor's {@link RoomUnit#getHandItem()} already reflects the just-granted id at raise time (the event
+ * is built after {@code setHandItem}), so {@link #matches} reads it directly and no extra event field is
+ * needed.</p>
+ *
+ * <p>Serialization mirrors the single-int trigger shape: it appends {@code intParamCount=1} and the
+ * stored {@code handItemId}, so the client reads/saves exactly one int and
+ * {@link #saveData(WiredSettings)} reads it back in the same slot.</p>
+ */
+public class WiredTriggerUserGetsHandItem extends InteractionWiredTrigger {
+    public static final WiredTriggerType type = WiredTriggerType.USER_GETS_HANDITEM;
+
+    private static final int ANY_HAND_ITEM = 0;
+
+    private int handItemId = ANY_HAND_ITEM;
+
+    public WiredTriggerUserGetsHandItem(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerUserGetsHandItem(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        RoomUnit actor = event.getActor().orElse(null);
+        if (actor == null) {
+            return false;
+        }
+
+        return this.handItemId == ANY_HAND_ITEM || actor.getHandItem() == this.handItemId;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.handItemId);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.handItemId = (params.length > 0) ? Math.max(ANY_HAND_ITEM, params[0]) : ANY_HAND_ITEM;
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.handItemId));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.handItemId = ANY_HAND_ITEM;
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData != null && wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            if (data != null) {
+                this.handItemId = Math.max(ANY_HAND_ITEM, data.handItemId);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.handItemId = ANY_HAND_ITEM;
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return true;
+    }
+
+    static class JsonData {
+        int handItemId;
+
+        public JsonData(int handItemId) {
+            this.handItemId = handItemId;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
@@ -1196,6 +1196,10 @@ public class RoomUnitManager {
     public void giveHandItem(RoomUnit roomUnit, int handItem) {
         roomUnit.setHandItem(handItem);
         this.room.sendComposer(new RoomUserHandItemComposer(roomUnit).compose());
+
+        if (handItem > 0) {
+            com.eu.habbo.habbohotel.wired.core.WiredManager.triggerUserGetsHandItem(this.room, roomUnit);
+        }
     }
 
     // ==================== IDLE AND DANCE ====================

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredTriggerType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredTriggerType.java
@@ -29,7 +29,10 @@ public enum WiredTriggerType {
     CUSTOM(13),
     STARTS_DANCING(11),
     STOPS_DANCING(11),
-    RECEIVE_SIGNAL(15);
+    RECEIVE_SIGNAL(15),
+    // New client dialogs. Each requires the matching Nitro WiredTriggerLayoutCode value.
+    USER_GETS_HANDITEM(25),
+    DICE_ROLLED(24);
 
     public final int code;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEvent.java
@@ -121,6 +121,12 @@ public final class WiredEvent {
         /** Signal received from a Send Signal effect */
         SIGNAL_RECEIVED(WiredTriggerType.RECEIVE_SIGNAL),
 
+        /** User receives a hand item */
+        USER_GETS_HANDITEM(WiredTriggerType.USER_GETS_HANDITEM),
+
+        /** A dice furni was rolled */
+        DICE_ROLLED(WiredTriggerType.DICE_ROLLED),
+
         /** Custom trigger type for plugins */
         CUSTOM(WiredTriggerType.CUSTOM);
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredManager.java
@@ -706,6 +706,30 @@ public final class WiredManager {
     }
 
     /**
+     * Trigger when a user receives a hand item.
+     */
+    public static boolean triggerUserGetsHandItem(Room room, RoomUnit user) {
+        if (!isEnabled() || room == null || user == null) {
+            return false;
+        }
+
+        WiredEvent event = WiredEvents.userGetsHandItem(room, user);
+        return handleEvent(event);
+    }
+
+    /**
+     * Trigger when a dice furni is rolled.
+     */
+    public static boolean triggerDiceRolled(Room room, HabboItem dice) {
+        if (!isEnabled() || room == null || dice == null) {
+            return false;
+        }
+
+        WiredEvent event = WiredEvents.diceRolled(room, dice);
+        return handleEvent(event);
+    }
+
+    /**
      * Trigger when a team wins a game.
      */
     public static boolean triggerTeamWins(Room room, RoomUnit user) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/migrate/WiredEvents.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/migrate/WiredEvents.java
@@ -452,6 +452,27 @@ public final class WiredEvents {
                 .build();
     }
 
+    /**
+     * Create an event for when a user receives a hand item.
+     */
+    public static WiredEvent userGetsHandItem(Room room, RoomUnit user) {
+        return WiredEvent.builder(WiredEvent.Type.USER_GETS_HANDITEM, room)
+                .actor(user)
+                .tile(user.getCurrentLocation())
+                .build();
+    }
+
+    /**
+     * Create an event for when a dice furni is rolled (its value finalized).
+     */
+    public static WiredEvent diceRolled(Room room, HabboItem dice) {
+        RoomTile tile = room.getLayout().getTile(dice.getX(), dice.getY());
+        return WiredEvent.builder(WiredEvent.Type.DICE_ROLLED, room)
+                .sourceItem(dice)
+                .tile(tile)
+                .build();
+    }
+
     // ========== Legacy Compatibility ==========
 
     /**

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/RandomDiceNumber.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/RandomDiceNumber.java
@@ -2,8 +2,10 @@ package com.eu.habbo.threading.runnables;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.interactions.InteractionColorWheel;
+import com.eu.habbo.habbohotel.items.interactions.InteractionDice;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
 
 public class RandomDiceNumber implements Runnable {
     private final HabboItem item;
@@ -35,6 +37,11 @@ public class RandomDiceNumber implements Runnable {
         Emulator.getThreading().run(this.item);
 
         this.room.updateItem(this.item);
+
+        if (this.item instanceof InteractionDice) {
+            WiredManager.triggerDiceRolled(this.room, this.item);
+        }
+
         if (this.item instanceof InteractionColorWheel) {
             ((InteractionColorWheel) this.item).clearRunnable();
         }


### PR DESCRIPTION
Two new **genuinely-firing** wired event triggers, ported from the fork's `java25-migration` onto `dev` (Trove-free, purely **additive**).

## What
- **`dice_rolled`** (code 24) — fires when a dice furni's value is finalized. Raised from `RandomDiceNumber.run()`, guarded to `InteractionDice` (the shared colour-wheel path is unaffected). Optional `[requiredValue]`: `0` = any roll, else matches the rolled value.
- **`user_gets_handitem`** (code 25) — fires when a user receives a hand item. Raised from `RoomUnitManager.giveHandItem(...)` (the single hand-item funnel, guarded `handItem > 0`).

Each adds: `WiredTriggerType` + `WiredEvent.Type` + `WiredEvents` factory + `WiredManager` trigger method + a `WiredTrigger*` class, registered in `ItemManager` (`wf_trg_dice_rolled` / `wf_trg_user_gets_handitem`).

## Notes
- `mvn clean compile`: **BUILD SUCCESS** on `dev`.
- Runtime needs the matching `wf_trg_*` rows in `items_base` + the Nitro client dialogs (WiredTriggerLayout codes 24/25, part of the wired-views work in duckietm/Nitro-V3#289).
- Draft pending runtime test.