### PR TITLE
feat(wired): Phase-C conditions/effects/triggers (currency, badges, posture, movement, freeze, furni-range, same-height, dance/idle)

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -259,6 +259,43 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_win", WiredTriggerTeamWins.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_game_team_lose", WiredTriggerTeamLoses.class));
         this.interactionsList.add(new ItemInteraction("wf_trg_recv_signal", WiredTriggerReceiveSignal.class));
+        // Phase-C triggers (dance/idle)
+        this.interactionsList.add(new ItemInteraction("wf_trg_starts_dancing", WiredTriggerHabboStartsDancing.class));
+        this.interactionsList.add(new ItemInteraction("wf_trg_stops_dancing", WiredTriggerHabboStopsDancing.class));
+        this.interactionsList.add(new ItemInteraction("wf_trg_idles", WiredTriggerHabboIdles.class));
+        this.interactionsList.add(new ItemInteraction("wf_trg_unidles", WiredTriggerHabboUnidles.class));
+        // Phase-C effects (currency)
+        this.interactionsList.add(new ItemInteraction("wf_act_give_credits", WiredEffectGiveCredits.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_give_duckets", WiredEffectGiveDuckets.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_give_diamonds", WiredEffectGiveDiamonds.class));
+        // Phase-C effects (badges / achievements / posture / movement / misc)
+        this.interactionsList.add(new ItemInteraction("wf_act_give_badge", WiredEffectGiveBadge.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_give_userbadge", WiredEffectGiveBadge.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_remove_badge", WiredEffectRemoveBadge.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_give_achievement", WiredEffectGiveAchievement.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_give_experience", WiredEffectGiveExperience.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_say_command", WiredEffectSayCommand.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_open_habbo_pages", WiredEffectOpenHabboPages.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_make_user_say", WiredEffectMakeUserSay.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_log", WiredEffectLog.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_walk_to_furni", WiredEffectWalkToFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_sit", WiredEffectSit.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_lay", WiredEffectLay.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_make_fast_walk", WiredEffectMakeFastWalk.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_toggle_moodlight", WiredEffectToggleMoodlight.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_reset_highscores", WiredEffectResetHighscores.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_move_user_tiles", WiredEffectMoveUserTiles.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_all_users_leave_team", WiredEffectAllUsersLeaveTeam.class));
+        // Phase-C conditions (currency / freeze / furni-range / same-height)
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_has_credits", WiredConditionHabboLacksCredits.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_has_diamonds", WiredConditionHabboLacksDiamonds.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_habbo_has_duckets", WiredConditionHabboLacksDuckets.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_freeze", WiredConditionFrozen.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_freeze", WiredConditionNotFrozen.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_furni_in_range", WiredConditionFurniInRange.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_furni_not_in_range", WiredConditionFurniNotInRange.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_has_same_height", WiredConditionSameHeight.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_not_has_same_height", WiredConditionNotSameHeight.class));
         // owns_furni: check the triggerer's inventory for the picked furni type(s) (reuse HAS_ALTITUDE picker).
         this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_owns_furni", WiredConditionHabboOwnsFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_habbo_not_owns_furni", WiredConditionHabboNotOwnsFurni.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFrozen.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFrozen.java
