### PR TITLE
feat(wired): conditions & effects batch (owns furni/badge, motto, has-items, profile tags, give look, neg effects)

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -259,6 +259,27 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_win", WiredTriggerTeamWins.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_lose", WiredTriggerTeamLoses.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_recv_signal", WiredTriggerReceiveSignal.class));
+        // owns_furni: check the triggerer's inventory for the picked furni type(s) (reuse HAS_ALTITUDE picker).
+        this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_owns_furni", WiredConditionHabboOwnsFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_not_owns_furni", WiredConditionHabboNotOwnsFurni.class));
+        // Negative-branch effects (run when the stack's conditions FAIL); reuse the SHOW_MESSAGE dialog.
+        this.interactionsList.add(new ItemInteraction("wf_act_neg_show_message", WiredEffectNegativeShowMessage.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_neg_log", WiredEffectNegativeLog.class));
+        // give_look exists client-side (FurnitureData): set the user's figure (text dialog = figure string).
+        this.interactionsList.add(new ItemInteraction("wf_act_give_look", WiredEffectGiveLook.class));
+        // Profile tags (text dialog = the tag; persisted via the new HabboStats tag helpers).
+        this.interactionsList.add(new ItemInteraction("wf_act_add_tag", WiredEffectAddTag.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_add_tag_perm", WiredEffectAddTag.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_remove_tag", WiredEffectRemoveTag.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_has_tag", WiredConditionHasTag.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_has_tag", WiredConditionNotHasTag.class));
+        // Identity conditions reusing a meaningful existing dialog field (text = motto / int = item count).
+        this.interactionsList.add(new ItemInteraction("wf_cnd_motto_contains", WiredConditionMottoContains.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_has_at_least_x_items", WiredConditionHabboHasMinItems.class));
+        // OWNED-badge check (Phase A skipped these because only a worn-badge class existed): reuses the
+        // wears-badge dialog but checks inventory ownership via BadgesComponent.hasBadge.
+        this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_owns_badge", WiredConditionHabboOwnsBadge.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_owns_badge", WiredConditionNotHabboOwnsBadge.class));
 
 
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_state", WiredEffectToggleFurni.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboHasMinItems.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboHasMinItems.java
@@ -1,0 +1,174 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.games.GameTeamColors;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Passes when the resolved user owns at least {@code amount} inventory items. Reuses the TEAM_HAS_SCORE
+ * dialog (numeric amount + source + quantifier) exactly like {@link WiredConditionHabboLacksCredits}, so
+ * no new client dialog is required; only the per-user predicate differs. Note: {@code itemCount()} counts
+ * non-placed inventory items (room_id = 0), not furni placed in rooms.
+ */
+public class WiredConditionHabboHasMinItems extends WiredConditionTeamGameBase {
+    public static final WiredConditionType type = WiredConditionType.TEAM_HAS_SCORE;
+
+    private int teamType = GameTeamColors.RED.type;
+    private int comparison = COMPARISON_EQUAL;
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int quantifier = QUANTIFIER_ANY;
+
+    public WiredConditionHabboHasMinItems(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionHabboHasMinItems(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        List<RoomUnit> users = this.resolveUsers(ctx, this.userSource);
+
+        return this.matchesQuantifier(users, this.quantifier, roomUnit -> this.matchesUser(room, roomUnit));
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.teamType,
+                this.comparison,
+                this.amount,
+                this.userSource,
+                this.quantifier
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.resetSettings();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException ignored) {
+            this.resetSettings();
+            return;
+        }
+        if (data == null) {
+            return;
+        }
+
+        this.teamType = this.normalizeExplicitTeamType(data.teamType);
+        this.comparison = this.normalizeComparison(data.comparison);
+        this.amount = this.normalizeScore(data.score);
+        this.userSource = this.normalizeUserSource(data.userSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.resetSettings();
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(5);
+        message.appendInt(this.teamType);
+        message.appendInt(this.comparison);
+        message.appendInt(this.amount);
+        message.appendInt(this.userSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.resetSettings();
+
+        if (params.length > 0) this.teamType = this.normalizeExplicitTeamType(params[0]);
+        if (params.length > 1) this.comparison = this.normalizeComparison(params[1]);
+        if (params.length > 2) this.amount = this.normalizeScore(params[2]);
+        if (params.length > 3) this.userSource = this.normalizeUserSource(params[3]);
+        if (params.length > 4) this.quantifier = this.normalizeQuantifier(params[4]);
+
+        return true;
+    }
+
+    private boolean matchesUser(Room room, RoomUnit roomUnit) {
+        if (room == null || roomUnit == null) {
+            return false;
+        }
+
+        Habbo habbo = room.getHabbo(roomUnit);
+        if (habbo == null || habbo.getInventory() == null) {
+            return false;
+        }
+
+        return habbo.getInventory().getItemsComponent().itemCount() >= this.amount;
+    }
+
+    private void resetSettings() {
+        this.teamType = GameTeamColors.RED.type;
+        this.comparison = COMPARISON_EQUAL;
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ANY;
+    }
+
+    static class JsonData {
+        int teamType;
+        int comparison;
+        int score;
+        int userSource;
+        int quantifier;
+
+        public JsonData(int teamType, int comparison, int score, int userSource, int quantifier) {
+            this.teamType = teamType;
+            this.comparison = comparison;
+            this.score = score;
+            this.userSource = userSource;
+            this.quantifier = quantifier;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboNotOwnsFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboNotOwnsFurni.java
@@ -1,0 +1,57 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import java.util.HashSet;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Negation of {@link WiredConditionHabboOwnsFurni}: passes when the triggering user does NOT own furni of
+ * the selected type(s). Reuses the same HAS_ALTITUDE picker dialog and inventory check.
+ */
+public class WiredConditionHabboNotOwnsFurni extends WiredConditionHabboOwnsFurni {
+
+    public WiredConditionHabboNotOwnsFurni(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionHabboNotOwnsFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return false;
+        }
+
+        this.refresh(room);
+
+        HashSet<Integer> typeIds = this.resolveTypeIds(ctx);
+        if (typeIds.isEmpty()) {
+            return true;
+        }
+
+        List<RoomUnit> users = WiredSourceUtil.resolveUsers(ctx, WiredSourceUtil.SOURCE_TRIGGER);
+        if (users.isEmpty()) {
+            return true;
+        }
+
+        for (RoomUnit unit : users) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo != null && !this.userOwns(habbo, typeIds)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboOwnsBadge.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboOwnsBadge.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Passes when the resolved user OWNS the given badge (in their inventory), not merely wears it. Reuses
+ * the {@link WiredConditionHabboWearsBadge} dialog (ACTOR_WEARS_BADGE, badge-code text + source +
+ * quantifier) and all of its serialization; the only difference is the owned-vs-worn check, so it needs
+ * no new client dialog. This is the OWNED-badge condition that the Phase-A alias deliberately skipped
+ * (the wears-badge class only checks worn badges).
+ */
+public class WiredConditionHabboOwnsBadge extends WiredConditionHabboWearsBadge {
+
+    public WiredConditionHabboOwnsBadge(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionHabboOwnsBadge(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    protected boolean matchesBadge(Room room, RoomUnit roomUnit) {
+        Habbo habbo = room.getHabbo(roomUnit);
+        if (habbo == null) {
+            return false;
+        }
+
+        return habbo.getInventory().getBadgesComponent().hasBadge(this.badge);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboOwnsFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboOwnsFurni.java
@@ -1,0 +1,276 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import java.util.HashSet;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Passes when the TRIGGERING user owns (in inventory) furni matching the selected furni type(s). The
+ * picked furni only supply their base-item TYPE; the check is against the user's inventory, not the room.
+ * Reuses the HAS_ALTITUDE furni-picker dialog (its numeric field is unused here, kept only for dialog
+ * compatibility). Quantifier ALL = user owns every picked type; ANY = user owns at least one.
+ * Inventory = non-placed items (room_id = 0).
+ */
+public class WiredConditionHabboOwnsFurni extends InteractionWiredCondition {
+    protected static final int QUANTIFIER_ALL = 0;
+    protected static final int QUANTIFIER_ANY = 1;
+
+    public static final WiredConditionType type = WiredConditionType.HAS_ALTITUDE;
+
+    protected final HashSet<HabboItem> items;
+    protected int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+    protected int quantifier = QUANTIFIER_ANY;
+
+    public WiredConditionHabboOwnsFurni(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+        this.items = new HashSet<>();
+    }
+
+    public WiredConditionHabboOwnsFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+        this.items = new HashSet<>();
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return false;
+        }
+
+        this.refresh(room);
+
+        HashSet<Integer> typeIds = this.resolveTypeIds(ctx);
+        if (typeIds.isEmpty()) {
+            return false;
+        }
+
+        List<RoomUnit> users = WiredSourceUtil.resolveUsers(ctx, WiredSourceUtil.SOURCE_TRIGGER);
+        if (users.isEmpty()) {
+            return false;
+        }
+
+        for (RoomUnit unit : users) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo != null && this.userOwns(habbo, typeIds)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected HashSet<Integer> resolveTypeIds(WiredContext ctx) {
+        var typeIds = new HashSet<Integer>();
+        for (HabboItem item : WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items)) {
+            if (item != null && item.getBaseItem() != null) {
+                typeIds.add(item.getBaseItem().getId());
+            }
+        }
+        return typeIds;
+    }
+
+    protected boolean userOwns(Habbo habbo, HashSet<Integer> typeIds) {
+        if (habbo.getInventory() == null) {
+            return false;
+        }
+
+        var owned = new HashSet<Integer>();
+        for (HabboItem item : habbo.getInventory().getItemsComponent().getItems().values()) {
+            if (item != null && item.getBaseItem() != null) {
+                owned.add(item.getBaseItem().getId());
+            }
+        }
+
+        if (this.quantifier == QUANTIFIER_ALL) {
+            return owned.containsAll(typeIds);
+        }
+
+        for (Integer typeId : typeIds) {
+            if (owned.contains(typeId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.furniSource,
+                this.quantifier,
+                this.items.stream().map(HabboItem::getId).toList()
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.items.clear();
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ANY;
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException exception) {
+            this.onPickUp();
+            return;
+        }
+
+        if (data == null) {
+            return;
+        }
+
+        this.furniSource = this.normalizeFurniSource(data.furniSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+
+        if (data.itemIds == null) {
+            return;
+        }
+
+        for (Integer id : data.itemIds) {
+            if (id == null) {
+                continue;
+            }
+
+            HabboItem item = room.getHabboItem(id);
+            if (item != null) {
+                this.items.add(item);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.items.clear();
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ANY;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        this.refresh(room);
+
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.items.size());
+
+        for (HabboItem item : this.items) {
+            message.appendInt(item.getId());
+        }
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.furniSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.furniSource = (params.length > 0) ? this.normalizeFurniSource(params[0]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 1) ? this.normalizeQuantifier(params[1]) : QUANTIFIER_ANY;
+
+        int count = settings.getFurniIds().length;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+            return false;
+        }
+
+        if (count > 0 && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
+            this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+        }
+
+        this.items.clear();
+
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+            if (room == null) {
+                return false;
+            }
+
+            for (int itemId : settings.getFurniIds()) {
+                HabboItem item = room.getHabboItem(itemId);
+                if (item != null) {
+                    this.items.add(item);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    protected void refresh(Room room) {
+        var remove = new HashSet<HabboItem>();
+
+        for (HabboItem item : this.items) {
+            if (room.getHabboItem(item.getId()) == null) {
+                remove.add(item);
+            }
+        }
+
+        for (HabboItem item : remove) {
+            this.items.remove(item);
+        }
+    }
+
+    protected int normalizeQuantifier(int value) {
+        return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    protected int normalizeFurniSource(int value) {
+        return switch (value) {
+            case WiredSourceUtil.SOURCE_SELECTED, WiredSourceUtil.SOURCE_SELECTOR, WiredSourceUtil.SOURCE_SIGNAL, WiredSourceUtil.SOURCE_TRIGGER -> value;
+            default -> WiredSourceUtil.SOURCE_TRIGGER;
+        };
+    }
+
+    static class JsonData {
+        int furniSource;
+        int quantifier;
+        List<Integer> itemIds;
+
+        public JsonData(int furniSource, int quantifier, List<Integer> itemIds) {
+            this.furniSource = furniSource;
+            this.quantifier = quantifier;
+            this.itemIds = itemIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHasTag.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHasTag.java
@@ -1,0 +1,212 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Passes when the resolved user has the configured profile tag (case-insensitive). Reuses the
+ * ACTOR_WEARS_BADGE text dialog (text = tag), so no new client dialog is required. An empty configured
+ * tag never matches. Reads {@link com.eu.habbo.habbohotel.users.HabboStats#hasTag}.
+ */
+public class WiredConditionHasTag extends InteractionWiredCondition {
+    protected static final int QUANTIFIER_ALL = 0;
+    protected static final int QUANTIFIER_ANY = 1;
+    protected static final int MAX_TAG_LENGTH = 38;
+
+    public static final WiredConditionType type = WiredConditionType.ACTOR_WEARS_BADGE;
+
+    protected String tag = "";
+    protected int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    protected int quantifier = QUANTIFIER_ANY;
+
+    public WiredConditionHasTag(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionHasTag(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        if (ctx == null || ctx.room() == null) {
+            return false;
+        }
+
+        Room room = ctx.room();
+        List<RoomUnit> targets = WiredSourceUtil.resolveUsers(ctx, this.userSource);
+        if (targets.isEmpty()) return false;
+
+        if (this.quantifier == QUANTIFIER_ALL) {
+            return this.matchesAllTargets(room, targets);
+        }
+
+        return this.matchesAnyTarget(room, targets);
+    }
+
+    protected boolean matchesAllTargets(Room room, List<RoomUnit> targets) {
+        for (RoomUnit roomUnit : targets) {
+            if (!this.matchesTag(room, roomUnit)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected boolean matchesAnyTarget(Room room, List<RoomUnit> targets) {
+        for (RoomUnit roomUnit : targets) {
+            if (this.matchesTag(room, roomUnit)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected boolean matchesTag(Room room, RoomUnit roomUnit) {
+        if (this.tag.isEmpty()) {
+            return false;
+        }
+
+        Habbo habbo = room.getHabbo(roomUnit);
+        if (habbo == null || habbo.getHabboStats() == null) {
+            return false;
+        }
+
+        return habbo.getHabboStats().hasTag(this.tag);
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.tag,
+                this.userSource,
+                this.quantifier
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null) {
+            return;
+        }
+
+        if (wiredData.startsWith("{")) {
+            JsonData data;
+            try {
+                data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            } catch (RuntimeException ignored) {
+                this.onPickUp();
+                return;
+            }
+            if (data == null) {
+                return;
+            }
+            this.tag = this.normalizeTag(data.tag);
+            this.userSource = this.normalizeUserSource(data.userSource);
+            this.quantifier = this.normalizeQuantifier(data.quantifier);
+        } else {
+            this.tag = this.normalizeTag(wiredData);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.quantifier = QUANTIFIER_ANY;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.tag = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ANY;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.tag);
+        message.appendInt(2);
+        message.appendInt(this.userSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        this.tag = this.normalizeTag(settings.getStringParam());
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? this.normalizeUserSource(params[0]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 1) ? this.normalizeQuantifier(params[1]) : QUANTIFIER_ANY;
+
+        return true;
+    }
+
+    protected int getQuantifier() {
+        return this.quantifier;
+    }
+
+    protected int normalizeQuantifier(Integer value) {
+        if (value == null) {
+            return QUANTIFIER_ANY;
+        }
+
+        return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    protected String normalizeTag(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String normalized = value.trim();
+        return normalized.length() <= MAX_TAG_LENGTH ? normalized : normalized.substring(0, MAX_TAG_LENGTH);
+    }
+
+    protected int normalizeUserSource(int value) {
+        return WiredSourceUtil.isDefaultUserSource(value) ? value : WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String tag;
+        int userSource;
+        Integer quantifier;
+
+        public JsonData(String tag, int userSource, int quantifier) {
+            this.tag = tag;
+            this.userSource = userSource;
+            this.quantifier = quantifier;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMottoContains.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionMottoContains.java
@@ -1,0 +1,210 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Passes when the resolved user's motto contains the configured text (case-insensitive). Reuses the
+ * ACTOR_WEARS_BADGE dialog (a single text field + source + quantifier — the text holds the motto
+ * substring instead of a badge code), so no new client dialog is required. An empty configured text
+ * never matches.
+ */
+public class WiredConditionMottoContains extends InteractionWiredCondition {
+    protected static final int QUANTIFIER_ALL = 0;
+    protected static final int QUANTIFIER_ANY = 1;
+    protected static final int MAX_TEXT_LENGTH = 64;
+
+    public static final WiredConditionType type = WiredConditionType.ACTOR_WEARS_BADGE;
+
+    protected String text = "";
+    protected int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    protected int quantifier = QUANTIFIER_ANY;
+
+    public WiredConditionMottoContains(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionMottoContains(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        if (ctx == null || ctx.room() == null) {
+            return false;
+        }
+
+        Room room = ctx.room();
+        List<RoomUnit> targets = WiredSourceUtil.resolveUsers(ctx, this.userSource);
+        if (targets.isEmpty()) return false;
+
+        if (this.quantifier == QUANTIFIER_ALL) {
+            return this.matchesAllTargets(room, targets);
+        }
+
+        return this.matchesAnyTarget(room, targets);
+    }
+
+    protected boolean matchesAllTargets(Room room, List<RoomUnit> targets) {
+        for (RoomUnit roomUnit : targets) {
+            if (!this.matchesMotto(room, roomUnit)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected boolean matchesAnyTarget(Room room, List<RoomUnit> targets) {
+        for (RoomUnit roomUnit : targets) {
+            if (this.matchesMotto(room, roomUnit)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected boolean matchesMotto(Room room, RoomUnit roomUnit) {
+        if (this.text.isEmpty()) {
+            return false;
+        }
+
+        Habbo habbo = room.getHabbo(roomUnit);
+        if (habbo == null || habbo.getHabboInfo() == null) {
+            return false;
+        }
+
+        String motto = habbo.getHabboInfo().getMotto();
+        return motto != null && motto.toLowerCase().contains(this.text.toLowerCase());
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.text,
+                this.userSource,
+                this.quantifier
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null) {
+            return;
+        }
+
+        if (wiredData.startsWith("{")) {
+            JsonData data;
+            try {
+                data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            } catch (RuntimeException ignored) {
+                this.onPickUp();
+                return;
+            }
+            if (data == null) {
+                return;
+            }
+            this.text = this.normalizeText(data.text);
+            this.userSource = this.normalizeUserSource(data.userSource);
+            this.quantifier = this.normalizeQuantifier(data.quantifier);
+        } else {
+            this.text = this.normalizeText(wiredData);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.quantifier = QUANTIFIER_ANY;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.text = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ANY;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.text);
+        message.appendInt(2);
+        message.appendInt(this.userSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        this.text = this.normalizeText(settings.getStringParam());
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? this.normalizeUserSource(params[0]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 1) ? this.normalizeQuantifier(params[1]) : QUANTIFIER_ANY;
+
+        return true;
+    }
+
+    protected int normalizeQuantifier(Integer value) {
+        if (value == null) {
+            return QUANTIFIER_ANY;
+        }
+
+        return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    protected String normalizeText(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String normalized = value.trim();
+        return normalized.length() <= MAX_TEXT_LENGTH ? normalized : normalized.substring(0, MAX_TEXT_LENGTH);
+    }
+
+    protected int normalizeUserSource(int value) {
+        return WiredSourceUtil.isDefaultUserSource(value) ? value : WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String text;
+        int userSource;
+        Integer quantifier;
+
+        public JsonData(String text, int userSource, int quantifier) {
+            this.text = text;
+            this.userSource = userSource;
+            this.quantifier = quantifier;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHabboOwnsBadge.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHabboOwnsBadge.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Negation of {@link WiredConditionHabboOwnsBadge}: passes when the user does NOT own the given badge.
+ * Mirrors the NOT pattern of {@link WiredConditionNotHabboWearsBadge} (inverts the quantified match,
+ * empty targets -> true) and reuses the same badge dialog via NOT_ACTOR_WEARS_BADGE.
+ */
+public class WiredConditionNotHabboOwnsBadge extends WiredConditionHabboOwnsBadge {
+    public static final WiredConditionType type = WiredConditionType.NOT_ACTOR_WEARS_BADGE;
+
+    public WiredConditionNotHabboOwnsBadge(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionNotHabboOwnsBadge(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        List<RoomUnit> targets = WiredSourceUtil.resolveUsers(ctx, this.userSource);
+        if (targets.isEmpty()) return true;
+
+        if (this.getQuantifier() == QUANTIFIER_ALL) {
+            return !this.matchesAllTargets(room, targets);
+        }
+
+        return !this.matchesAnyTarget(room, targets);
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHasTag.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotHasTag.java
@@ -1,0 +1,51 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Negation of {@link WiredConditionHasTag}: passes when the resolved user does NOT have the configured
+ * profile tag. Mirrors the NOT-condition pattern (invert the quantified match, empty targets -> true) and
+ * reuses the same tag text dialog via NOT_ACTOR_WEARS_BADGE.
+ */
+public class WiredConditionNotHasTag extends WiredConditionHasTag {
+    public static final WiredConditionType type = WiredConditionType.NOT_ACTOR_WEARS_BADGE;
+
+    public WiredConditionNotHasTag(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionNotHasTag(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        if (ctx == null || ctx.room() == null) {
+            return false;
+        }
+
+        Room room = ctx.room();
+        List<RoomUnit> targets = WiredSourceUtil.resolveUsers(ctx, this.userSource);
+        if (targets.isEmpty()) return true;
+
+        if (this.getQuantifier() == QUANTIFIER_ALL) {
+            return !this.matchesAllTargets(room, targets);
+        }
+
+        return !this.matchesAnyTarget(room, targets);
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectAddTag.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectAddTag.java
@@ -1,0 +1,161 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserTagsComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adds a profile tag to the resolved users (persisted via {@link com.eu.habbo.habbohotel.users.HabboStats#addTag}).
+ * Reuses the {@link WiredEffectType#SHOW_MESSAGE} dialog (single text field = the tag + a user-source
+ * selector), so it needs no new client dialog. Backs both wf_act_add_tag and wf_act_add_tag_perm; both
+ * persist (a profile tag is inherently persistent).
+ */
+public class WiredEffectAddTag extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private static final int MAX_TAG_LENGTH = 38;
+
+    private String tag = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectAddTag(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectAddTag(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.tag);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String value = settings.getStringParam();
+        if (value == null || value.trim().isEmpty()) {
+            return false;
+        }
+        String trimmed = value.trim();
+        this.tag = trimmed.length() <= MAX_TAG_LENGTH ? trimmed : trimmed.substring(0, MAX_TAG_LENGTH);
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            if (habbo.getHabboStats().addTag(this.tag)) {
+                room.sendComposer(new RoomUserTagsComposer(habbo).compose());
+            }
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.tag, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.tag = data.tag == null ? "" : data.tag;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.tag = "";
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.tag = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String tag;
+        int delay;
+        int userSource;
+
+        public JsonData(String tag, int delay, int userSource) {
+            this.tag = tag;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveLook.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveLook.java
@@ -1,0 +1,170 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.clothingvalidation.ClothingValidationManager;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDataComposer;
+import com.eu.habbo.messages.outgoing.users.UpdateUserLookComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Sets the figure (look) of the resolved users to a configured figure string. Reuses the
+ * {@link WiredEffectType#SHOW_MESSAGE} dialog (text field = the figure + a user-source selector), so no
+ * new client dialog is required. The figure is format-validated for the user's gender via
+ * {@link ClothingValidationManager}; the look is applied + broadcast exactly as MimicCommand does.
+ * Persisted on the user's next data save (matching the mimic path).
+ */
+public class WiredEffectGiveLook extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private static final int MAX_LOOK_LENGTH = 256;
+
+    private String figure = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveLook(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveLook(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.figure);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String value = settings.getStringParam();
+        if (value == null || value.trim().isEmpty()) {
+            return false;
+        }
+        String trimmed = value.trim();
+        this.figure = trimmed.length() <= MAX_LOOK_LENGTH ? trimmed : trimmed.substring(0, MAX_LOOK_LENGTH);
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null || habbo.getHabboInfo() == null) continue;
+
+            String gender = habbo.getHabboInfo().getGender().name();
+            String validated = ClothingValidationManager.validateLook(this.figure, gender);
+            if (validated == null || validated.isEmpty()) continue;
+
+            habbo.getHabboInfo().setLook(validated);
+            if (habbo.getClient() != null) {
+                habbo.getClient().sendResponse(new UpdateUserLookComposer(habbo));
+            }
+            room.sendComposer(new RoomUserDataComposer(habbo).compose());
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.figure, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.figure = data.figure == null ? "" : data.figure;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.figure = "";
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.figure = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String figure;
+        int delay;
+        int userSource;
+
+        public JsonData(String figure, int delay, int userSource) {
+            this.figure = figure;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLog.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLog.java
@@ -1,0 +1,157 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectLog extends InteractionWiredEffect {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WiredEffectLog.class);
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private String message = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectLog(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectLog(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.message);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String message = settings.getStringParam();
+        if (message == null || message.isEmpty()) {
+            return false;
+        }
+        this.message = message;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        LOGGER.info("[WiredLog room {}] {}", ctx.room().getId(), this.message);
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.message, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.message = data.message;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        }
+        else {
+            String[] data = wiredData.split("\t");
+            this.message = "";
+
+            if (data.length >= 2) {
+                super.setDelay(Integer.parseInt(data[0]));
+
+                try {
+                    this.message = data[1];
+                } catch (Exception e) {
+                }
+            }
+
+            this.needsUpdate(true);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.message = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return false;
+    }
+
+    static class JsonData {
+        String message;
+        int delay;
+        int userSource;
+
+        public JsonData(String message, int delay, int userSource) {
+            this.message = message;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectNegativeLog.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectNegativeLog.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Server-side log that runs only when the stack's conditions FAIL (the negative branch). Identical to
+ * {@link WiredEffectLog} except its {@link WiredEffectType#NEG_LOG} type makes
+ * WiredEngine.isNegativeConditionEffect schedule it on condition failure instead of success. Reuses the
+ * SHOW_MESSAGE(7) client text dialog (NEG_LOG shares code 7).
+ */
+public class WiredEffectNegativeLog extends WiredEffectLog {
+    public static final WiredEffectType type = WiredEffectType.NEG_LOG;
+
+    public WiredEffectNegativeLog(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectNegativeLog(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectNegativeShowMessage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectNegativeShowMessage.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * "Show message" that runs only when the stack's conditions FAIL (the negative branch). Identical to
+ * {@link WiredEffectWhisper} except its {@link WiredEffectType#NEG_SHOW_MESSAGE} type makes
+ * WiredEngine.isNegativeConditionEffect schedule it on condition failure instead of success. Reuses the
+ * SHOW_MESSAGE(7) client dialog (NEG_SHOW_MESSAGE shares code 7).
+ */
+public class WiredEffectNegativeShowMessage extends WiredEffectWhisper {
+    public static final WiredEffectType type = WiredEffectType.NEG_SHOW_MESSAGE;
+
+    public WiredEffectNegativeShowMessage(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectNegativeShowMessage(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectRemoveTag.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectRemoveTag.java
@@ -1,0 +1,161 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserTagsComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Removes a profile tag from the resolved users (persisted via
+ * {@link com.eu.habbo.habbohotel.users.HabboStats#removeTag}). Reuses the
+ * {@link WiredEffectType#SHOW_MESSAGE} dialog (text field = the tag + user-source selector); no new
+ * client dialog required.
+ */
+public class WiredEffectRemoveTag extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private static final int MAX_TAG_LENGTH = 38;
+
+    private String tag = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectRemoveTag(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectRemoveTag(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.tag);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String value = settings.getStringParam();
+        if (value == null || value.trim().isEmpty()) {
+            return false;
+        }
+        String trimmed = value.trim();
+        this.tag = trimmed.length() <= MAX_TAG_LENGTH ? trimmed : trimmed.substring(0, MAX_TAG_LENGTH);
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            if (habbo.getHabboStats().removeTag(this.tag)) {
+                room.sendComposer(new RoomUserTagsComposer(habbo).compose());
+            }
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.tag, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.tag = data.tag == null ? "" : data.tag;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.tag = "";
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.tag = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String tag;
+        int delay;
+        int userSource;
+
+        public JsonData(String tag, int delay, int userSource) {
+            this.tag = tag;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -870,4 +870,84 @@ public class HabboStats implements Runnable {
     public void addHabboOfferPurchase(HabboOfferPurchase offerPurchase) {
         this.offerCache.put(offerPurchase.getOfferId(), offerPurchase);
     }
+
+    /** True if the user has the given profile tag (case-insensitive). */
+    public boolean hasTag(String tag) {
+        if (tag == null || tag.isEmpty() || this.tags == null) {
+            return false;
+        }
+
+        for (String existing : this.tags) {
+            if (existing != null && existing.equalsIgnoreCase(tag)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** Adds a profile tag (if absent) and persists it. Returns true if the tag set changed. */
+    public boolean addTag(String tag) {
+        if (tag == null) {
+            return false;
+        }
+
+        String trimmed = tag.trim();
+        if (trimmed.isEmpty() || this.hasTag(trimmed)) {
+            return false;
+        }
+
+        java.util.List<String> list = new java.util.ArrayList<>();
+        if (this.tags != null) {
+            for (String existing : this.tags) {
+                if (existing != null && !existing.isEmpty()) {
+                    list.add(existing);
+                }
+            }
+        }
+        list.add(trimmed);
+        this.tags = list.toArray(new String[0]);
+        this.persistTags();
+        return true;
+    }
+
+    /** Removes a profile tag (if present) and persists it. Returns true if the tag set changed. */
+    public boolean removeTag(String tag) {
+        if (tag == null || this.tags == null) {
+            return false;
+        }
+
+        String trimmed = tag.trim();
+        java.util.List<String> list = new java.util.ArrayList<>();
+        boolean removed = false;
+        for (String existing : this.tags) {
+            if (existing == null || existing.isEmpty()) {
+                continue;
+            }
+            if (existing.equalsIgnoreCase(trimmed)) {
+                removed = true;
+                continue;
+            }
+            list.add(existing);
+        }
+
+        if (!removed) {
+            return false;
+        }
+
+        this.tags = list.toArray(new String[0]);
+        this.persistTags();
+        return true;
+    }
+
+    private void persistTags() {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement statement = connection.prepareStatement("UPDATE users_settings SET `tags` = ? WHERE user_id = ? LIMIT 1")) {
+            statement.setString(1, this.tags == null ? "" : String.join(";", this.tags));
+            statement.setInt(2, this.habboInfo.getId());
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to persist users_settings.tags for user {}", this.habboInfo.getId(), e);
+        }
+    }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredEffectType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredEffectType.java
@@ -61,7 +61,11 @@ public enum WiredEffectType {
     FURNI_WITH_VAR_SELECTOR(75),
     USERS_WITH_VAR_SELECTOR(76),
     NEG_CALL_STACKS(86),
-    NEG_SEND_SIGNAL(87);
+    NEG_SEND_SIGNAL(87),
+    // Negative-branch effects that reuse the SHOW_MESSAGE(7) client dialog (text). Distinct enum
+    // constants so WiredEngine.isNegativeConditionEffect runs them only when conditions FAIL.
+    NEG_SHOW_MESSAGE(7),
+    NEG_LOG(7);
 
     public final int code;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEngine.java
@@ -773,7 +773,8 @@ public final class WiredEngine {
         }
 
         WiredEffectType effectType = ((InteractionWiredEffect) effect).getType();
-        return effectType == WiredEffectType.NEG_CALL_STACKS || effectType == WiredEffectType.NEG_SEND_SIGNAL;
+        return effectType == WiredEffectType.NEG_CALL_STACKS || effectType == WiredEffectType.NEG_SEND_SIGNAL
+                || effectType == WiredEffectType.NEG_SHOW_MESSAGE || effectType == WiredEffectType.NEG_LOG;
     }
 
     private WiredTextInputCaptureSupport.CaptureResult resolveTextInputCapture(WiredStack stack, WiredEvent event) {


### PR DESCRIPTION
Ports a batch of server-side wired **conditions & effects** from the fork's `java25-migration` onto `dev` (purely **additive**, Trove→`java.util` converted). 14 new classes + small additive edits to ItemManager / HabboStats / WiredEffectType / WiredEngine.

## Conditions
- `owns_furni` / `not_owns_furni` — triggerer owns (in inventory) the picked furni type(s)
- `owns_badge` / `not_owns_badge` — inventory badge ownership
- `motto_contains` — user motto contains text
- `has_at_least_x_items` — inventory item-count threshold
- `has_tag` / `not_has_tag` — profile tag present

## Effects
- `add_tag` / `remove_tag` — profile tags (persisted via new `HabboStats` helpers; `users_settings.tags` already exists on dev)
- `give_look` — set the user's figure from the text dialog
- `neg_show_message` / `neg_log` — negative-branch effects (run when the stack's conditions FAIL) via new `WiredEffectType.NEG_SHOW_MESSAGE`/`NEG_LOG` + `WiredEngine.isNegativeConditionEffect`

## Notes
- Includes the `WiredEffectLog` base class (parent of `neg_log`); the upcoming **phase-c** PR builds on it and will not re-add it.
- Trove→java.util conversions: `THashSet`→`HashSet`, `TObjectProcedure.forEach`→`for`-loop, fastutil `.valueCollection()`→`.values()`.
- `mvn clean compile`: **BUILD SUCCESS** on `dev`. Draft pending runtime test.