### PR TITLE
feat(control): 3 conf_* control furni (hidewired / dice-disable / doorkick-disable)

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -203,6 +203,12 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_conf_handitem_block", InteractionHanditemBlockControl.class));
         this.interactionsList.add(new ItemInteraction("wf_conf_queue_speed", InteractionQueueSpeedControl.class));
         this.interactionsList.add(new ItemInteraction("wf_conf_wired_disable", InteractionWiredDisableControl.class));
+        this.interactionsList.add(new ItemInteraction("conf_hidewired", InteractionHideWiredControl.class));
+        this.interactionsList.add(new ItemInteraction("wf_conf_hidewired", InteractionHideWiredControl.class));
+        this.interactionsList.add(new ItemInteraction("conf_dice_disable", InteractionDiceDisableControl.class));
+        this.interactionsList.add(new ItemInteraction("wf_conf_dice_disable", InteractionDiceDisableControl.class));
+        this.interactionsList.add(new ItemInteraction("conf_doorkick_disable", InteractionDoorkickDisableControl.class));
+        this.interactionsList.add(new ItemInteraction("wf_conf_doorkick_disable", InteractionDoorkickDisableControl.class));
         this.interactionsList.add(new ItemInteraction("switch_remote_control", InteractionSwitchRemoteControl.class));
         this.interactionsList.add(new ItemInteraction("fx_box", InteractionFXBox.class));
         this.interactionsList.add(new ItemInteraction("blackhole", InteractionBlackHole.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionDice.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionDice.java
@@ -45,6 +45,9 @@ public class InteractionDice extends HabboItem {
     public void onClick(GameClient client, Room room, Object[] objects) throws Exception {
         super.onClick(client, room, objects);
 
+        if (com.eu.habbo.habbohotel.rooms.RoomDiceDisableSupport.isActive(room))
+            return;
+
         if (client != null) {
             if (RoomLayout.tilesAdjecent(room.getLayout().getTile(this.getX(), this.getY()), client.getHabbo().getRoomUnit().getCurrentLocation())) {
                 if (!this.getExtradata().equalsIgnoreCase("-1")) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionDiceDisableControl.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionDiceDisableControl.java
@@ -1,0 +1,16 @@
+package com.eu.habbo.habbohotel.items.interactions;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class InteractionDiceDisableControl extends InteractionRemoteSwitchControl {
+    public InteractionDiceDisableControl(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionDiceDisableControl(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionDoorkickDisableControl.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionDoorkickDisableControl.java
@@ -1,0 +1,16 @@
+package com.eu.habbo.habbohotel.items.interactions;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class InteractionDoorkickDisableControl extends InteractionRemoteSwitchControl {
+    public InteractionDoorkickDisableControl(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionDoorkickDisableControl(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionHideWiredControl.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionHideWiredControl.java
@@ -1,0 +1,16 @@
+package com.eu.habbo.habbohotel.items.interactions;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class InteractionHideWiredControl extends InteractionRemoteSwitchControl {
+    public InteractionHideWiredControl(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionHideWiredControl(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDiceDisableSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDiceDisableSupport.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionDiceDisableControl;
+import com.eu.habbo.habbohotel.users.HabboItem;
+
+public final class RoomDiceDisableSupport {
+    private static final String CONTROLLER_INTERACTION = "conf_dice_disable";
+
+    private RoomDiceDisableSupport() {
+    }
+
+    public static boolean isActive(Room room) {
+        if (room == null) {
+            return false;
+        }
+
+        for (HabboItem item : room.getFloorItems()) {
+            if (isActiveController(item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isActiveController(HabboItem item) {
+        return isControllerItem(item) && "1".equals(item.getExtradata());
+    }
+
+    public static boolean isControllerItem(HabboItem item) {
+        if (item == null || item.getBaseItem() == null) {
+            return false;
+        }
+
+        if (item instanceof InteractionDiceDisableControl) {
+            return true;
+        }
+
+        if (item.getBaseItem().getInteractionType() == null) {
+            return false;
+        }
+
+        String interactionName = item.getBaseItem().getInteractionType().getName();
+
+        return interactionName != null && interactionName.equalsIgnoreCase(CONTROLLER_INTERACTION);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDoorkickDisableSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDoorkickDisableSupport.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionDoorkickDisableControl;
+import com.eu.habbo.habbohotel.users.HabboItem;
+
+public final class RoomDoorkickDisableSupport {
+    private static final String CONTROLLER_INTERACTION = "conf_doorkick_disable";
+
+    private RoomDoorkickDisableSupport() {
+    }
+
+    public static boolean isDoorkickDisabled(Room room) {
+        if (room == null) {
+            return false;
+        }
+
+        for (HabboItem item : room.getFloorItems()) {
+            if (isActiveController(item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isActiveController(HabboItem item) {
+        return isControllerItem(item) && "1".equals(item.getExtradata());
+    }
+
+    public static boolean isControllerItem(HabboItem item) {
+        if (item == null || item.getBaseItem() == null) {
+            return false;
+        }
+
+        if (item instanceof InteractionDoorkickDisableControl) {
+            return true;
+        }
+
+        if (item.getBaseItem().getInteractionType() == null) {
+            return false;
+        }
+
+        String interactionName = item.getBaseItem().getInteractionType().getName();
+
+        return interactionName != null && interactionName.equalsIgnoreCase(CONTROLLER_INTERACTION);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomHideWiredSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomHideWiredSupport.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionHideWiredControl;
+import com.eu.habbo.habbohotel.users.HabboItem;
+
+public final class RoomHideWiredSupport {
+    private static final String CONTROLLER_INTERACTION = "conf_hidewired";
+
+    private RoomHideWiredSupport() {
+    }
+
+    public static boolean isActive(Room room) {
+        if (room == null) {
+            return false;
+        }
+
+        for (HabboItem item : room.getFloorItems()) {
+            if (isActiveController(item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isActiveController(HabboItem item) {
+        return isControllerItem(item) && "1".equals(item.getExtradata());
+    }
+
+    public static boolean isControllerItem(HabboItem item) {
+        if (item == null || item.getBaseItem() == null) {
+            return false;
+        }
+
+        if (item instanceof InteractionHideWiredControl) {
+            return true;
+        }
+
+        if (item.getBaseItem().getInteractionType() == null) {
+            return false;
+        }
+
+        String interactionName = item.getBaseItem().getInteractionType().getName();
+
+        return interactionName != null && interactionName.equalsIgnoreCase(CONTROLLER_INTERACTION);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -877,8 +877,10 @@ public class RoomManager {
                 }
             }
 
+            final boolean hideWiredControllerActive = RoomHideWiredSupport.isActive(room);
+
             for (HabboItem object : allFloorItems) {
-                if (room.isHideWired() && object instanceof InteractionWired) {
+                if ((room.isHideWired() || hideWiredControllerActive) && object instanceof InteractionWired) {
                     continue;
                 }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnit.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnit.java
@@ -373,7 +373,7 @@ public class RoomUnit {
                 .getBoolean("hotel.room.public.doortile.kick");
         boolean invalidated = topItem != null && topItem.invalidatesToRoomKick();
 
-        if (this.canLeaveRoomByDoor && isAtDoor && publicRoomKicks && !invalidated) {
+        if (this.canLeaveRoomByDoor && isAtDoor && publicRoomKicks && !invalidated && !RoomDoorkickDisableSupport.isDoorkickDisabled(room)) {
           Emulator.getThreading().run(new RoomUnitKick(habbo, room, false), 500);
         }
       }


### PR DESCRIPTION
Implements 3 control furni that ship in furnidata but were loaded as inert `InteractionDefault` (no class, no `interaction_type`). Ported from the fork's `java25-migration` onto `dev` (Trove-free, **additive**). Mirrors the existing `conf_invis_control` / `WiredDisableControl` pattern.

## What
- **`conf_hidewired`** → `InteractionHideWiredControl` + `RoomHideWiredSupport`: withholds wired furni from clients while a controller is active (gates the `RoomManager` floor-items send loop — adapted to `dev`'s plain `for` loop).
- **`conf_dice_disable`** → `InteractionDiceDisableControl` + `RoomDiceDisableSupport`: early-returns in `InteractionDice.onClick` so dice can't be rolled.
- **`conf_doorkick_disable`** → `InteractionDoorkickDisableControl` + `RoomDoorkickDisableSupport`: guards the `RoomUnit` door-kick so rights-less users aren't kicked at the door tile.

Each registers both `conf_X` and `wf_conf_X` aliases in `ItemManager`.

## Notes
- `mvn clean compile`: **BUILD SUCCESS** on `dev`.
- Runtime needs the `conf_*` furni `interaction_type` set in `items_base` (they currently load as `default`).
- Draft pending runtime test.