@@ -1,0 +1,196 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredFreezeUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class WiredConditionFrozen extends InteractionWiredCondition {
+    protected static final int QUANTIFIER_ALL = 0;
+    protected static final int QUANTIFIER_ANY = 1;
+    protected static final int MAX_EFFECT_ID = 10_000;
+
+    public static final WiredConditionType type = WiredConditionType.ACTOR_WEARS_EFFECT;
+
+    protected int effectId = 0;
+    protected int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    protected int quantifier = QUANTIFIER_ANY;
+
+    public WiredConditionFrozen(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionFrozen(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        List<RoomUnit> targets = WiredSourceUtil.resolveUsers(ctx, this.userSource);
+        if (targets.isEmpty()) return false;
+
+        if (this.quantifier == QUANTIFIER_ALL) {
+            return this.matchesAllTargets(targets);
+        }
+
+        return this.matchesAnyTarget(targets);
+    }
+
+    protected boolean matchesAllTargets(List<RoomUnit> targets) {
+        for (RoomUnit roomUnit : targets) {
+            if (!this.matchesFrozen(roomUnit)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected boolean matchesAnyTarget(List<RoomUnit> targets) {
+        for (RoomUnit roomUnit : targets) {
+            if (this.matchesFrozen(roomUnit)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected boolean matchesFrozen(RoomUnit roomUnit) {
+        return WiredFreezeUtil.isFrozen(roomUnit);
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.effectId,
+                this.userSource,
+                this.quantifier
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || wiredData.isEmpty()) {
+            this.onPickUp();
+            return;
+        }
+
+        if (wiredData.startsWith("{")) {
+            JsonData data;
+            try {
+                data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            } catch (RuntimeException ignored) {
+                this.onPickUp();
+                return;
+            }
+            if (data == null) {
+                this.onPickUp();
+                return;
+            }
+            this.effectId = WiredUserConditionInputGuard.normalizeEffectId(data.effectId);
+            this.userSource = WiredUserConditionInputGuard.normalizeUserSource(data.userSource);
+            this.quantifier = this.normalizeQuantifier(data.quantifier, QUANTIFIER_ANY);
+        } else {
+            try {
+                this.effectId = WiredUserConditionInputGuard.normalizeEffectId(Integer.parseInt(wiredData));
+            } catch (NumberFormatException ignored) {
+                this.effectId = 0;
+            }
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.quantifier = QUANTIFIER_ANY;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.effectId = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ANY;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(true);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(3);
+        message.appendInt(this.effectId);
+        message.appendInt(this.userSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        if(settings.getIntParams().length < 1) return false;
+        int[] params = settings.getIntParams();
+        this.effectId = WiredUserConditionInputGuard.normalizeEffectId(params[0]);
+        this.userSource = (params.length > 1) ? WiredUserConditionInputGuard.normalizeUserSource(params[1]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 2) ? this.normalizeQuantifier(params[2], QUANTIFIER_ANY) : QUANTIFIER_ANY;
+
+        return true;
+    }
+
+    protected int getQuantifier() {
+        return this.quantifier;
+    }
+
+    protected int normalizeQuantifier(Integer value, int fallback) {
+        if (value == null) {
+            return fallback;
+        }
+
+        return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    protected int normalizeEffectId(int value) {
+        return Math.max(0, Math.min(MAX_EFFECT_ID, value));
+    }
+
+    protected int normalizeUserSource(int value) {
+        return WiredSourceUtil.isDefaultUserSource(value) ? value : WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        int effectId;
+        int userSource;
+        Integer quantifier;
+
+        public JsonData(int effectId, int userSource, int quantifier) {
+            this.effectId = effectId;
+            this.userSource = userSource;
+            this.quantifier = quantifier;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniInRange.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniInRange.java
@@ -1,0 +1,316 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.Emulator;
+import java.util.HashSet;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomLayout;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Passes when selected furni are within {@code radius} tiles of the trigger furni. Mirror of
+ * {@link WiredConditionFurniNotInRange} with the distance test inverted; reuses the HAS_ALTITUDE dialog
+ * (furni picker + numeric field repurposed as the radius + source + quantifier), so it needs no new
+ * client dialog.
+ */
+public class WiredConditionFurniInRange extends InteractionWiredCondition {
+    private static final int COMPARISON_LESS = 0;
+    private static final int COMPARISON_EQUAL = 1;
+    private static final int COMPARISON_GREATER = 2;
+    private static final int QUANTIFIER_ALL = 0;
+    private static final int QUANTIFIER_ANY = 1;
+
+    public static final WiredConditionType type = WiredConditionType.HAS_ALTITUDE;
+
+    private final HashSet<HabboItem> items;
+    private int comparison = COMPARISON_EQUAL;
+    private double radius = 0.0D;
+    private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int quantifier = QUANTIFIER_ALL;
+
+    public WiredConditionFurniInRange(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+        this.items = new HashSet<>();
+    }
+
+    public WiredConditionFurniInRange(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+        this.items = new HashSet<>();
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return false;
+        }
+
+        this.refresh(room);
+
+        RoomLayout layout = room.getLayout();
+        if (layout == null) {
+            return false;
+        }
+
+        HabboItem triggerItem = ctx.triggerItem();
+        if (triggerItem == null) {
+            return false;
+        }
+
+        RoomTile origin = layout.getTile(triggerItem.getX(), triggerItem.getY());
+        if (origin == null) {
+            return false;
+        }
+
+        List<HabboItem> targets = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
+        if (targets.isEmpty()) {
+            return false;
+        }
+
+        if (this.quantifier == QUANTIFIER_ANY) {
+            return targets.stream().anyMatch(item -> this.isInsideRange(origin, layout, item));
+        }
+
+        return targets.stream().allMatch(item -> this.isInsideRange(origin, layout, item));
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.comparison,
+                this.formatRadius(this.radius),
+                this.furniSource,
+                this.quantifier,
+                this.items.stream().map(HabboItem::getId).toList()
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.items.clear();
+        this.comparison = COMPARISON_EQUAL;
+        this.radius = 0.0D;
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException exception) {
+            this.onPickUp();
+            return;
+        }
+
+        if (data == null) {
+            return;
+        }
+
+        this.comparison = this.normalizeComparison(data.comparison);
+        this.radius = this.parseRadiusOrDefault(data.radius);
+        this.furniSource = this.normalizeFurniSource(data.furniSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+
+        if (data.itemIds == null) {
+            return;
+        }
+
+        for (Integer id : data.itemIds) {
+            if (id == null) {
+                continue;
+            }
+
+            HabboItem item = room.getHabboItem(id);
+            if (item != null) {
+                this.items.add(item);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.items.clear();
+        this.comparison = COMPARISON_EQUAL;
+        this.radius = 0.0D;
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        this.refresh(room);
+
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.items.size());
+
+        for (HabboItem item : this.items) {
+            message.appendInt(item.getId());
+        }
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.formatRadius(this.radius));
+        message.appendInt(3);
+        message.appendInt(this.comparison);
+        message.appendInt(this.furniSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.comparison = (params.length > 0) ? this.normalizeComparison(params[0]) : COMPARISON_EQUAL;
+        this.furniSource = (params.length > 1) ? this.normalizeFurniSource(params[1]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 2) ? this.normalizeQuantifier(params[2]) : QUANTIFIER_ALL;
+        this.radius = this.parseRadiusOrDefault(settings.getStringParam());
+
+        int count = settings.getFurniIds().length;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+            return false;
+        }
+
+        if (count > 0 && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
+            this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+        }
+
+        this.items.clear();
+
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+            if (room == null) {
+                return false;
+            }
+
+            for (int itemId : settings.getFurniIds()) {
+                HabboItem item = room.getHabboItem(itemId);
+                if (item != null) {
+                    this.items.add(item);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isInsideRange(RoomTile origin, RoomLayout layout, HabboItem item) {
+        if (item == null) {
+            return false;
+        }
+
+        RoomTile tile = layout.getTile(item.getX(), item.getY());
+        if (tile == null) {
+            return false;
+        }
+
+        return origin.distance(tile) <= this.radius;
+    }
+
+    private void refresh(Room room) {
+        var remove = new HashSet<HabboItem>();
+
+        for (HabboItem item : this.items) {
+            if (room.getHabboItem(item.getId()) == null) {
+                remove.add(item);
+            }
+        }
+
+        for (HabboItem item : remove) {
+            this.items.remove(item);
+        }
+    }
+
+    int normalizeComparison(int value) {
+        if (value < COMPARISON_LESS || value > COMPARISON_GREATER) {
+            return COMPARISON_EQUAL;
+        }
+
+        return value;
+    }
+
+    int normalizeQuantifier(int value) {
+        return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    int normalizeFurniSource(int value) {
+        return switch (value) {
+            case WiredSourceUtil.SOURCE_SELECTED,
+                 WiredSourceUtil.SOURCE_SELECTOR,
+                 WiredSourceUtil.SOURCE_SIGNAL,
+                 WiredSourceUtil.SOURCE_TRIGGER -> value;
+            default -> WiredSourceUtil.SOURCE_TRIGGER;
+        };
+    }
+
+    double normalizeRadius(double value) {
+        double clampedValue = Math.max(0.0D, value);
+        return BigDecimal.valueOf(clampedValue).setScale(2, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    double parseRadiusOrDefault(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return 0.0D;
+        }
+
+        try {
+            return this.normalizeRadius(new BigDecimal(value.trim()).doubleValue());
+        } catch (NumberFormatException exception) {
+            return 0.0D;
+        }
+    }
+
+    String formatRadius(double value) {
+        BigDecimal decimal = BigDecimal.valueOf(this.normalizeRadius(value)).stripTrailingZeros();
+        return (decimal.scale() < 0 ? decimal.setScale(0, RoundingMode.DOWN) : decimal).toPlainString();
+    }
+
+    static class JsonData {
+        int comparison;
+        String radius;
+        int furniSource;
+        int quantifier;
+        List<Integer> itemIds;
+
+        public JsonData(int comparison, String radius, int furniSource, int quantifier, List<Integer> itemIds) {
+            this.comparison = comparison;
+            this.radius = radius;
+            this.furniSource = furniSource;
+            this.quantifier = quantifier;
+            this.itemIds = itemIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniNotInRange.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniNotInRange.java
@@ -1,0 +1,310 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.Emulator;
+import java.util.HashSet;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomLayout;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class WiredConditionFurniNotInRange extends InteractionWiredCondition {
+    private static final int COMPARISON_LESS = 0;
+    private static final int COMPARISON_EQUAL = 1;
+    private static final int COMPARISON_GREATER = 2;
+    private static final int QUANTIFIER_ALL = 0;
+    private static final int QUANTIFIER_ANY = 1;
+
+    public static final WiredConditionType type = WiredConditionType.HAS_ALTITUDE;
+
+    private final HashSet<HabboItem> items;
+    private int comparison = COMPARISON_EQUAL;
+    private double radius = 0.0D;
+    private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int quantifier = QUANTIFIER_ALL;
+
+    public WiredConditionFurniNotInRange(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+        this.items = new HashSet<>();
+    }
+
+    public WiredConditionFurniNotInRange(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+        this.items = new HashSet<>();
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return false;
+        }
+
+        this.refresh(room);
+
+        RoomLayout layout = room.getLayout();
+        if (layout == null) {
+            return false;
+        }
+
+        HabboItem triggerItem = ctx.triggerItem();
+        if (triggerItem == null) {
+            return true;
+        }
+
+        RoomTile origin = layout.getTile(triggerItem.getX(), triggerItem.getY());
+        if (origin == null) {
+            return true;
+        }
+
+        List<HabboItem> targets = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
+        if (targets.isEmpty()) {
+            return true;
+        }
+
+        if (this.quantifier == QUANTIFIER_ANY) {
+            return targets.stream().anyMatch(item -> this.isOutsideRange(origin, layout, item));
+        }
+
+        return targets.stream().allMatch(item -> this.isOutsideRange(origin, layout, item));
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.comparison,
+                this.formatRadius(this.radius),
+                this.furniSource,
+                this.quantifier,
+                this.items.stream().map(HabboItem::getId).toList()
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.items.clear();
+        this.comparison = COMPARISON_EQUAL;
+        this.radius = 0.0D;
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException exception) {
+            this.onPickUp();
+            return;
+        }
+
+        if (data == null) {
+            return;
+        }
+
+        this.comparison = this.normalizeComparison(data.comparison);
+        this.radius = this.parseRadiusOrDefault(data.radius);
+        this.furniSource = this.normalizeFurniSource(data.furniSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+
+        if (data.itemIds == null) {
+            return;
+        }
+
+        for (Integer id : data.itemIds) {
+            if (id == null) {
+                continue;
+            }
+
+            HabboItem item = room.getHabboItem(id);
+            if (item != null) {
+                this.items.add(item);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.items.clear();
+        this.comparison = COMPARISON_EQUAL;
+        this.radius = 0.0D;
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        this.refresh(room);
+
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.items.size());
+
+        for (HabboItem item : this.items) {
+            message.appendInt(item.getId());
+        }
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.formatRadius(this.radius));
+        message.appendInt(3);
+        message.appendInt(this.comparison);
+        message.appendInt(this.furniSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.comparison = (params.length > 0) ? this.normalizeComparison(params[0]) : COMPARISON_EQUAL;
+        this.furniSource = (params.length > 1) ? this.normalizeFurniSource(params[1]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 2) ? this.normalizeQuantifier(params[2]) : QUANTIFIER_ALL;
+        this.radius = this.parseRadiusOrDefault(settings.getStringParam());
+
+        int count = settings.getFurniIds().length;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+            return false;
+        }
+
+        if (count > 0 && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
+            this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+        }
+
+        this.items.clear();
+
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+            if (room == null) {
+                return false;
+            }
+
+            for (int itemId : settings.getFurniIds()) {
+                HabboItem item = room.getHabboItem(itemId);
+                if (item != null) {
+                    this.items.add(item);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isOutsideRange(RoomTile origin, RoomLayout layout, HabboItem item) {
+        if (item == null) {
+            return true;
+        }
+
+        RoomTile tile = layout.getTile(item.getX(), item.getY());
+        if (tile == null) {
+            return true;
+        }
+
+        return origin.distance(tile) > this.radius;
+    }
+
+    private void refresh(Room room) {
+        var remove = new HashSet<HabboItem>();
+
+        for (HabboItem item : this.items) {
+            if (room.getHabboItem(item.getId()) == null) {
+                remove.add(item);
+            }
+        }
+
+        for (HabboItem item : remove) {
+            this.items.remove(item);
+        }
+    }
+
+    int normalizeComparison(int value) {
+        if (value < COMPARISON_LESS || value > COMPARISON_GREATER) {
+            return COMPARISON_EQUAL;
+        }
+
+        return value;
+    }
+
+    int normalizeQuantifier(int value) {
+        return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    int normalizeFurniSource(int value) {
+        return switch (value) {
+            case WiredSourceUtil.SOURCE_SELECTED,
+                 WiredSourceUtil.SOURCE_SELECTOR,
+                 WiredSourceUtil.SOURCE_SIGNAL,
+                 WiredSourceUtil.SOURCE_TRIGGER -> value;
+            default -> WiredSourceUtil.SOURCE_TRIGGER;
+        };
+    }
+
+    double normalizeRadius(double value) {
+        double clampedValue = Math.max(0.0D, value);
+        return BigDecimal.valueOf(clampedValue).setScale(2, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    double parseRadiusOrDefault(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return 0.0D;
+        }
+
+        try {
+            return this.normalizeRadius(new BigDecimal(value.trim()).doubleValue());
+        } catch (NumberFormatException exception) {
+            return 0.0D;
+        }
+    }
+
+    String formatRadius(double value) {
+        BigDecimal decimal = BigDecimal.valueOf(this.normalizeRadius(value)).stripTrailingZeros();
+        return (decimal.scale() < 0 ? decimal.setScale(0, RoundingMode.DOWN) : decimal).toPlainString();
+    }
+
+    static class JsonData {
+        int comparison;
+        String radius;
+        int furniSource;
+        int quantifier;
+        List<Integer> itemIds;
+
+        public JsonData(int comparison, String radius, int furniSource, int quantifier, List<Integer> itemIds) {
+            this.comparison = comparison;
+            this.radius = radius;
+            this.furniSource = furniSource;
+            this.quantifier = quantifier;
+            this.itemIds = itemIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboLacksCredits.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboLacksCredits.java
@@ -1,0 +1,168 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.games.GameTeamColors;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class WiredConditionHabboLacksCredits extends WiredConditionTeamGameBase {
+    public static final WiredConditionType type = WiredConditionType.TEAM_HAS_SCORE;
+
+    private int teamType = GameTeamColors.RED.type;
+    private int comparison = COMPARISON_EQUAL;
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int quantifier = QUANTIFIER_ANY;
+
+    public WiredConditionHabboLacksCredits(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionHabboLacksCredits(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        List<RoomUnit> users = this.resolveUsers(ctx, this.userSource);
+
+        return this.matchesQuantifier(users, this.quantifier, roomUnit -> this.matchesUser(room, roomUnit));
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.teamType,
+                this.comparison,
+                this.amount,
+                this.userSource,
+                this.quantifier
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.resetSettings();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException ignored) {
+            this.resetSettings();
+            return;
+        }
+        if (data == null) {
+            return;
+        }
+
+        this.teamType = this.normalizeExplicitTeamType(data.teamType);
+        this.comparison = this.normalizeComparison(data.comparison);
+        this.amount = this.normalizeScore(data.score);
+        this.userSource = this.normalizeUserSource(data.userSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.resetSettings();
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(5);
+        message.appendInt(this.teamType);
+        message.appendInt(this.comparison);
+        message.appendInt(this.amount);
+        message.appendInt(this.userSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.resetSettings();
+
+        if (params.length > 0) this.teamType = this.normalizeExplicitTeamType(params[0]);
+        if (params.length > 1) this.comparison = this.normalizeComparison(params[1]);
+        if (params.length > 2) this.amount = this.normalizeScore(params[2]);
+        if (params.length > 3) this.userSource = this.normalizeUserSource(params[3]);
+        if (params.length > 4) this.quantifier = this.normalizeQuantifier(params[4]);
+
+        return true;
+    }
+
+    private boolean matchesUser(Room room, RoomUnit roomUnit) {
+        if (room == null || roomUnit == null) {
+            return false;
+        }
+
+        Habbo habbo = room.getHabbo(roomUnit);
+        if (habbo == null || habbo.getHabboInfo() == null) {
+            return false;
+        }
+
+        return habbo.getHabboInfo().getCredits() < this.amount;
+    }
+
+    private void resetSettings() {
+        this.teamType = GameTeamColors.RED.type;
+        this.comparison = COMPARISON_EQUAL;
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ANY;
+    }
+
+    static class JsonData {
+        int teamType;
+        int comparison;
+        int score;
+        int userSource;
+        int quantifier;
+
+        public JsonData(int teamType, int comparison, int score, int userSource, int quantifier) {
+            this.teamType = teamType;
+            this.comparison = comparison;
+            this.score = score;
+            this.userSource = userSource;
+            this.quantifier = quantifier;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboLacksDiamonds.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboLacksDiamonds.java
@@ -1,0 +1,170 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.games.GameTeamColors;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class WiredConditionHabboLacksDiamonds extends WiredConditionTeamGameBase {
+    public static final WiredConditionType type = WiredConditionType.TEAM_HAS_SCORE;
+
+    private static final int DIAMONDS_CURRENCY_TYPE = 5;
+
+    private int teamType = GameTeamColors.RED.type;
+    private int comparison = COMPARISON_EQUAL;
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int quantifier = QUANTIFIER_ALL;
+
+    public WiredConditionHabboLacksDiamonds(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionHabboLacksDiamonds(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        List<RoomUnit> users = this.resolveUsers(ctx, this.userSource);
+
+        return this.matchesQuantifier(users, this.quantifier, roomUnit -> this.matchesUser(room, roomUnit));
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.teamType,
+                this.comparison,
+                this.amount,
+                this.userSource,
+                this.quantifier
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.resetSettings();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException ignored) {
+            this.resetSettings();
+            return;
+        }
+        if (data == null) {
+            return;
+        }
+
+        this.teamType = this.normalizeExplicitTeamType(data.teamType);
+        this.comparison = this.normalizeComparison(data.comparison);
+        this.amount = this.normalizeScore(data.amount);
+        this.userSource = this.normalizeUserSource(data.userSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.resetSettings();
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(5);
+        message.appendInt(this.teamType);
+        message.appendInt(this.comparison);
+        message.appendInt(this.amount);
+        message.appendInt(this.userSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.resetSettings();
+
+        if (params.length > 0) this.teamType = this.normalizeExplicitTeamType(params[0]);
+        if (params.length > 1) this.comparison = this.normalizeComparison(params[1]);
+        if (params.length > 2) this.amount = this.normalizeScore(params[2]);
+        if (params.length > 3) this.userSource = this.normalizeUserSource(params[3]);
+        if (params.length > 4) this.quantifier = this.normalizeQuantifier(params[4]);
+
+        return true;
+    }
+
+    private boolean matchesUser(Room room, RoomUnit roomUnit) {
+        if (room == null || roomUnit == null) {
+            return false;
+        }
+
+        Habbo habbo = room.getHabbo(roomUnit);
+        if (habbo == null || habbo.getHabboInfo() == null) {
+            return false;
+        }
+
+        return habbo.getHabboInfo().getCurrencyAmount(DIAMONDS_CURRENCY_TYPE) < this.amount;
+    }
+
+    private void resetSettings() {
+        this.teamType = GameTeamColors.RED.type;
+        this.comparison = COMPARISON_EQUAL;
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+    }
+
+    static class JsonData {
+        int teamType;
+        int comparison;
+        int amount;
+        int userSource;
+        int quantifier;
+
+        public JsonData(int teamType, int comparison, int amount, int userSource, int quantifier) {
+            this.teamType = teamType;
+            this.comparison = comparison;
+            this.amount = amount;
+            this.userSource = userSource;
+            this.quantifier = quantifier;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboLacksDuckets.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionHabboLacksDuckets.java
@@ -1,0 +1,172 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.games.GameTeamColors;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class WiredConditionHabboLacksDuckets extends WiredConditionTeamGameBase {
+    public static final WiredConditionType type = WiredConditionType.TEAM_HAS_SCORE;
+
+    private static final int DUCKETS_CURRENCY = 0;
+
+    private int teamType = GameTeamColors.RED.type;
+    private int comparison = COMPARISON_EQUAL;
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int quantifier = QUANTIFIER_ALL;
+
+    public WiredConditionHabboLacksDuckets(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionHabboLacksDuckets(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        List<RoomUnit> users = this.resolveUsers(ctx, this.userSource);
+
+        return this.matchesQuantifier(users, this.quantifier, roomUnit -> this.matchesUser(room, roomUnit));
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.teamType,
+                this.comparison,
+                this.amount,
+                this.userSource,
+                this.quantifier
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.resetSettings();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException ignored) {
+            this.resetSettings();
+            return;
+        }
+        if (data == null) {
+            return;
+        }
+
+        this.teamType = this.normalizeExplicitTeamType(data.teamType);
+        this.comparison = this.normalizeComparison(data.comparison);
+        this.amount = this.normalizeScore(data.score);
+        this.userSource = this.normalizeUserSource(data.userSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.resetSettings();
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(5);
+        message.appendInt(this.teamType);
+        message.appendInt(this.comparison);
+        message.appendInt(this.amount);
+        message.appendInt(this.userSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.resetSettings();
+
+        if (params.length > 0) this.teamType = this.normalizeExplicitTeamType(params[0]);
+        if (params.length > 1) this.comparison = this.normalizeComparison(params[1]);
+        if (params.length > 2) this.amount = this.normalizeScore(params[2]);
+        if (params.length > 3) this.userSource = this.normalizeUserSource(params[3]);
+        if (params.length > 4) this.quantifier = this.normalizeQuantifier(params[4]);
+
+        return true;
+    }
+
+    private boolean matchesUser(Room room, RoomUnit roomUnit) {
+        if (room == null || roomUnit == null) {
+            return false;
+        }
+
+        Habbo habbo = room.getHabbo(roomUnit);
+        if (habbo == null || habbo.getHabboInfo() == null) {
+            return false;
+        }
+
+        int value = habbo.getHabboInfo().getCurrencyAmount(DUCKETS_CURRENCY);
+
+        return value < this.amount;
+    }
+
+    private void resetSettings() {
+        this.teamType = GameTeamColors.RED.type;
+        this.comparison = COMPARISON_EQUAL;
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+    }
+
+    static class JsonData {
+        int teamType;
+        int comparison;
+        int score;
+        int userSource;
+        int quantifier;
+
+        public JsonData(int teamType, int comparison, int score, int userSource, int quantifier) {
+            this.teamType = teamType;
+            this.comparison = comparison;
+            this.score = score;
+            this.userSource = userSource;
+            this.quantifier = quantifier;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFrozen.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotFrozen.java
@@ -1,0 +1,46 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredFreezeUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class WiredConditionNotFrozen extends WiredConditionHabboHasEffect {
+    private static final WiredConditionType type = WiredConditionType.NOT_ACTOR_WEARS_EFFECT;
+
+    public WiredConditionNotFrozen(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionNotFrozen(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        List<RoomUnit> targets = WiredSourceUtil.resolveUsers(ctx, this.userSource);
+        if (targets.isEmpty()) return false;
+
+        if (this.getQuantifier() == QUANTIFIER_ALL) {
+            return !this.matchesAllTargets(targets);
+        }
+
+        return !this.matchesAnyTarget(targets);
+    }
+
+    @Override
+    protected boolean matchesEffect(RoomUnit roomUnit) {
+        return WiredFreezeUtil.isFrozen(roomUnit);
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotSameHeight.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotSameHeight.java
@@ -1,0 +1,244 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.Emulator;
+import java.util.HashSet;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Negation of {@link WiredConditionSameHeight}: passes when the selected furni do NOT all share the same
+ * stack height (Z) — i.e. at least one differs. Same furni-picker resolution (via {@code this.items}) and
+ * dialog reuse; needs at least 2 furni to be meaningful.
+ */
+public class WiredConditionNotSameHeight extends InteractionWiredCondition {
+    private static final int QUANTIFIER_ALL = 0;
+    private static final int QUANTIFIER_ANY = 1;
+
+    public static final WiredConditionType type = WiredConditionType.HAS_ALTITUDE;
+
+    private final HashSet<HabboItem> items;
+    private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int quantifier = QUANTIFIER_ALL;
+
+    public WiredConditionNotSameHeight(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+        this.items = new HashSet<>();
+    }
+
+    public WiredConditionNotSameHeight(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+        this.items = new HashSet<>();
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return false;
+        }
+
+        this.refresh(room);
+
+        List<HabboItem> targets = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
+        if (targets.size() < 2) {
+            return false;
+        }
+
+        BigDecimal reference = null;
+        for (HabboItem item : targets) {
+            if (item == null) {
+                continue;
+            }
+
+            BigDecimal z = BigDecimal.valueOf(item.getZ());
+            if (reference == null) {
+                reference = z;
+            } else if (reference.compareTo(z) != 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.furniSource,
+                this.quantifier,
+                this.items.stream().map(HabboItem::getId).toList()
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.items.clear();
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException exception) {
+            this.onPickUp();
+            return;
+        }
+
+        if (data == null) {
+            return;
+        }
+
+        this.furniSource = this.normalizeFurniSource(data.furniSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+
+        if (data.itemIds == null) {
+            return;
+        }
+
+        for (Integer id : data.itemIds) {
+            if (id == null) {
+                continue;
+            }
+
+            HabboItem item = room.getHabboItem(id);
+            if (item != null) {
+                this.items.add(item);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.items.clear();
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        this.refresh(room);
+
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.items.size());
+
+        for (HabboItem item : this.items) {
+            message.appendInt(item.getId());
+        }
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.furniSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.furniSource = (params.length > 0) ? this.normalizeFurniSource(params[0]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 1) ? this.normalizeQuantifier(params[1]) : QUANTIFIER_ALL;
+
+        int count = settings.getFurniIds().length;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+            return false;
+        }
+
+        if (count > 0 && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
+            this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+        }
+
+        this.items.clear();
+
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+            if (room == null) {
+                return false;
+            }
+
+            for (int itemId : settings.getFurniIds()) {
+                HabboItem item = room.getHabboItem(itemId);
+                if (item != null) {
+                    this.items.add(item);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private void refresh(Room room) {
+        var remove = new HashSet<HabboItem>();
+
+        for (HabboItem item : this.items) {
+            if (room.getHabboItem(item.getId()) == null) {
+                remove.add(item);
+            }
+        }
+
+        for (HabboItem item : remove) {
+            this.items.remove(item);
+        }
+    }
+
+    int normalizeQuantifier(int value) {
+        return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    int normalizeFurniSource(int value) {
+        return switch (value) {
+            case WiredSourceUtil.SOURCE_SELECTED,
+                 WiredSourceUtil.SOURCE_SELECTOR,
+                 WiredSourceUtil.SOURCE_SIGNAL,
+                 WiredSourceUtil.SOURCE_TRIGGER -> value;
+            default -> WiredSourceUtil.SOURCE_TRIGGER;
+        };
+    }
+
+    static class JsonData {
+        int furniSource;
+        int quantifier;
+        List<Integer> itemIds;
+
+        public JsonData(int furniSource, int quantifier, List<Integer> itemIds) {
+            this.furniSource = furniSource;
+            this.quantifier = quantifier;
+            this.itemIds = itemIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionSameHeight.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionSameHeight.java
@@ -1,0 +1,242 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.Emulator;
+import java.util.HashSet;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Passes when ALL selected furni share the same stack height (Z). Reuses the HAS_ALTITUDE furni-picker
+ * dialog (the numeric field is unused here, kept only for dialog/serialization compatibility), and
+ * resolves the selected furni exactly like {@link WiredConditionFurniInRange} (via {@code this.items}),
+ * so it has no new client requirement. Z equality uses {@link BigDecimal#compareTo} for exactness.
+ */
+public class WiredConditionSameHeight extends InteractionWiredCondition {
+    private static final int QUANTIFIER_ALL = 0;
+    private static final int QUANTIFIER_ANY = 1;
+
+    public static final WiredConditionType type = WiredConditionType.HAS_ALTITUDE;
+
+    private final HashSet<HabboItem> items;
+    private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int quantifier = QUANTIFIER_ALL;
+
+    public WiredConditionSameHeight(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+        this.items = new HashSet<>();
+    }
+
+    public WiredConditionSameHeight(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+        this.items = new HashSet<>();
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) {
+            return false;
+        }
+
+        this.refresh(room);
+
+        List<HabboItem> targets = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
+        if (targets.isEmpty()) {
+            return false;
+        }
+
+        BigDecimal reference = null;
+        for (HabboItem item : targets) {
+            if (item == null) {
+                return false;
+            }
+
+            BigDecimal z = BigDecimal.valueOf(item.getZ());
+            if (reference == null) {
+                reference = z;
+            } else if (reference.compareTo(z) != 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+                this.furniSource,
+                this.quantifier,
+                this.items.stream().map(HabboItem::getId).toList()
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.items.clear();
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) {
+            return;
+        }
+
+        JsonData data;
+        try {
+            data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (RuntimeException exception) {
+            this.onPickUp();
+            return;
+        }
+
+        if (data == null) {
+            return;
+        }
+
+        this.furniSource = this.normalizeFurniSource(data.furniSource);
+        this.quantifier = this.normalizeQuantifier(data.quantifier);
+
+        if (data.itemIds == null) {
+            return;
+        }
+
+        for (Integer id : data.itemIds) {
+            if (id == null) {
+                continue;
+            }
+
+            HabboItem item = room.getHabboItem(id);
+            if (item != null) {
+                this.items.add(item);
+            }
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.items.clear();
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = QUANTIFIER_ALL;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        this.refresh(room);
+
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.items.size());
+
+        for (HabboItem item : this.items) {
+            message.appendInt(item.getId());
+        }
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.furniSource);
+        message.appendInt(this.quantifier);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.furniSource = (params.length > 0) ? this.normalizeFurniSource(params[0]) : WiredSourceUtil.SOURCE_TRIGGER;
+        this.quantifier = (params.length > 1) ? this.normalizeQuantifier(params[1]) : QUANTIFIER_ALL;
+
+        int count = settings.getFurniIds().length;
+        if (count > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+            return false;
+        }
+
+        if (count > 0 && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
+            this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+        }
+
+        this.items.clear();
+
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+            if (room == null) {
+                return false;
+            }
+
+            for (int itemId : settings.getFurniIds()) {
+                HabboItem item = room.getHabboItem(itemId);
+                if (item != null) {
+                    this.items.add(item);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private void refresh(Room room) {
+        var remove = new HashSet<HabboItem>();
+
+        for (HabboItem item : this.items) {
+            if (room.getHabboItem(item.getId()) == null) {
+                remove.add(item);
+            }
+        }
+
+        for (HabboItem item : remove) {
+            this.items.remove(item);
+        }
+    }
+
+    int normalizeQuantifier(int value) {
+        return (value == QUANTIFIER_ANY) ? QUANTIFIER_ANY : QUANTIFIER_ALL;
+    }
+
+    int normalizeFurniSource(int value) {
+        return switch (value) {
+            case WiredSourceUtil.SOURCE_SELECTED, WiredSourceUtil.SOURCE_SELECTOR, WiredSourceUtil.SOURCE_SIGNAL, WiredSourceUtil.SOURCE_TRIGGER -> value;
+            default -> WiredSourceUtil.SOURCE_TRIGGER;
+        };
+    }
+
+    static class JsonData {
+        int furniSource;
+        int quantifier;
+        List<Integer> itemIds;
+
+        public JsonData(int furniSource, int quantifier, List<Integer> itemIds) {
+            this.furniSource = furniSource;
+            this.quantifier = quantifier;
+            this.itemIds = itemIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectAllUsersLeaveTeam.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectAllUsersLeaveTeam.java
@@ -1,0 +1,141 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.games.Game;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectAllUsersLeaveTeam extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.LEAVE_TEAM;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectAllUsersLeaveTeam(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectAllUsersLeaveTeam(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        for (Habbo h : new java.util.ArrayList<>(ctx.room().getCurrentHabbos().values())) {
+            Class<? extends com.eu.habbo.habbohotel.games.Game> g = h.getHabboInfo().getCurrentGame();
+            if (g == null) continue;
+            com.eu.habbo.habbohotel.games.Game game = ctx.room().getGame(g);
+            if (game != null) game.removeHabbo(h);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(com.eu.habbo.habbohotel.rooms.RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        }
+        else {
+            this.setDelay(Integer.parseInt(wiredData));
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.setDelay(0);
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        int delay = settings.getDelay();
+
+        if(delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20))
+            throw new WiredSaveException("Delay too long");
+
+        this.setDelay(delay);
+        return true;
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        int delay;
+        int userSource;
+
+        public JsonData(int delay, int userSource) {
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveAchievement.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveAchievement.java
@@ -1,0 +1,165 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectGiveAchievement extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private String achievement = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveAchievement(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveAchievement(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.achievement);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String nextAchievement = settings.getStringParam();
+        if (nextAchievement != null) {
+            nextAchievement = nextAchievement.trim();
+        }
+        if (nextAchievement == null || nextAchievement.isEmpty()) {
+            return false;
+        }
+        this.achievement = nextAchievement;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        com.eu.habbo.habbohotel.achievements.Achievement ach = Emulator.getGameEnvironment().getAchievementManager().getAchievement(this.achievement);
+        if (ach == null) return;
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            com.eu.habbo.habbohotel.achievements.AchievementManager.progressAchievement(habbo, ach);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.achievement, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.achievement = data.achievement != null ? data.achievement : "";
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        }
+        else {
+            String[] data = wiredData.split("\t");
+            this.achievement = "";
+
+            if (data.length >= 2) {
+                super.setDelay(Integer.parseInt(data[0]));
+
+                this.achievement = data[1];
+            }
+
+            this.needsUpdate(true);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.achievement = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String achievement;
+        int delay;
+        int userSource;
+
+        public JsonData(String achievement, int delay, int userSource) {
+            this.achievement = achievement;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveBadge.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveBadge.java
@@ -1,0 +1,169 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboBadge;
+import com.eu.habbo.habbohotel.users.inventory.BadgesComponent;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectGiveBadge extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private String badge = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveBadge(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveBadge(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.badge);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String nextBadge = settings.getStringParam() != null ? settings.getStringParam().trim() : "";
+        if (nextBadge.isEmpty()) {
+            return false;
+        }
+        this.badge = nextBadge;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            if (habbo.getInventory().getBadgesComponent().hasBadge(this.badge)) continue;
+
+            HabboBadge b = BadgesComponent.createBadge(this.badge, habbo);
+            if (b != null && habbo.getClient() != null) {
+                habbo.getClient().sendResponse(new AddUserBadgeComposer(b));
+            }
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.badge, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.badge = data.badge;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        }
+        else {
+            String[] data = wiredData.split("\t");
+            this.badge = "";
+
+            if (data.length >= 2) {
+                super.setDelay(Integer.parseInt(data[0]));
+
+                try {
+                    this.badge = data[1];
+                } catch (Exception e) {
+                }
+            }
+
+            this.needsUpdate(true);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.badge = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String badge;
+        int delay;
+        int userSource;
+
+        public JsonData(String badge, int delay, int userSource) {
+            this.badge = badge;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveCredits.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveCredits.java
@@ -1,0 +1,156 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Gives credits to the resolved users. Server-only effect; it reuses the
+ * {@link WiredEffectType#SHOW_MESSAGE} client dialog (a single text field = the amount + a user-source
+ * selector), exactly like {@link WiredEffectGiveRespect}, so it needs no new client dialog. The amount is
+ * capped by {@link WiredNumericInputGuard#maxRewardAmount()} per execution to bound abuse.
+ */
+public class WiredEffectGiveCredits extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveCredits(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveCredits(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.amount + "");
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int nextAmount = WiredNumericInputGuard.parsePositiveAmount(settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
+        if (nextAmount <= 0) {
+            return false;
+        }
+        this.amount = nextAmount;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            habbo.giveCredits(this.amount);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.amount, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.amount = data.amount;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.amount = 0;
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        int amount;
+        int delay;
+        int userSource;
+
+        public JsonData(int amount, int delay, int userSource) {
+            this.amount = amount;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDiamonds.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDiamonds.java
@@ -1,0 +1,158 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Gives diamonds to the resolved users. Diamonds are points currency type
+ * {@code seasonal.currency.diamond} (default 5), the same channel {@code WiredEffectGiveReward} uses.
+ * Reuses the {@link WiredEffectType#SHOW_MESSAGE} client dialog (amount text field + user-source
+ * selector) like {@link WiredEffectGiveRespect}, so it needs no new client dialog. Amount capped.
+ */
+public class WiredEffectGiveDiamonds extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveDiamonds(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveDiamonds(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.amount + "");
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int nextAmount = WiredNumericInputGuard.parsePositiveAmount(settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
+        if (nextAmount <= 0) {
+            return false;
+        }
+        this.amount = nextAmount;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        int diamondType = Emulator.getConfig().getInt("seasonal.currency.diamond", 5);
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            habbo.givePoints(diamondType, this.amount);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.amount, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.amount = data.amount;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.amount = 0;
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        int amount;
+        int delay;
+        int userSource;
+
+        public JsonData(int amount, int delay, int userSource) {
+            this.amount = amount;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDuckets.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDuckets.java
@@ -1,0 +1,155 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Gives duckets (pixels / currency type 0) to the resolved users. Reuses the
+ * {@link WiredEffectType#SHOW_MESSAGE} client dialog (amount text field + user-source selector), like
+ * {@link WiredEffectGiveRespect}, so it needs no new client dialog. Amount capped per execution.
+ */
+public class WiredEffectGiveDuckets extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveDuckets(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveDuckets(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.amount + "");
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int nextAmount = WiredNumericInputGuard.parsePositiveAmount(settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
+        if (nextAmount <= 0) {
+            return false;
+        }
+        this.amount = nextAmount;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            habbo.givePixels(this.amount);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.amount, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.amount = data.amount;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.amount = 0;
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        int amount;
+        int delay;
+        int userSource;
+
+        public JsonData(int amount, int delay, int userSource) {
+            this.amount = amount;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveExperience.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveExperience.java
@@ -1,0 +1,156 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Gives achievement score (experience) to the resolved users. Server-only effect; it reuses the
+ * {@link WiredEffectType#SHOW_MESSAGE} client dialog (a single text field = the amount + a user-source
+ * selector), exactly like {@link WiredEffectGiveCredits}, so it needs no new client dialog. The amount is
+ * capped by {@link WiredNumericInputGuard#maxRewardAmount()} per execution to bound abuse.
+ */
+public class WiredEffectGiveExperience extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveExperience(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveExperience(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.amount + "");
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int nextAmount = WiredNumericInputGuard.parsePositiveAmount(settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
+        if (nextAmount <= 0) {
+            return false;
+        }
+        this.amount = nextAmount;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            habbo.getHabboStats().addAchievementScore(this.amount);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.amount, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.amount = data.amount;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.amount = 0;
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        int amount;
+        int delay;
+        int userSource;
+
+        public JsonData(int amount, int delay, int userSource) {
+            this.amount = amount;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLay.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLay.java
@@ -1,0 +1,202 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.rooms.RoomUnitStatus;
+import com.eu.habbo.habbohotel.rooms.RoomUserRotation;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredTextPlaceholderUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectLay extends InteractionWiredEffect {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WiredEffectLay.class);
+    public static final WiredEffectType type = WiredEffectType.KICK_USER;
+
+    private String message = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectLay(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectLay(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null || !unit.canForcePosture()) {
+                continue;
+            }
+
+            // Replicates LayCommand: lay, snap body rotation to a cardinal direction, and only lay
+            // when the 3 tiles in front are walkable (so the user doesn't lay into a wall).
+            unit.cmdLay = true;
+            room.updateHabbo(habbo);
+            unit.cmdSit = true;
+            unit.setBodyRotation(RoomUserRotation.values()[unit.getBodyRotation().getValue() - unit.getBodyRotation().getValue() % 2]);
+
+            RoomTile tile = unit.getCurrentLocation();
+            if (tile == null) {
+                continue;
+            }
+
+            boolean blocked = false;
+            for (int i = 0; i < 3; i++) {
+                RoomTile front = room.getLayout().getTileInFront(tile, unit.getBodyRotation().getValue(), i);
+                if (front == null || !front.isWalkable()) {
+                    blocked = true;
+                    break;
+                }
+            }
+            if (blocked) {
+                continue;
+            }
+
+            unit.setStatus(RoomUnitStatus.LAY, 0.5 + "");
+            room.sendComposer(new RoomUserStatusComposer(unit).compose());
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.message, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.setDelay(data.delay);
+            this.message = data.message;
+            this.userSource = data.userSource;
+        }
+        else {
+            try {
+                String[] data = set.getString("wired_data").split("\t");
+
+                if (data.length >= 1) {
+                    this.setDelay(Integer.parseInt(data[0]));
+
+                    if (data.length >= 2) {
+                        this.message = data[1];
+                    }
+                }
+            } catch (Exception e) {
+                this.message = "";
+                this.setDelay(0);
+            }
+
+            this.needsUpdate(true);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.message = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.message);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        String message = settings.getStringParam();
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+        int delay = settings.getDelay();
+
+        if(delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20))
+            throw new WiredSaveException("Delay too long");
+
+        this.message = message.substring(0, Math.min(message.length(), Emulator.getConfig().getInt("hotel.wired.message.max_length", 100)));
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER || WiredTextPlaceholderUtil.requiresActor(this.getRoom(), this);
+    }
+
+    static class JsonData {
+        String message;
+        int delay;
+        int userSource;
+
+        public JsonData(String message, int delay, int userSource) {
+            this.message = message;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMakeFastWalk.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMakeFastWalk.java
@@ -1,0 +1,165 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredTextPlaceholderUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectMakeFastWalk extends InteractionWiredEffect {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WiredEffectMakeFastWalk.class);
+    public static final WiredEffectType type = WiredEffectType.KICK_USER;
+
+    private String message = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectMakeFastWalk(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectMakeFastWalk(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            unit.setFastWalk(true);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.message, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.setDelay(data.delay);
+            this.message = data.message;
+            this.userSource = data.userSource;
+        }
+        else {
+            try {
+                String[] data = set.getString("wired_data").split("\t");
+
+                if (data.length >= 1) {
+                    this.setDelay(Integer.parseInt(data[0]));
+
+                    if (data.length >= 2) {
+                        this.message = data[1];
+                    }
+                }
+            } catch (Exception e) {
+                this.message = "";
+                this.setDelay(0);
+            }
+
+            this.needsUpdate(true);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.message = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.message);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        String message = settings.getStringParam();
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+        int delay = settings.getDelay();
+
+        if(delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20))
+            throw new WiredSaveException("Delay too long");
+
+        this.message = message.substring(0, Math.min(message.length(), Emulator.getConfig().getInt("hotel.wired.message.max_length", 100)));
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER || WiredTextPlaceholderUtil.requiresActor(this.getRoom(), this);
+    }
+
+    static class JsonData {
+        String message;
+        int delay;
+        int userSource;
+
+        public JsonData(String message, int delay, int userSource) {
+            this.message = message;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMakeUserSay.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMakeUserSay.java
@@ -1,0 +1,259 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.rooms.*;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredTextPlaceholderUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectMakeUserSay extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+    protected static final int VISIBILITY_SOURCE_USERS = 0;
+    protected static final int VISIBILITY_ALL_ROOM_USERS = 1;
+    private static final int DEFAULT_SHOW_MESSAGE_MAX_LENGTH = 200;
+    private static final int DEFAULT_SHOW_MESSAGE_MAX_LINES = 8;
+
+    protected String message = "";
+    protected int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    protected int visibilitySelection = VISIBILITY_SOURCE_USERS;
+    protected int bubbleStyle = RoomChatMessageBubbles.WIRED.getType();
+
+    public WiredEffectMakeUserSay(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectMakeUserSay(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.message);
+        message.appendInt(3);
+        message.appendInt(this.userSource);
+        message.appendInt(this.visibilitySelection);
+        message.appendInt(this.bubbleStyle);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        String message = settings.getStringParam();
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+        this.visibilitySelection = (params.length > 1 && params[1] == VISIBILITY_ALL_ROOM_USERS)
+                ? VISIBILITY_ALL_ROOM_USERS
+                : VISIBILITY_SOURCE_USERS;
+        this.bubbleStyle = (params.length > 2) ? params[2] : RoomChatMessageBubbles.WIRED.getType();
+
+        if(gameClient.getHabbo() == null || !gameClient.getHabbo().hasPermission(Permission.ACC_SUPERWIRED)) {
+            message = Emulator.getGameEnvironment().getWordFilter().filter(message, null);
+        }
+
+        int maxLength = Emulator.getConfig().getInt("hotel.wired.show_message.max_length", DEFAULT_SHOW_MESSAGE_MAX_LENGTH);
+        int maxLines = Emulator.getConfig().getInt("hotel.wired.show_message.max_lines", DEFAULT_SHOW_MESSAGE_MAX_LINES);
+        message = clampMessage(message, maxLength, maxLines);
+
+        int delay = settings.getDelay();
+
+        if(delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20))
+            throw new WiredSaveException("Delay too long");
+
+        this.message = message;
+        this.setDelay(delay);
+        return true;
+    }
+
+    private static String clampMessage(String value, int maxLength, int maxLines) {
+        if (value == null || value.isEmpty()) {
+            return "";
+        }
+
+        int safeMaxLength = Math.max(1, maxLength);
+        int safeMaxLines = Math.max(1, maxLines);
+
+        String normalized = value.replace("\r\n", "\n").replace('\r', '\n');
+        String[] lines = normalized.split("\n", -1);
+
+        var builder = new StringBuilder();
+        int linesToWrite = Math.min(lines.length, safeMaxLines);
+
+        for (int index = 0; index < linesToWrite; index++) {
+            if (builder.length() > 0) {
+                builder.append('\n');
+            }
+
+            builder.append(lines[index]);
+        }
+
+        if (builder.length() > safeMaxLength) {
+            builder.setLength(safeMaxLength);
+        }
+
+        return builder.toString();
+    }
+
+    protected List<RoomUnit> resolveUsers(WiredContext ctx) {
+        return WiredSourceUtil.resolveUsers(ctx, this.userSource);
+    }
+
+    protected String buildMessage(WiredContext ctx, Habbo referenceHabbo) {
+        String username = "";
+
+        if (referenceHabbo != null && referenceHabbo.getHabboInfo() != null) {
+            username = referenceHabbo.getHabboInfo().getUsername();
+        }
+
+        String msg = this.message
+                .replace("%user%", username)
+                .replace("%online_count%", Emulator.getGameEnvironment().getHabboManager().getOnlineCount() + "")
+                .replace("%room_count%", Emulator.getGameEnvironment().getRoomManager().getActiveRooms().size() + "");
+
+        return WiredTextPlaceholderUtil.applyUsernamePlaceholders(ctx, msg);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        if (this.message.length() > 0) {
+            Room room = ctx.room();
+            if (room == null) {
+                return;
+            }
+
+            List<RoomUnit> sourceUsers = resolveUsers(ctx);
+
+            for (RoomUnit unit : sourceUsers) {
+                Habbo h = room.getHabbo(unit);
+                if (h == null) {
+                    continue;
+                }
+
+                String msg = buildMessage(ctx, h);
+                room.talk(
+                        h,
+                        new RoomChatMessage(msg, unit, RoomChatMessageBubbles.getBubble(this.bubbleStyle)),
+                        RoomChatType.TALK,
+                        true
+                );
+
+                if (h.getRoomUnit().isIdle()) {
+                    h.getRoomUnit().getRoom().unIdle(h);
+                }
+            }
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.message, this.getDelay(), this.userSource, this.visibilitySelection, this.bubbleStyle));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        JsonData jsonData = WiredUtilityPayloadGuard.fromJson(wiredData, JsonData.class);
+        if(jsonData != null) {
+            this.setDelay(WiredUtilityPayloadGuard.delay(jsonData.delay));
+            this.message = WiredUtilityPayloadGuard.text(jsonData.message);
+            this.userSource = (jsonData.userSource != null) ? WiredUtilityPayloadGuard.userSource(jsonData.userSource) : WiredSourceUtil.SOURCE_TRIGGER;
+            this.visibilitySelection = (jsonData.visibilitySelection != null && jsonData.visibilitySelection == VISIBILITY_ALL_ROOM_USERS)
+                    ? VISIBILITY_ALL_ROOM_USERS
+                    : VISIBILITY_SOURCE_USERS;
+            this.bubbleStyle = (jsonData.bubbleStyle != null) ? jsonData.bubbleStyle : RoomChatMessageBubbles.WIRED.getType();
+        }
+        else {
+            this.message = "";
+
+            String[] wiredDataSplit = wiredData != null ? wiredData.split("\t") : new String[0];
+            if (wiredDataSplit.length >= 2) {
+                super.setDelay(WiredUtilityPayloadGuard.parseDelay(wiredDataSplit[0]));
+                this.message = wiredDataSplit[1];
+            }
+
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.visibilitySelection = VISIBILITY_SOURCE_USERS;
+            this.bubbleStyle = RoomChatMessageBubbles.WIRED.getType();
+            this.needsUpdate(true);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.message = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.visibilitySelection = VISIBILITY_SOURCE_USERS;
+        this.bubbleStyle = RoomChatMessageBubbles.WIRED.getType();
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return (this.userSource == WiredSourceUtil.SOURCE_TRIGGER) || WiredTextPlaceholderUtil.requiresActor(this.getRoom(), this);
+    }
+
+    static class JsonData {
+        String message;
+        int delay;
+        Integer userSource;
+        Integer visibilitySelection;
+        Integer bubbleStyle;
+
+        public JsonData(String message, int delay, int userSource, int visibilitySelection, int bubbleStyle) {
+            this.message = message;
+            this.delay = delay;
+            this.userSource = userSource;
+            this.visibilitySelection = visibilitySelection;
+            this.bubbleStyle = bubbleStyle;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveUserTiles.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMoveUserTiles.java
@@ -1,0 +1,306 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomTileState;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.rooms.RoomUserRotation;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredMovementPhysics;
+import com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredUserMovementHelper;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectMoveUserTiles extends InteractionWiredEffect {
+    private static final int ROTATION_CLOCKWISE = 8;
+    private static final int ROTATION_COUNTER_CLOCKWISE = 9;
+    private static final int MIN_TILE_COUNT = 1;
+    private static final int MAX_TILE_COUNT = 10;
+
+    public static final WiredEffectType type = WiredEffectType.MOVE_ROTATE_USER;
+
+    private int movementDirection = -1;
+    private int rotationDirection = -1;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int tileCount = MIN_TILE_COUNT;
+
+    public WiredEffectMoveUserTiles(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectMoveUserTiles(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        WiredMovementPhysics movementPhysics = WiredMoveCarryHelper.getUserMovementPhysics(room, this, ctx);
+
+        for (RoomUnit roomUnit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            if (roomUnit == null || roomUnit.getRoom() != room) {
+                continue;
+            }
+
+            boolean hasRotation = this.rotationDirection >= 0;
+            RoomUserRotation targetBodyRotation = hasRotation ? this.getTargetRotation(roomUnit) : roomUnit.getBodyRotation();
+            RoomUserRotation targetHeadRotation = hasRotation ? targetBodyRotation : roomUnit.getHeadRotation();
+
+            if (roomUnit.isWalking()) {
+                if (hasRotation) {
+                    WiredUserMovementHelper.updateUserDirection(room, roomUnit, targetBodyRotation, targetHeadRotation);
+                }
+                continue;
+            }
+
+            boolean noAnimation = WiredMoveCarryHelper.hasNoAnimationExtra(room, this);
+            int animationDuration = noAnimation ? 0 : WiredMoveCarryHelper.getAnimationDuration(room, this, WiredUserMovementHelper.DEFAULT_ANIMATION_DURATION);
+
+            boolean movedAny = false;
+
+            for (int i = 0; i < this.tileCount; i++) {
+                RoomTile targetTile = (this.movementDirection >= 0) ? this.getTargetTile(room, roomUnit, this.movementDirection) : null;
+                boolean canMove = this.canMoveTo(room, roomUnit, targetTile, movementPhysics);
+
+                if (!canMove) {
+                    break;
+                }
+
+                double targetZ = targetTile.getStackHeight() + ((targetTile.state == RoomTileState.SIT) ? -0.5 : 0);
+                if (!WiredUserMovementHelper.moveUser(room, roomUnit, targetTile, targetZ, targetBodyRotation, targetHeadRotation,
+                        animationDuration, noAnimation, movementPhysics)) {
+                    break;
+                }
+
+                movedAny = true;
+            }
+
+            if (!movedAny && hasRotation) {
+                WiredUserMovementHelper.updateUserDirection(room, roomUnit, targetBodyRotation, targetHeadRotation);
+            }
+        }
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+            this.getDelay(),
+            this.movementDirection,
+            this.rotationDirection,
+            this.userSource,
+            this.tileCount
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.setDelay(data.delay);
+            this.movementDirection = this.normalizeDirection(data.movementDirection);
+            this.rotationDirection = this.normalizeRotation(data.rotationDirection);
+            this.userSource = data.userSource;
+            this.tileCount = this.normalizeTileCount(data.tileCount);
+            return;
+        }
+
+        this.setDelay(0);
+        this.movementDirection = -1;
+        this.rotationDirection = -1;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.tileCount = MIN_TILE_COUNT;
+    }
+
+    @Override
+    public void onPickUp() {
+        this.setDelay(0);
+        this.movementDirection = -1;
+        this.rotationDirection = -1;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.tileCount = MIN_TILE_COUNT;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(3);
+        message.appendInt(this.movementDirection);
+        message.appendInt(this.rotationDirection);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        if (settings.getIntParams().length < 3) {
+            throw new WiredSaveException("Invalid data");
+        }
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.movementDirection = this.normalizeDirection(settings.getIntParams()[0]);
+        this.rotationDirection = this.normalizeRotation(settings.getIntParams()[1]);
+        this.userSource = settings.getIntParams()[2];
+        this.tileCount = (settings.getIntParams().length > 3) ? this.normalizeTileCount(settings.getIntParams()[3]) : MIN_TILE_COUNT;
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    @Override
+    protected long requiredCooldown() {
+        return COOLDOWN_MOVEMENT;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    private int normalizeDirection(int direction) {
+        return (direction >= 0 && direction <= 7) ? direction : -1;
+    }
+
+    private int normalizeRotation(int rotation) {
+        return ((rotation >= 0 && rotation <= 7) || rotation == ROTATION_CLOCKWISE || rotation == ROTATION_COUNTER_CLOCKWISE) ? rotation : -1;
+    }
+
+    private int normalizeTileCount(int count) {
+        if (count < MIN_TILE_COUNT) {
+            return MIN_TILE_COUNT;
+        }
+
+        if (count > MAX_TILE_COUNT) {
+            return MAX_TILE_COUNT;
+        }
+
+        return count;
+    }
+
+    private RoomUserRotation getTargetRotation(RoomUnit roomUnit) {
+        RoomUserRotation currentRotation = (roomUnit != null && roomUnit.getBodyRotation() != null) ? roomUnit.getBodyRotation() : RoomUserRotation.NORTH;
+
+        if (this.rotationDirection == ROTATION_CLOCKWISE) {
+            return RoomUserRotation.clockwise(currentRotation);
+        }
+
+        if (this.rotationDirection == ROTATION_COUNTER_CLOCKWISE) {
+            return RoomUserRotation.counterClockwise(currentRotation);
+        }
+
+        return RoomUserRotation.fromValue(this.rotationDirection);
+    }
+
+    private RoomTile getTargetTile(Room room, RoomUnit roomUnit, int direction) {
+        RoomTile currentTile = roomUnit.getCurrentLocation();
+
+        if (currentTile == null) {
+            return null;
+        }
+
+        int deltaX = 0;
+        int deltaY = 0;
+
+        switch (RoomUserRotation.fromValue(direction)) {
+            case NORTH -> deltaY = 1;
+            case NORTH_EAST -> {
+                deltaX = 1;
+                deltaY = 1;
+            }
+            case EAST -> deltaX = 1;
+            case SOUTH_EAST -> {
+                deltaX = 1;
+                deltaY = -1;
+            }
+            case SOUTH -> deltaY = -1;
+            case SOUTH_WEST -> {
+                deltaX = -1;
+                deltaY = -1;
+            }
+            case WEST -> deltaX = -1;
+            case NORTH_WEST -> {
+                deltaX = -1;
+                deltaY = 1;
+            }
+        }
+
+        return room.getLayout().getTile((short) (currentTile.x + deltaX), (short) (currentTile.y + deltaY));
+    }
+
+    private boolean canMoveTo(Room room, RoomUnit roomUnit, RoomTile targetTile, WiredMovementPhysics movementPhysics) {
+        return WiredUserMovementHelper.canMoveTo(room, roomUnit, targetTile, movementPhysics);
+    }
+
+    public static boolean handleWalkWhileActive(Room room, RoomUnit roomUnit, RoomTile targetTile) {
+        return false;
+    }
+
+    static class JsonData {
+        int delay;
+        int movementDirection;
+        int rotationDirection;
+        int userSource;
+        int tileCount;
+
+        public JsonData(int delay, int movementDirection, int rotationDirection, int userSource, int tileCount) {
+            this.delay = delay;
+            this.movementDirection = movementDirection;
+            this.rotationDirection = rotationDirection;
+            this.userSource = userSource;
+            this.tileCount = tileCount;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectOpenHabboPages.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectOpenHabboPages.java
@@ -1,0 +1,156 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.users.InClientLinkComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Opens an in-client link / Habbo page for the resolved users (e.g. "habbopages/...", "catalog/open/...").
+ * Reuses the {@link WiredEffectType#SHOW_MESSAGE} client dialog (single text field = the link path + a
+ * user-source selector), so it needs no new client dialog. The link is delivered via
+ * {@link InClientLinkComposer}, as proven by ClickUserEvent / InteractionInformationTerminal.
+ */
+public class WiredEffectOpenHabboPages extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private String link = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectOpenHabboPages(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectOpenHabboPages(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.link);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String value = settings.getStringParam();
+        if (value == null || value.trim().isEmpty()) {
+            return false;
+        }
+        this.link = value.trim();
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null || habbo.getClient() == null) continue;
+
+            habbo.getClient().sendResponse(new InClientLinkComposer(this.link));
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.link, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.link = data.link == null ? "" : data.link;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        } else {
+            this.link = "";
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.link = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String link;
+        int delay;
+        int userSource;
+
+        public JsonData(String link, int delay, int userSource) {
+            this.link = link;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectRemoveBadge.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectRemoveBadge.java
@@ -1,0 +1,169 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.inventory.BadgesComponent;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.inventory.InventoryBadgesComposer;
+import com.eu.habbo.messages.outgoing.users.UserBadgesComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectRemoveBadge extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private String badge = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectRemoveBadge(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectRemoveBadge(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.badge);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String nextBadge = settings.getStringParam() != null ? settings.getStringParam().trim() : "";
+        if (nextBadge.isEmpty()) {
+            return false;
+        }
+        this.badge = nextBadge;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            BadgesComponent bc = habbo.getInventory().getBadgesComponent();
+            if (bc.removeBadge(this.badge) == null) continue;
+
+            BadgesComponent.deleteBadge(habbo.getHabboInfo().getId(), this.badge);
+
+            if (habbo.getClient() != null) {
+                habbo.getClient().sendResponse(new InventoryBadgesComposer(habbo));
+            }
+
+            room.sendComposer(new UserBadgesComposer(bc.getWearingBadges(), habbo.getHabboInfo().getId()).compose());
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.badge, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.badge = data.badge != null ? data.badge : "";
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        }
+        else {
+            String[] data = wiredData.split("\t");
+            this.badge = "";
+
+            if (data.length >= 2) {
+                super.setDelay(Integer.parseInt(data[0]));
+                this.badge = data[1];
+            }
+
+            this.needsUpdate(true);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.badge = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String badge;
+        int delay;
+        int userSource;
+
+        public JsonData(String badge, int delay, int userSource) {
+            this.badge = badge;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectResetHighscores.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectResetHighscores.java
@@ -1,0 +1,102 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredHighscore;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectResetHighscores extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.RESET_TIMERS;
+
+    public WiredEffectResetHighscores(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectResetHighscores(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        return true;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        for (HabboItem it : ctx.room().getRoomSpecialTypes().getItemsOfType(InteractionWiredHighscore.class)) {
+            Emulator.getGameEnvironment().getItemManager().getHighscoreManager().setEntriesForItemId(it.getId(), new java.util.ArrayList<>());
+            ((InteractionWiredHighscore) it).reloadData();
+            ctx.room().updateItem(it);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return "";
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+
+    }
+
+    @Override
+    public void onPickUp() {
+
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSayCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSayCommand.java
@@ -1,0 +1,161 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.commands.CommandHandler;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectSayCommand extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SHOW_MESSAGE;
+
+    private String command = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectSayCommand(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectSayCommand(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.command);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        String nextCommand = settings.getStringParam();
+        nextCommand = (nextCommand == null) ? "" : nextCommand.trim();
+        if (nextCommand.isEmpty()) {
+            return false;
+        }
+        this.command = nextCommand;
+
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+
+        this.setDelay(settings.getDelay());
+
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        String line = this.command.startsWith(":") ? this.command : ":" + this.command;
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null || habbo.getClient() == null) continue;
+
+            CommandHandler.handleCommand(habbo.getClient(), line);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.command, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.command = (data.command == null) ? "" : data.command;
+            this.setDelay(data.delay);
+            this.userSource = data.userSource;
+        }
+        else {
+            String[] data = wiredData.split("\t");
+            this.command = "";
+
+            if (data.length >= 2) {
+                super.setDelay(Integer.parseInt(data[0]));
+                this.command = data[1];
+            }
+
+            this.needsUpdate(true);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.command = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        String command;
+        int delay;
+        int userSource;
+
+        public JsonData(String command, int delay, int userSource) {
+            this.command = command;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSit.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSit.java
@@ -1,0 +1,175 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.habbohotel.wired.core.WiredTextPlaceholderUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectSit extends InteractionWiredEffect {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WiredEffectSit.class);
+    public static final WiredEffectType type = WiredEffectType.KICK_USER;
+
+    private String message = "";
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectSit(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectSit(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            if (!unit.canForcePosture()) continue;
+
+            if (unit.isWalking()) unit.stopWalking();
+
+            room.makeSit(habbo);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.message, this.getDelay(), this.userSource));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if(wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.setDelay(data.delay);
+            this.message = data.message;
+            this.userSource = data.userSource;
+        }
+        else {
+            try {
+                String[] data = set.getString("wired_data").split("\t");
+
+                if (data.length >= 1) {
+                    this.setDelay(Integer.parseInt(data[0]));
+
+                    if (data.length >= 2) {
+                        this.message = data[1];
+                    }
+                }
+            } catch (Exception e) {
+                this.message = "";
+                this.setDelay(0);
+            }
+
+            this.needsUpdate(true);
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.message = "";
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString(this.message);
+        message.appendInt(1);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        String message = settings.getStringParam();
+        int[] params = settings.getIntParams();
+        this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+        int delay = settings.getDelay();
+
+        if(delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20))
+            throw new WiredSaveException("Delay too long");
+
+        this.message = message.substring(0, Math.min(message.length(), Emulator.getConfig().getInt("hotel.wired.message.max_length", 100)));
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER || WiredTextPlaceholderUtil.requiresActor(this.getRoom(), this);
+    }
+
+    static class JsonData {
+        String message;
+        int delay;
+        int userSource;
+
+        public JsonData(String message, int delay, int userSource) {
+            this.message = message;
+            this.delay = delay;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleMoodlight.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectToggleMoodlight.java
@@ -1,0 +1,145 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionMoodLight;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomMoodlightData;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectToggleMoodlight extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.RESET_TIMERS;
+
+    private int delay = 0;
+
+    public WiredEffectToggleMoodlight(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectToggleMoodlight(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(5);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        this.setDelay(settings.getDelay());
+        return true;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        for (HabboItem moodLight : room.getRoomSpecialTypes().getItemsOfType(InteractionMoodLight.class)) {
+            // enabled ? 2 : 1, preset id, background only ? 2 : 1, color, intensity
+
+            String extradata = "2,1,2,#FF00FF,255";
+            for (RoomMoodlightData data : room.getMoodlightData().values()) {
+                if (data.isEnabled()) {
+                    extradata = data.toString();
+                    break;
+                }
+            }
+
+            RoomMoodlightData adjusted = RoomMoodlightData.fromString(extradata);
+            if (RoomMoodlightData.fromString(moodLight.getExtradata()).isEnabled()) adjusted.disable();
+            moodLight.setExtradata(adjusted.toString());
+
+            moodLight.needsUpdate(true);
+            room.updateItem(moodLight);
+            Emulator.getThreading().run(moodLight);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(
+            this.getDelay()
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        JsonData jsonData = WiredUtilityPayloadGuard.fromJson(wiredData, JsonData.class);
+        if (jsonData != null) {
+            this.delay = WiredUtilityPayloadGuard.delay(jsonData.delay);
+        } else {
+            if (wiredData != null && !wiredData.equals("")) {
+                this.delay = WiredUtilityPayloadGuard.parseDelay(wiredData);
+            }
+        }
+
+        this.setDelay(WiredUtilityPayloadGuard.delay(this.delay));
+    }
+
+    @Override
+    public void onPickUp() {
+        this.delay = 0;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int delay;
+
+        public JsonData(int delay) {
+            this.delay = delay;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWalkToFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWalkToFurni.java
@@ -1,0 +1,266 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import java.util.HashSet;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredLegacyDataGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.*;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WiredEffectWalkToFurni extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.TELEPORT;
+
+    protected List<HabboItem> items;
+    private boolean fastTeleport = false;
+    private int furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectWalkToFurni(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+        this.items = new ArrayList<>();
+    }
+
+    public WiredEffectWalkToFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+        this.items = new ArrayList<>();
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
+        var items = new HashSet<HabboItem>();
+
+        for (HabboItem item : itemsSnapshot) {
+            if (item.getRoomId() != this.getRoomId() || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null)
+                items.add(item);
+        }
+
+        for (HabboItem item : items) {
+            this.items.remove(item);
+        }
+        itemsSnapshot = new ArrayList<>(this.items);
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(itemsSnapshot.size());
+        for (HabboItem item : itemsSnapshot)
+            message.appendInt(item.getId());
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(3);
+        message.appendInt(this.fastTeleport ? 1 : 0);
+        message.appendInt(this.furniSource);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+        if (this.requiresTriggeringUser()) {
+            List<Integer> invalidTriggers = new ArrayList<>();
+            for (InteractionWiredTrigger object : room.getRoomSpecialTypes().getTriggers(this.getX(), this.getY())) {
+                if (!object.isTriggeredByRoomUnit()) {
+                    invalidTriggers.add(object.getBaseItem().getSpriteId());
+                }
+            }
+            message.appendInt(invalidTriggers.size());
+            for (Integer i : invalidTriggers) {
+                message.appendInt(i);
+            }
+        } else {
+            message.appendInt(0);
+        }
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        if (params.length > 2) {
+            this.fastTeleport = params[0] == 1;
+            this.furniSource = params[1];
+            this.userSource = params[2];
+        } else {
+            this.fastTeleport = false;
+            this.furniSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
+            this.userSource = (params.length > 1) ? params[1] : WiredSourceUtil.SOURCE_TRIGGER;
+        }
+
+        int itemsCount = settings.getFurniIds().length;
+
+        if(itemsCount > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+            throw new WiredSaveException("Too many furni selected");
+        }
+
+        if (itemsCount > 0 && this.furniSource == WiredSourceUtil.SOURCE_TRIGGER) {
+            this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+        }
+
+        List<HabboItem> newItems = new ArrayList<>();
+
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            for (int i = 0; i < itemsCount; i++) {
+                int itemId = settings.getFurniIds()[i];
+                HabboItem it = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(itemId);
+
+                if(it == null)
+                    throw new WiredSaveException(String.format("Item %s not found", itemId));
+
+                newItems.add(it);
+            }
+        }
+
+        int delay = settings.getDelay();
+
+        if(delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20))
+            throw new WiredSaveException("Delay too long");
+
+        this.items.clear();
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            this.items.addAll(newItems);
+        }
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+
+        if (room == null || room.getLayout() == null) {
+            return;
+        }
+
+        List<HabboItem> effectiveItems = WiredSourceUtil.resolveItems(ctx, this.furniSource, this.items);
+        if (this.furniSource == WiredSourceUtil.SOURCE_SELECTED) {
+            this.items.removeIf(item -> item == null || item.getRoomId() != this.getRoomId()
+                    || Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId()).getHabboItem(item.getId()) == null);
+        }
+
+        if (effectiveItems.isEmpty()) return;
+
+        for (RoomUnit roomUnit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            int i = Emulator.getRandom().nextInt(effectiveItems.size());
+            HabboItem item = effectiveItems.get(i);
+
+            if (item == null) continue;
+
+            RoomTile tile = room.getLayout().getTile(item.getX(), item.getY());
+            if (tile != null) {
+                roomUnit.setGoalLocation(tile);
+            }
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        List<HabboItem> itemsSnapshot = new ArrayList<>(this.items);
+        return WiredManager.getGson().toJson(new JsonData(
+            this.getDelay(),
+            itemsSnapshot.stream().map(HabboItem::getId).toList(),
+            this.fastTeleport,
+            this.furniSource,
+            this.userSource
+        ));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.items = new ArrayList<>();
+        String wiredData = set.getString("wired_data");
+
+        JsonData jsonData = WiredMovementPayloadGuard.fromJson(wiredData, JsonData.class);
+        if (jsonData != null) {
+            this.setDelay(WiredMovementPayloadGuard.delay(jsonData.delay));
+            this.fastTeleport = jsonData.fastTeleport;
+            this.furniSource = WiredMovementPayloadGuard.furniSource(jsonData.furniSource);
+            this.userSource = WiredMovementPayloadGuard.userSource(jsonData.userSource);
+            if (jsonData.itemIds != null) {
+                for (Integer id: jsonData.itemIds) {
+                    if (id == null) continue;
+                    HabboItem item = room.getHabboItem(id);
+                    if (item != null) {
+                        this.items.add(item);
+                    }
+                }
+            }
+            if (this.furniSource == WiredSourceUtil.SOURCE_TRIGGER && !this.items.isEmpty()) {
+                this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+            }
+        } else {
+            String[] wiredDataOld = wiredData != null ? wiredData.split("\t") : new String[0];
+
+            if (wiredDataOld.length >= 1) {
+                this.setDelay(WiredLegacyDataGuard.parseDelay(wiredDataOld[0]));
+            }
+            if (wiredDataOld.length == 2) {
+                if (wiredDataOld[1].contains(";")) {
+                    this.items.addAll(WiredLegacyDataGuard.parseRoomItems(wiredDataOld[1], room));
+                }
+            }
+            this.fastTeleport = false;
+            this.furniSource = this.items.isEmpty() ? WiredSourceUtil.SOURCE_TRIGGER : WiredSourceUtil.SOURCE_SELECTED;
+            this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.items.clear();
+        this.fastTeleport = false;
+        this.furniSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    @Override
+    protected long requiredCooldown() {
+        return COOLDOWN_DEFAULT;
+    }
+
+    static class JsonData {
+        int delay;
+        List<Integer> itemIds;
+        boolean fastTeleport;
+        int furniSource;
+        int userSource;
+
+        public JsonData(int delay, List<Integer> itemIds, boolean fastTeleport, int furniSource, int userSource) {
+            this.delay = delay;
+            this.itemIds = itemIds;
+            this.fastTeleport = fastTeleport;
+            this.furniSource = furniSource;
+            this.userSource = userSource;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboIdles.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboIdles.java
@@ -1,0 +1,89 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Fires when a room unit starts idling. The matching {@code USER_IDLES} event is raised by
+ * {@code RoomUnitManager}/{@code RoomCycleManager} and routed by the engine to this trigger
+ * (via {@link WiredTriggerType#IDLES}). No configuration — like {@link WiredTriggerCollision}, it just
+ * needs an actor.
+ */
+public class WiredTriggerHabboIdles extends InteractionWiredTrigger {
+    private static final WiredTriggerType type = WiredTriggerType.IDLES;
+
+    public WiredTriggerHabboIdles(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerHabboIdles(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        return event.getActor().isPresent();
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return "";
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+
+    }
+
+    @Override
+    public void onPickUp() {
+
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        return true;
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboStartsDancing.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboStartsDancing.java
@@ -1,0 +1,88 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Fires when a room unit starts dancing. The matching {@code USER_STARTS_DANCING} event is raised by
+ * {@code RoomUnitManager} and routed by the engine to this trigger (via {@link WiredTriggerType#STARTS_DANCING}).
+ * No configuration — like {@link WiredTriggerCollision}, it just needs an actor.
+ */
+public class WiredTriggerHabboStartsDancing extends InteractionWiredTrigger {
+    private static final WiredTriggerType type = WiredTriggerType.STARTS_DANCING;
+
+    public WiredTriggerHabboStartsDancing(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerHabboStartsDancing(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        return event.getActor().isPresent();
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return "";
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+
+    }
+
+    @Override
+    public void onPickUp() {
+
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        return true;
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboStopsDancing.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboStopsDancing.java
@@ -1,0 +1,88 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Fires when a room unit stops dancing. The matching {@code USER_STOPS_DANCING} event is raised by
+ * {@code RoomUnitManager} and routed by the engine to this trigger (via {@link WiredTriggerType#STOPS_DANCING}).
+ * No configuration — like {@link WiredTriggerCollision}, it just needs an actor.
+ */
+public class WiredTriggerHabboStopsDancing extends InteractionWiredTrigger {
+    private static final WiredTriggerType type = WiredTriggerType.STOPS_DANCING;
+
+    public WiredTriggerHabboStopsDancing(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerHabboStopsDancing(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        return event.getActor().isPresent();
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return "";
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+
+    }
+
+    @Override
+    public void onPickUp() {
+
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        return true;
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboUnidles.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerHabboUnidles.java
@@ -1,0 +1,88 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Fires when a room unit stops idling. The matching {@code USER_UNIDLES} event is raised by
+ * {@code RoomUnitManager} and routed by the engine to this trigger (via {@link WiredTriggerType#UNIDLES}).
+ * No configuration — like {@link WiredTriggerCollision}, it just needs an actor.
+ */
+public class WiredTriggerHabboUnidles extends InteractionWiredTrigger {
+    private static final WiredTriggerType type = WiredTriggerType.UNIDLES;
+
+    public WiredTriggerHabboUnidles(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerHabboUnidles(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        return event.getActor().isPresent();
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return "";
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+
+    }
+
+    @Override
+    public void onPickUp() {
+
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        return true;
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return true;
+    }
+}


### PR DESCRIPTION
Ports the **Phase-C** batch of standard wired conditions/effects/triggers from the fork's `java25-migration` onto `dev` (purely **additive**, Trove→`java.util` converted). 31 new classes + ItemManager registrations; reuses existing `WiredEffectType`/`WiredConditionType` constants (no enum changes).

## ⚠️ Stacked on #295
This branch is **stacked on duckietm/Arcturus-Morningstar-Extended#295** (it consumes `WiredEffectLog`, registered here as `wf_act_log`). **Merge #295 first**, then this PR's diff reduces to its own Phase-C commit. Until then this PR also shows #295's commit.

## Effects (currency / badges / posture / movement / misc)
give_credits, give_duckets, give_diamonds, give_badge (+userbadge alias), remove_badge, give_achievement, give_experience, say_command, open_habbo_pages, make_user_say, log (`wf_act_log`), walk_to_furni, sit, lay, make_fast_walk, toggle_moodlight, reset_highscores, move_user_tiles, all_users_leave_team

## Conditions
not_habbo_has_credits/diamonds/duckets, freeze/not_freeze, furni_in_range/not_in_range, has_same_height/not_has_same_height

## Triggers
starts_dancing, stops_dancing, idles, unidles

## Notes
- Trove→java.util: `TObjectProcedure.forEach`→`for`-loop (18 files), `THashSet`→`HashSet` (5), fastutil `.valueCollection()`→`.values()` (1).
- `mvn clean compile`: **BUILD SUCCESS** on the stacked base (independently re-verified). Draft pending runtime test.