### PR TITLE
feat(wired): new dialog types (set_roller_speed, bot_dance, give_points_type, give_or_take_furni, play_youtube, quick_bopper, set_room_ad, no_battlebanzai, user_on_furni_with_state, trg_frn_adjacent_state)

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -260,6 +260,19 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_lose", WiredTriggerTeamLoses.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_recv_signal", WiredTriggerReceiveSignal.class));
 
+        this.interactionsList.add(new ItemInteraction("wf_act_roller_speed", WiredEffectSetRollerSpeed.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_bot_start_dance", WiredEffectBotDance.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_bot_stop_dance", WiredEffectBotDance.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_give_points_type", WiredEffectGivePointsType.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_battlebanzai", WiredConditionNoBattleBanzaiRunning.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_battlebz", WiredConditionNoBattleBanzaiRunning.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_give_or_take_furni", WiredEffectGiveOrTakeFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_play_youtube_sound", WiredEffectPlayYoutube.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_quick_bopper", WiredEffectQuickBopper.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_set_room_ad", WiredEffectSetRoomAd.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_user_on_furni_with_state", WiredConditionUserOnFurniWithState.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_trg_frn_adjacent_state", WiredConditionTriggerFurniAdjacentState.class));
+
 
         this.interactionsList.add(new ItemInteraction("wf_act_toggle_state", WiredEffectToggleFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_act_reset_timers", WiredEffectResetTimers.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNoBattleBanzaiRunning.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNoBattleBanzaiRunning.java
@@ -1,0 +1,95 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.games.Game;
+import com.eu.habbo.habbohotel.games.GameState;
+import com.eu.habbo.habbohotel.games.battlebanzai.BattleBanzaiGame;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Passes only when no BattleBanzai game is currently running in the room. A "running" game is one
+ * whose {@link Game#getState()} is {@link GameState#RUNNING} (mirrors the live check in
+ * {@code InteractionBattleBanzaiGate}). This is a no-config condition: it carries zero int params and
+ * no string, so it reuses the no-input client dialog {@code MOVEMENT_VALIDATION}-style layout via the
+ * dedicated new client code {@code WiredConditionlayout.NO_BATTLEBANZAI} (44).
+ *
+ * <p>Serialization mirrors {@link WiredConditionMovementValidation}: it appends {@code intParamCount=0}
+ * and an empty string, so the client reads no ints and saves none, and {@link #saveData(WiredSettings)}
+ * reads nothing back.</p>
+ */
+public class WiredConditionNoBattleBanzaiRunning extends InteractionWiredCondition {
+
+    public static final WiredConditionType type = WiredConditionType.NO_BATTLEBANZAI;
+
+    public WiredConditionNoBattleBanzaiRunning(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionNoBattleBanzaiRunning(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return true;
+        }
+
+        Game game = room.getGame(BattleBanzaiGame.class);
+        return game == null || game.getState() != GameState.RUNNING;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return "";
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+    }
+
+    @Override
+    public void onPickUp() {
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerFurniAdjacentState.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionTriggerFurniAdjacentState.java
@@ -1,0 +1,248 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Passes when a furni ADJACENT to the wired trigger furni currently has its {@code extradata} state
+ * equal to a required value. "Adjacent" means any of the 8 tiles surrounding the trigger furni's
+ * tile (computed via {@link com.eu.habbo.habbohotel.rooms.RoomLayout#getTilesAround(RoomTile)}); items
+ * on each neighbour tile are read with {@link Room#getItemsAt(RoomTile)} and their state via
+ * {@link HabboItem#getExtradata()}.
+ *
+ * <p>Inputs: one {@code stringParam} carrying the required state, plus an optional furni picker. When
+ * the picker selects one or more furni, only adjacent items whose base-item type matches one of the
+ * selected furni count (a way to scope the check to a particular furni kind); when nothing is selected
+ * the condition matches any adjacent furni whose state equals the required value.</p>
+ *
+ * <p>Carries no int params: it serializes {@code intParamCount=0} and the required state in the string
+ * slot, mirroring {@link WiredConditionMatchStatePosition}'s furni-selecting serialize shape (furni
+ * flag true + {@code MAXIMUM_FURNI_SELECTION} + selected ids). Uses the dedicated new client dialog
+ * {@code WiredConditionlayout.TRG_FURNI_ADJACENT_STATE} (46).</p>
+ */
+public class WiredConditionTriggerFurniAdjacentState extends InteractionWiredCondition {
+
+    public static final WiredConditionType type = WiredConditionType.TRG_FURNI_ADJACENT_STATE;
+
+    private String requiredState = "";
+    private final HashSet<Integer> selectedFurni = new HashSet<>();
+
+    public WiredConditionTriggerFurniAdjacentState(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionTriggerFurniAdjacentState(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        if (ctx == null || ctx.room() == null) {
+            return false;
+        }
+
+        Room room = ctx.room();
+
+        HabboItem trigger = ctx.triggerItem();
+        if (trigger == null) {
+            return false;
+        }
+
+        RoomTile triggerTile = room.getLayout() == null
+                ? null
+                : room.getLayout().getTile((short) trigger.getX(), (short) trigger.getY());
+
+        if (triggerTile == null) {
+            return false;
+        }
+
+        // Resolve the set of base-item ids the picker scopes the check to (empty == any furni).
+        var allowedBaseItems = new HashSet<Integer>();
+        for (int itemId : this.selectedFurni) {
+            HabboItem selected = room.getHabboItem(itemId);
+            if (selected != null) {
+                allowedBaseItems.add(selected.getBaseItem().getId());
+            }
+        }
+
+        List<RoomTile> neighbours = room.getLayout().getTilesAround(triggerTile);
+
+        for (RoomTile tile : neighbours) {
+            if (tile == null) {
+                continue;
+            }
+
+            for (HabboItem item : room.getItemsAt(tile)) {
+                if (item == null || item.getId() == trigger.getId()) {
+                    continue;
+                }
+
+                if (!allowedBaseItems.isEmpty() && !allowedBaseItems.contains(item.getBaseItem().getId())) {
+                    continue;
+                }
+
+                String extradata = item.getExtradata();
+                if (extradata != null && extradata.equals(this.requiredState)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        this.refresh(room);
+
+        message.appendBoolean(true);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.selectedFurni.size());
+
+        for (int itemId : this.selectedFurni) {
+            message.appendInt(itemId);
+        }
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.requiredState);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        String state = settings.getStringParam();
+        this.requiredState = (state == null) ? "" : state;
+
+        this.selectedFurni.clear();
+
+        Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+
+        int[] furniIds = settings.getFurniIds();
+        if (furniIds != null) {
+            int maxFurni = Emulator.getConfig().getInt("hotel.wired.furni.selection.count", WiredManager.MAXIMUM_FURNI_SELECTION);
+            if (furniIds.length > maxFurni) {
+                return false;
+            }
+
+            for (int itemId : furniIds) {
+                if (room == null) {
+                    this.selectedFurni.add(itemId);
+                    continue;
+                }
+
+                HabboItem item = room.getHabboItem(itemId);
+                if (item != null) {
+                    this.selectedFurni.add(item.getId());
+                }
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.requiredState, new ArrayList<>(this.selectedFurni)));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || wiredData.isEmpty()) {
+            return;
+        }
+
+        if (wiredData.startsWith("{")) {
+            JsonData data;
+            try {
+                data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            } catch (RuntimeException exception) {
+                this.onPickUp();
+                return;
+            }
+
+            if (data == null) {
+                return;
+            }
+
+            this.requiredState = (data.state == null) ? "" : data.state;
+
+            if (data.furni != null) {
+                for (Integer itemId : data.furni) {
+                    if (itemId != null) {
+                        this.selectedFurni.add(itemId);
+                    }
+                }
+            }
+        }
+
+        this.refresh(room);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.requiredState = "";
+        this.selectedFurni.clear();
+    }
+
+    private void refresh(Room room) {
+        if (room == null) {
+            return;
+        }
+
+        var remove = new HashSet<Integer>();
+        for (int itemId : this.selectedFurni) {
+            if (room.getHabboItem(itemId) == null) {
+                remove.add(itemId);
+            }
+        }
+
+        for (int itemId : remove) {
+            this.selectedFurni.remove(itemId);
+        }
+    }
+
+    static class JsonData {
+        String state;
+        List<Integer> furni;
+
+        public JsonData(String state, List<Integer> furni) {
+            this.state = state;
+            this.furni = furni;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserOnFurniWithState.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserOnFurniWithState.java
@@ -1,0 +1,271 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Passes when a resolved user stands on one of the selected furni AND that furni's
+ * {@link HabboItem#getExtradata() extradata state} equals a required value.
+ *
+ * <p>This is a specialisation of {@link WiredConditionTriggerOnFurni}: it reuses the same furni
+ * picker, {@code userSource}, and {@code quantifier} machinery (and therefore the same int-param
+ * layout {@code [furniSource, userSource, quantifier]} and furni-id selection), but additionally
+ * carries a single {@code requiredState} string. When that string is non-empty, a user only counts
+ * as "on the furni" if the furni under their feet currently reports that exact extradata state. An
+ * empty {@code requiredState} degrades gracefully to the plain on-furni behaviour.</p>
+ *
+ * <p>The state-match idiom mirrors {@link WiredConditionMatchStatePosition#matchesSetting}
+ * ({@code item.getExtradata().equals(requiredState)}). Serialization differs from the parent only in
+ * the string slot: the parent appends {@code ""}; here we append the {@code requiredState}. The int
+ * layout, furni-selection flag, and trailing pad/code are byte-for-byte identical, so it reuses the
+ * dedicated new client dialog {@code WiredConditionlayout.USER_ON_FURNI_WITH_STATE} (45).</p>
+ */
+public class WiredConditionUserOnFurniWithState extends WiredConditionTriggerOnFurni {
+
+    public static final WiredConditionType type = WiredConditionType.USER_ON_FURNI_WITH_STATE;
+
+    private static final int MAX_STATE_LENGTH = 256;
+
+    private String requiredState = "";
+
+    public WiredConditionUserOnFurniWithState(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionUserOnFurniWithState(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        if (ctx == null || ctx.room() == null) {
+            return false;
+        }
+
+        this.refresh();
+
+        List<RoomUnit> userTargets = WiredSourceUtil.resolveUsers(ctx, this.userSource);
+        if (userTargets.isEmpty())
+            return false;
+
+        List<HabboItem> itemTargets = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
+        if (itemTargets.isEmpty())
+            return false;
+
+        if (this.getQuantifier() == QUANTIFIER_ANY) {
+            return this.isAnyUserOnFurniWithState(userTargets, itemTargets, ctx.room());
+        }
+
+        return this.areAllUsersOnFurniWithState(userTargets, itemTargets, ctx.room());
+    }
+
+    private boolean isAnyUserOnFurniWithState(Collection<RoomUnit> users, Collection<HabboItem> items, Room room) {
+        for (RoomUnit roomUnit : users) {
+            if (roomUnit == null) continue;
+            if (this.matchingItemUnderUser(roomUnit, items, room)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean areAllUsersOnFurniWithState(Collection<RoomUnit> users, Collection<HabboItem> items, Room room) {
+        for (RoomUnit roomUnit : users) {
+            if (roomUnit == null) {
+                return false;
+            }
+            if (!this.matchingItemUnderUser(roomUnit, items, room)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean matchingItemUnderUser(RoomUnit roomUnit, Collection<HabboItem> items, Room room) {
+        Set<HabboItem> itemsAtUser = room.getItemsAt(roomUnit.getCurrentLocation());
+        if (itemsAtUser == null) {
+            return false;
+        }
+
+        for (HabboItem item : items) {
+            if (item != null && itemsAtUser.contains(item) && this.matchesRequiredState(item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    boolean matchesRequiredState(HabboItem item) {
+        if (this.requiredState == null || this.requiredState.isEmpty()) {
+            return true;
+        }
+
+        if (item == null) {
+            return false;
+        }
+
+        String extradata = item.getExtradata();
+        return extradata != null && extradata.equals(this.requiredState);
+    }
+
+    @Override
+    public String getWiredData() {
+        this.refresh();
+        return WiredManager.getGson().toJson(new JsonData(
+                this.items.stream().map(HabboItem::getId).toList(),
+                this.furniSource,
+                this.userSource,
+                this.getQuantifier(),
+                this.requiredState
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || wiredData.isEmpty()) {
+            return;
+        }
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            if (data == null) {
+                return;
+            }
+
+            this.furniSource = WiredFurniConditionInputGuard.normalizeFurniSource(data.furniSource);
+            this.userSource = WiredFurniConditionInputGuard.normalizeUserSource(data.userSource);
+            this.quantifier = this.normalizeQuantifier(data.quantifier);
+            this.requiredState = this.normalizeRequiredState(data.requiredState);
+
+            for (int id : WiredFurniConditionInputGuard.sanitizeItemIds(data.itemIds, WiredManager.MAXIMUM_FURNI_SELECTION)) {
+                HabboItem item = room.getHabboItem(id);
+
+                if (item != null) {
+                    this.items.add(item);
+                }
+            }
+
+            this.furniSource = WiredFurniConditionInputGuard.selectedOrNormalizedFurniSource(this.furniSource, !this.items.isEmpty());
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        super.onPickUp();
+        this.requiredState = "";
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        this.refresh();
+
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.items.size());
+
+        for (HabboItem item : this.items)
+            message.appendInt(item.getId());
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.requiredState == null ? "" : this.requiredState);
+        message.appendInt(3);
+        message.appendInt(this.furniSource);
+        message.appendInt(this.userSource);
+        message.appendInt(this.getQuantifier());
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int count = settings.getFurniIds().length;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) return false;
+
+        int[] params = settings.getIntParams();
+        this.furniSource = (params.length > 0) ? WiredFurniConditionInputGuard.normalizeFurniSource(params[0]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.userSource = (params.length > 1) ? WiredFurniConditionInputGuard.normalizeUserSource(params[1]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 2) ? this.normalizeQuantifier(params[2]) : QUANTIFIER_ALL;
+        this.requiredState = this.normalizeRequiredState(settings.getStringParam());
+
+        this.furniSource = WiredFurniConditionInputGuard.selectedOrNormalizedFurniSource(this.furniSource, count > 0);
+
+        this.items.clear();
+
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+
+            if (room != null) {
+                for (int i = 0; i < count; i++) {
+                    HabboItem item = room.getHabboItem(settings.getFurniIds()[i]);
+
+                    if (item != null) {
+                        this.items.add(item);
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    String normalizeRequiredState(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String trimmed = value.trim();
+        if (trimmed.length() > MAX_STATE_LENGTH) {
+            return trimmed.substring(0, MAX_STATE_LENGTH);
+        }
+
+        return trimmed;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    static class JsonData {
+        List<Integer> itemIds;
+        int furniSource;
+        int userSource;
+        int quantifier;
+        String requiredState;
+
+        public JsonData(List<Integer> itemIds, int furniSource, int userSource, int quantifier, String requiredState) {
+            this.itemIds = itemIds;
+            this.furniSource = furniSource;
+            this.userSource = userSource;
+            this.quantifier = quantifier;
+            this.requiredState = requiredState;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotDance.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectBotDance.java
@@ -1,0 +1,170 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.bots.Bot;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.DanceType;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredBotSourceUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDanceComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Makes a named bot start or stop dancing. Carries a bot {@code name} (stringParam) plus a single
+ * {@code danceType} int (0=stop/NONE, 1=HAB_HOP, 2=POGO_MOGO, 3=DUCK_FUNK, 4=THE_ROLLIE), which
+ * needs a dedicated dialog, so it uses the NEW client code {@link WiredEffectType#BOT_DANCE} (89)
+ * with a matching Nitro {@code WiredActionLayoutCode.BOT_DANCE} component. Both
+ * {@code wf_act_bot_start_dance} and {@code wf_act_bot_stop_dance} register to this class; the dance
+ * int distinguishes them (a start-dance furni defaults to a dance, a stop-dance furni to 0).
+ */
+public class WiredEffectBotDance extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.BOT_DANCE;
+    private static final int MIN_DANCE = 0;
+    private static final int MAX_DANCE = 4;
+
+    private String botName = "";
+    private int danceType = 0;
+
+    public WiredEffectBotDance(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectBotDance(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return;
+        }
+
+        List<Bot> bots = WiredBotSourceUtil.resolveBots(ctx, room, WiredBotSourceUtil.SOURCE_BOT_NAME, this.botName);
+        if (bots.isEmpty()) {
+            return;
+        }
+
+        DanceType dance = danceFromInt(this.danceType);
+
+        for (Bot bot : bots) {
+            if (bot.getRoomUnit() == null) {
+                continue;
+            }
+
+            bot.getRoomUnit().setDanceType(dance);
+            room.sendComposer(new RoomUserDanceComposer(bot.getRoomUnit()).compose());
+            bot.needsUpdate(true);
+            Emulator.getThreading().run(bot);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.botName);
+        message.appendInt(1);
+        message.appendInt(this.danceType);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        this.danceType = (params.length > 0) ? clampDance(params[0]) : 0;
+
+        String name = settings.getStringParam();
+        name = (name == null) ? "" : name.replace("\t", "");
+        this.botName = name.substring(0, Math.min(name.length(), Emulator.getConfig().getInt("hotel.wired.message.max_length", 100)));
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.setDelay(delay);
+        return true;
+    }
+
+    private static int clampDance(int value) {
+        return Math.max(MIN_DANCE, Math.min(MAX_DANCE, value));
+    }
+
+    private static DanceType danceFromInt(int value) {
+        return switch (clampDance(value)) {
+            case 1 -> DanceType.HAB_HOP;
+            case 2 -> DanceType.POGO_MOGO;
+            case 3 -> DanceType.DUCK_FUNK;
+            case 4 -> DanceType.THE_ROLLIE;
+            default -> DanceType.NONE;
+        };
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.getDelay(), this.botName, this.danceType));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        JsonData data = WiredEffectPayloadGuard.fromJson(set.getString("wired_data"), JsonData.class);
+        if (data != null) {
+            this.setDelay(WiredEffectPayloadGuard.delay(data.delay));
+            this.botName = WiredEffectPayloadGuard.text(data.bot_name);
+            this.danceType = clampDance(data.dance_type);
+        } else {
+            this.setDelay(0);
+            this.botName = "";
+            this.danceType = 0;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.botName = "";
+        this.danceType = 0;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int delay;
+        String bot_name;
+        int dance_type;
+
+        public JsonData(int delay, String bot_name, int dance_type) {
+            this.delay = delay;
+            this.bot_name = bot_name;
+            this.dance_type = dance_type;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveOrTakeFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveOrTakeFurni.java
@@ -1,0 +1,259 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+import com.eu.habbo.messages.outgoing.catalog.PurchaseOKComposer;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
+import com.eu.habbo.threading.runnables.QueryDeleteHabboItems;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Gives or takes a furni (identified by its catalog/base item id) to/from the resolved user(s).
+ * Carries four ints — {@code [baseItemId, quantity, giveOrTake, userSource]} — so it needs a dedicated
+ * NEW client dialog {@link WiredEffectType#GIVE_OR_TAKE_FURNI} (91) with a matching Nitro
+ * {@code WiredActionLayoutCode.GIVE_OR_TAKE_FURNI} component.
+ *
+ * <p>The GIVE branch mints fresh inventory copies through {@link com.eu.habbo.habbohotel.items.ItemManager#createItem}
+ * — the same channel {@code WiredManager.giveReward} and the catalog purchase path use — and announces each via
+ * {@link AddHabboItemComposer} / {@link PurchaseOKComposer} / {@link InventoryRefreshComposer}. The TAKE branch removes
+ * matching base items from the inventory with {@code ItemsComponent.getAndRemoveHabboItem} (mirroring
+ * {@code RequestInventoryItemsDelete}), notifies the client with {@link RemoveHabboItemComposer} and persists the
+ * deletions through {@link QueryDeleteHabboItems}. Quantity is bounded and the base item is validated so a malformed
+ * packet can never spawn an unknown item nor loop unbounded.</p>
+ */
+public class WiredEffectGiveOrTakeFurni extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.GIVE_OR_TAKE_FURNI;
+
+    public static final int MODE_GIVE = 0;
+    public static final int MODE_TAKE = 1;
+
+    private static final int MIN_QUANTITY = 1;
+    private static final int MAX_QUANTITY = 100;
+    private static final int DEFAULT_QUANTITY = 1;
+
+    private int baseItemId = 0;
+    private int quantity = DEFAULT_QUANTITY;
+    private int giveOrTake = MODE_GIVE;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveOrTakeFurni(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveOrTakeFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) return;
+
+        Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(this.baseItemId);
+        if (baseItem == null) return;
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null || habbo.getClient() == null) continue;
+
+            if (this.giveOrTake == MODE_TAKE) {
+                takeFurni(habbo, baseItem);
+            } else {
+                giveFurni(habbo, baseItem);
+            }
+        }
+    }
+
+    private void giveFurni(Habbo habbo, Item baseItem) {
+        boolean changed = false;
+
+        for (int i = 0; i < this.quantity; i++) {
+            HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getHabboInfo().getId(), baseItem, 0, 0, "");
+            if (item == null) {
+                continue;
+            }
+
+            habbo.getClient().sendResponse(new AddHabboItemComposer(item));
+            habbo.getInventory().getItemsComponent().addItem(item);
+            changed = true;
+        }
+
+        if (changed) {
+            habbo.getClient().sendResponse(new PurchaseOKComposer(null));
+            habbo.getClient().sendResponse(new InventoryRefreshComposer());
+        }
+    }
+
+    private void takeFurni(Habbo habbo, Item baseItem) {
+        HashMap<Integer, HabboItem> toRemove = new HashMap<>();
+
+        for (int i = 0; i < this.quantity; i++) {
+            HabboItem item = habbo.getInventory().getItemsComponent().getAndRemoveHabboItem(baseItem);
+            if (item == null) {
+                break;
+            }
+            toRemove.put(item.getId(), item);
+        }
+
+        if (toRemove.isEmpty()) {
+            return;
+        }
+
+        for (HabboItem object : toRemove.values()) {
+            habbo.getClient().sendResponse(new RemoveHabboItemComposer(object.getGiftAdjustedId()));
+        }
+
+        habbo.getClient().sendResponse(new InventoryRefreshComposer());
+        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove.values()));
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(4);
+        message.appendInt(this.baseItemId);
+        message.appendInt(this.quantity);
+        message.appendInt(this.giveOrTake);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        if (params.length < 4) {
+            throw new WiredSaveException("Invalid data");
+        }
+
+        int nextBaseItemId = params[0];
+        if (nextBaseItemId <= 0 || Emulator.getGameEnvironment().getItemManager().getItem(nextBaseItemId) == null) {
+            throw new WiredSaveException("Invalid furni");
+        }
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.baseItemId = nextBaseItemId;
+        this.quantity = clampQuantity(params[1]);
+        this.giveOrTake = (params[2] == MODE_TAKE) ? MODE_TAKE : MODE_GIVE;
+        this.userSource = params[3];
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    private static int clampQuantity(int value) {
+        return Math.max(MIN_QUANTITY, Math.min(MAX_QUANTITY, value));
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.baseItemId, this.quantity, this.giveOrTake, this.userSource, this.getDelay()));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData != null && wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.baseItemId = data.baseItemId;
+            this.quantity = clampQuantity(data.quantity);
+            this.giveOrTake = (data.giveOrTake == MODE_TAKE) ? MODE_TAKE : MODE_GIVE;
+            this.userSource = data.userSource;
+            this.setDelay(data.delay);
+        } else {
+            this.baseItemId = 0;
+            this.quantity = DEFAULT_QUANTITY;
+            this.giveOrTake = MODE_GIVE;
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.baseItemId = 0;
+        this.quantity = DEFAULT_QUANTITY;
+        this.giveOrTake = MODE_GIVE;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int baseItemId;
+        int quantity;
+        int giveOrTake;
+        int userSource;
+        int delay;
+
+        public JsonData(int baseItemId, int quantity, int giveOrTake, int userSource, int delay) {
+            this.baseItemId = baseItemId;
+            this.quantity = quantity;
+            this.giveOrTake = giveOrTake;
+            this.userSource = userSource;
+            this.delay = delay;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGivePointsType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGivePointsType.java
@@ -1,0 +1,198 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Gives the resolved user(s) an amount of a SELECTABLE currency (points) type. Unlike
+ * {@link WiredEffectGiveDiamonds} / {@link WiredEffectGiveDuckets} (which hard-code a single
+ * currency and reuse the SHOW_MESSAGE dialog), this effect lets the builder pick the points type
+ * in the dialog, so it carries three ints — {@code [pointsType, amount, userSource]} — and needs a
+ * dedicated NEW client dialog {@link WiredEffectType#GIVE_POINTS_TYPE} (90) with a matching Nitro
+ * {@code WiredActionLayoutCode.GIVE_POINTS_TYPE} component.
+ *
+ * <p>Currency is granted through {@link Habbo#givePoints(int, int)} — the same channel the
+ * diamond/seasonal effects use. Amount is capped via {@link WiredNumericInputGuard} and the points
+ * type is range-clamped so a malformed packet can never touch an unintended currency slot.</p>
+ */
+public class WiredEffectGivePointsType extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.GIVE_POINTS_TYPE;
+
+    private static final int MIN_POINTS_TYPE = 0;
+    private static final int MAX_POINTS_TYPE = 100;
+    private static final int DEFAULT_POINTS_TYPE = 0;
+
+    private int pointsType = DEFAULT_POINTS_TYPE;
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGivePointsType(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGivePointsType(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) return;
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            habbo.givePoints(this.pointsType, this.amount);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(3);
+        message.appendInt(this.pointsType);
+        message.appendInt(this.amount);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        if (params.length < 3) {
+            throw new WiredSaveException("Invalid data");
+        }
+
+        int nextPointsType = clampPointsType(params[0]);
+        int nextAmount = clampAmount(params[1]);
+        if (nextAmount <= 0) {
+            throw new WiredSaveException("Amount is invalid");
+        }
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.pointsType = nextPointsType;
+        this.amount = nextAmount;
+        this.userSource = params[2];
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    private static int clampPointsType(int value) {
+        return Math.max(MIN_POINTS_TYPE, Math.min(MAX_POINTS_TYPE, value));
+    }
+
+    private static int clampAmount(int value) {
+        if (value <= 0) {
+            return 0;
+        }
+        return Math.min(value, WiredNumericInputGuard.maxRewardAmount());
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.pointsType, this.amount, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData != null && wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.pointsType = clampPointsType(data.pointsType);
+            this.amount = clampAmount(data.amount);
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.pointsType = DEFAULT_POINTS_TYPE;
+            this.amount = 0;
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.pointsType = DEFAULT_POINTS_TYPE;
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int pointsType;
+        int amount;
+        int delay;
+        int userSource;
+
+        public JsonData(int pointsType, int amount, int delay, int userSource) {
+            this.pointsType = pointsType;
+            this.amount = amount;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectPlayYoutube.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectPlayYoutube.java
@@ -1,0 +1,158 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+import com.eu.habbo.messages.outgoing.rooms.youtube.YouTubeRoomBroadcastComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+
+/**
+ * Plays a single YouTube video/sound for the whole room, driving the same room-jukebox path that the
+ * client's own "play video" button uses ({@code YouTubeRoomPlayEvent}). Carries a YouTube id/url
+ * {@code videoId} (stringParam) plus a single optional {@code autoStart} int (1 = start playing,
+ * 0 = clear/stop), so it needs a dedicated dialog and uses the NEW client code
+ * {@link WiredEffectType#PLAY_YOUTUBE} (92) with a matching Nitro {@code WiredActionLayoutCode.PLAY_YOUTUBE}
+ * component.
+ *
+ * <p>On execute it mirrors {@code YouTubeRoomPlayEvent#handle}: it requires the room's YouTube feature
+ * to be enabled, then either stores + broadcasts the video (sender name = room owner, since wired has
+ * no triggering "DJ") or clears it. No new packet or core-path hook is needed — the {@link Room}
+ * already exposes {@code isYoutubeEnabled()/setYoutubeVideo/clearYoutubeVideo} and the outgoing
+ * {@link YouTubeRoomBroadcastComposer} already takes an arbitrary video id.</p>
+ */
+public class WiredEffectPlayYoutube extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.PLAY_YOUTUBE;
+
+    private static final int MAX_VIDEO_ID_LENGTH = 100;
+
+    private String videoId = "";
+    private int autoStart = 1;
+
+    public WiredEffectPlayYoutube(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectPlayYoutube(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return;
+        }
+
+        // Faithful to YouTubeRoomPlayEvent: the room must have the YouTube feature enabled.
+        if (!room.isYoutubeEnabled()) {
+            return;
+        }
+
+        if (this.autoStart == 0 || this.videoId.isEmpty()) {
+            room.clearYoutubeVideo();
+            room.sendComposer(new YouTubeRoomBroadcastComposer("", "", Collections.emptyList()).compose());
+            return;
+        }
+
+        // Wired has no triggering "DJ" user — attribute the broadcast to the room owner.
+        String senderName = room.getOwnerName() == null ? "" : room.getOwnerName();
+        room.setYoutubeVideo(this.videoId, senderName, Collections.emptyList());
+        room.sendComposer(new YouTubeRoomBroadcastComposer(this.videoId, senderName, Collections.emptyList()).compose());
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.videoId);
+        message.appendInt(1);
+        message.appendInt(this.autoStart);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        this.autoStart = (params.length > 0 && params[0] == 0) ? 0 : 1;
+
+        String id = settings.getStringParam();
+        id = (id == null) ? "" : id.replace("\t", "");
+        this.videoId = id.substring(0, Math.min(id.length(), MAX_VIDEO_ID_LENGTH));
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.setDelay(delay);
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.getDelay(), this.videoId, this.autoStart));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        JsonData data = WiredEffectPayloadGuard.fromJson(set.getString("wired_data"), JsonData.class);
+        if (data != null) {
+            this.setDelay(WiredEffectPayloadGuard.delay(data.delay));
+            String id = WiredEffectPayloadGuard.text(data.video_id);
+            this.videoId = id.substring(0, Math.min(id.length(), MAX_VIDEO_ID_LENGTH));
+            this.autoStart = (data.auto_start == 0) ? 0 : 1;
+        } else {
+            this.setDelay(0);
+            this.videoId = "";
+            this.autoStart = 1;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.videoId = "";
+        this.autoStart = 1;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int delay;
+        String video_id;
+        int auto_start;
+
+        public JsonData(int delay, String video_id, int auto_start) {
+            this.delay = delay;
+            this.video_id = video_id;
+            this.auto_start = auto_start;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectQuickBopper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectQuickBopper.java
@@ -1,0 +1,164 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.rooms.TraxManager;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Starts or stops the room's jukebox/trax music. This is the wired equivalent of clicking play/stop
+ * on the room's {@link com.eu.habbo.habbohotel.items.interactions.InteractionJukeBox}; the underlying
+ * playback is driven through the room {@link TraxManager} ({@link TraxManager#play(int)} /
+ * {@link TraxManager#stop()}), the exact same channel the jukebox UI uses.
+ *
+ * <p>Carries two ints — {@code [playOrStop, trackIndex]}:
+ * <ul>
+ *   <li>{@code playOrStop}: {@code 1} = start playback, {@code 0} = stop playback.</li>
+ *   <li>{@code trackIndex}: 0-based index into the room's current playlist to start from (only used
+ *       when starting). {@code TraxManager.play} wraps the index modulo the playlist size and falls
+ *       back to {@code stop()} when the playlist is empty, so an out-of-range index can never crash.</li>
+ * </ul>
+ * Because it carries a custom int pair it needs a dedicated NEW client dialog
+ * {@link WiredEffectType#QUICK_BOPPER} (93) with a matching Nitro
+ * {@code WiredActionLayoutCode.QUICK_BOPPER} component.</p>
+ */
+public class WiredEffectQuickBopper extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.QUICK_BOPPER;
+
+    private static final int STOP = 0;
+    private static final int PLAY = 1;
+    private static final int DEFAULT_PLAY_OR_STOP = PLAY;
+    private static final int DEFAULT_TRACK_INDEX = 0;
+
+    private int playOrStop = DEFAULT_PLAY_OR_STOP;
+    private int trackIndex = DEFAULT_TRACK_INDEX;
+
+    public WiredEffectQuickBopper(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectQuickBopper(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) return;
+
+        TraxManager traxManager = room.getTraxManager();
+        if (traxManager == null) return;
+
+        if (this.playOrStop == STOP) {
+            if (traxManager.isPlaying()) {
+                traxManager.stop();
+            }
+        } else {
+            if (traxManager.getJukeBox() == null || traxManager.getSongs().isEmpty()) {
+                return;
+            }
+            traxManager.play(this.trackIndex);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.playOrStop);
+        message.appendInt(this.trackIndex);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        this.playOrStop = (params.length > 0) ? clampPlayOrStop(params[0]) : DEFAULT_PLAY_OR_STOP;
+        this.trackIndex = (params.length > 1) ? clampTrackIndex(params[1]) : DEFAULT_TRACK_INDEX;
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.setDelay(delay);
+        return true;
+    }
+
+    private static int clampPlayOrStop(int value) {
+        return (value == STOP) ? STOP : PLAY;
+    }
+
+    private static int clampTrackIndex(int value) {
+        return Math.max(0, value);
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.getDelay(), this.playOrStop, this.trackIndex));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        JsonData data = WiredUtilityPayloadGuard.fromJson(set.getString("wired_data"), JsonData.class);
+        if (data != null) {
+            this.setDelay(WiredUtilityPayloadGuard.delay(data.delay));
+            this.playOrStop = clampPlayOrStop(data.playOrStop);
+            this.trackIndex = clampTrackIndex(data.trackIndex);
+        } else {
+            this.setDelay(0);
+            this.playOrStop = DEFAULT_PLAY_OR_STOP;
+            this.trackIndex = DEFAULT_TRACK_INDEX;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.playOrStop = DEFAULT_PLAY_OR_STOP;
+        this.trackIndex = DEFAULT_TRACK_INDEX;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int delay;
+        int playOrStop;
+        int trackIndex;
+
+        public JsonData(int delay, int playOrStop, int trackIndex) {
+            this.delay = delay;
+            this.playOrStop = playOrStop;
+            this.trackIndex = trackIndex;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSetRollerSpeed.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSetRollerSpeed.java
@@ -1,0 +1,126 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Sets the room's roller speed (the number of cycles between roller movements; -1 disables rollers,
+ * 0 is fastest, higher is slower — see {@code RoomCycleManager}). Carries a single signed int, which
+ * needs a dedicated dialog, so it uses the NEW client code {@link WiredEffectType#SET_ROLLER_SPEED}
+ * (88) with a matching Nitro {@code WiredActionLayoutCode.SET_ROLLER_SPEED} component.
+ */
+public class WiredEffectSetRollerSpeed extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SET_ROLLER_SPEED;
+    private static final int MIN_SPEED = -1;
+    private static final int MAX_SPEED = 10;
+    private static final int DEFAULT_SPEED = 2;
+
+    private int speed = DEFAULT_SPEED;
+
+    public WiredEffectSetRollerSpeed(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectSetRollerSpeed(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room != null) {
+            room.setRollerSpeed(this.speed);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.speed);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        this.speed = (params.length > 0) ? clampSpeed(params[0]) : DEFAULT_SPEED;
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.setDelay(delay);
+        return true;
+    }
+
+    private static int clampSpeed(int value) {
+        return Math.max(MIN_SPEED, Math.min(MAX_SPEED, value));
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.getDelay(), this.speed));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        JsonData data = WiredUtilityPayloadGuard.fromJson(set.getString("wired_data"), JsonData.class);
+        if (data != null) {
+            this.setDelay(WiredUtilityPayloadGuard.delay(data.delay));
+            this.speed = clampSpeed(data.speed);
+        } else {
+            this.setDelay(0);
+            this.speed = DEFAULT_SPEED;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.speed = DEFAULT_SPEED;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int delay;
+        int speed;
+
+        public JsonData(int delay, int speed) {
+            this.delay = delay;
+            this.speed = speed;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSetRoomAd.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSetRoomAd.java
@@ -1,0 +1,178 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Sets or refreshes the room's promotion (the "room ad" event shown in navigator promotion lists).
+ * Carries a {@code stringParam} that packs {@code caption\tdescription} and a single optional int
+ * {@code category}. On execute it drives the existing promotion subsystem via
+ * {@link com.eu.habbo.habbohotel.rooms.RoomPromotionManager#createPromotion(String, String, int)},
+ * which creates a brand-new promotion or, if one already exists, updates its title/description/
+ * category and pushes the end timestamp forward (the standard 2-hour window) and persists to
+ * {@code room_promotions}. This needs a dedicated dialog (caption + description + category picker),
+ * so it uses the NEW client code {@link WiredEffectType#SET_ROOM_AD} (94) with a matching Nitro
+ * {@code WiredActionLayoutCode.SET_ROOM_AD} component.
+ */
+public class WiredEffectSetRoomAd extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SET_ROOM_AD;
+
+    private static final int MIN_CATEGORY = 0;
+    private static final int MAX_CATEGORY = 50;
+    private static final int DEFAULT_CATEGORY = 0;
+    private static final int DEFAULT_MAX_CAPTION_LENGTH = 60;
+    private static final int DEFAULT_MAX_DESCRIPTION_LENGTH = 200;
+
+    private String caption = "";
+    private String description = "";
+    private int category = DEFAULT_CATEGORY;
+
+    public WiredEffectSetRoomAd(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectSetRoomAd(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return;
+        }
+
+        if (this.caption.isEmpty() && this.description.isEmpty()) {
+            return;
+        }
+
+        room.getPromotionManager().createPromotion(this.caption, this.description, this.category);
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.caption + "\t" + this.description);
+        message.appendInt(1);
+        message.appendInt(this.category);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        this.category = (params.length > 0) ? clampCategory(params[0]) : DEFAULT_CATEGORY;
+
+        String raw = settings.getStringParam();
+        raw = (raw == null) ? "" : raw;
+        String[] parts = raw.split("\t", -1);
+        this.caption = clampText(parts.length > 0 ? parts[0] : "", maxCaptionLength());
+        this.description = clampText(parts.length > 1 ? parts[1] : "", maxDescriptionLength());
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.setDelay(delay);
+        return true;
+    }
+
+    private static int clampCategory(int value) {
+        return Math.max(MIN_CATEGORY, Math.min(MAX_CATEGORY, value));
+    }
+
+    private static String clampText(String value, int maxLength) {
+        if (value == null) {
+            return "";
+        }
+
+        String cleaned = value.replace("\t", "").replace("\r", "").replace("\n", " ").trim();
+        if (cleaned.length() > maxLength) {
+            cleaned = cleaned.substring(0, maxLength);
+        }
+        return cleaned;
+    }
+
+    private static int maxCaptionLength() {
+        return Emulator.getConfig().getInt("hotel.wired.set_room_ad.caption_max_length", DEFAULT_MAX_CAPTION_LENGTH);
+    }
+
+    private static int maxDescriptionLength() {
+        return Emulator.getConfig().getInt("hotel.wired.set_room_ad.description_max_length", DEFAULT_MAX_DESCRIPTION_LENGTH);
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.getDelay(), this.caption, this.description, this.category));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        JsonData data = WiredEffectPayloadGuard.fromJson(set.getString("wired_data"), JsonData.class);
+        if (data != null) {
+            this.setDelay(WiredEffectPayloadGuard.delay(data.delay));
+            this.caption = clampText(WiredEffectPayloadGuard.text(data.caption), maxCaptionLength());
+            this.description = clampText(WiredEffectPayloadGuard.text(data.description), maxDescriptionLength());
+            this.category = clampCategory(data.category);
+        } else {
+            this.setDelay(0);
+            this.caption = "";
+            this.description = "";
+            this.category = DEFAULT_CATEGORY;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.caption = "";
+        this.description = "";
+        this.category = DEFAULT_CATEGORY;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int delay;
+        String caption;
+        String description;
+        int category;
+
+        public JsonData(int delay, String caption, String description, int category) {
+            this.delay = delay;
+            this.caption = caption;
+            this.description = description;
+            this.category = category;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredConditionType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredConditionType.java
@@ -42,7 +42,10 @@ public enum WiredConditionType {
     HAS_VAR(40),
     NOT_HAS_VAR(41),
     VAR_VAL_MATCH(42),
-    VAR_AGE_MATCH(43);
+    VAR_AGE_MATCH(43),
+    NO_BATTLEBANZAI(44),
+    USER_ON_FURNI_WITH_STATE(45),
+    TRG_FURNI_ADJACENT_STATE(46);
 
     public final int code;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredEffectType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredEffectType.java
@@ -61,7 +61,14 @@ public enum WiredEffectType {
     FURNI_WITH_VAR_SELECTOR(75),
     USERS_WITH_VAR_SELECTOR(76),
     NEG_CALL_STACKS(86),
-    NEG_SEND_SIGNAL(87);
+    NEG_SEND_SIGNAL(87),
+    SET_ROLLER_SPEED(88),
+    BOT_DANCE(89),
+    GIVE_POINTS_TYPE(90),
+    GIVE_OR_TAKE_FURNI(91),
+    PLAY_YOUTUBE(92),
+    QUICK_BOPPER(93),
+    SET_ROOM_AD(94);
 
     public final int code;
 


### PR DESCRIPTION
Ports 10 new server-side wired dialog types from the fork's `java25-migration` onto `dev` (purely **additive**, Trove→`java.util` converted). 10 new classes + additive enum/registry edits.

## Effects
- `set_roller_speed`, `bot_dance` (start/stop), `give_points_type`, `give_or_take_furni`, `play_youtube`, `quick_bopper`, `set_room_ad`

## Conditions
- `no_battlebanzai` (no BattleBanzai running), `user_on_furni_with_state`, `trg_frn_adjacent_state`

## Core edits (additive)
- `WiredConditionType`: +NO_BATTLEBANZAI(44), USER_ON_FURNI_WITH_STATE(45), TRG_FURNI_ADJACENT_STATE(46)
- `WiredEffectType`: +SET_ROLLER_SPEED(88)…SET_ROOM_AD(94)
- `ItemManager`: 12 registrations (two effects/conditions carry alias pairs)

## Notes
- Trove→java.util conversions: `THashSet`→`HashSet`, `TIntObjectHashMap`→`HashMap`, `forEachValue`/`forEach(TObjectProcedure)`→`for`-loop, `QueryDeleteHabboItems(troveMap)`→`(.values())`, fastutil-aware.
- `mvn clean compile`: **BUILD SUCCESS** on `dev` (independently re-verified). Draft pending runtime test.