### PR TITLE
feat(wired): comparison operators for chest has-items conditions (server)

### DIFF
--- a/Database Updates/017_wired_chest_currency.sql
+++ b/Database Updates/017_wired_chest_currency.sql
@@ -1,0 +1,28 @@
+-- =====================================================================
+-- 017_wired_chest_currency.sql
+-- =====================================================================
+-- Phase-2 chest/storage, currency slice. Point the previously-inert
+-- ('default') items_base rows at their newly-registered classes so the
+-- emulator loads the real chest/effect/condition. Same pattern as
+-- 013/014/015/016. Requires an emulator restart. Idempotent.
+--
+--   wf_storage_coins1      -> InteractionWiredChestCurrency  (Credit Chest, dialog code 100)
+--   wf_storage_coins2      -> InteractionWiredChestCurrency  (Credit Chest)
+--   wf_act_give_currency   -> WiredEffectGiveCurrencyFromChest (effect code 99)
+--   wf_cnd_chest_has_items -> WiredConditionChestHasItems     (condition code 47)
+--
+-- NOTE: wf_storage_furni1/2/_starter, give_furni, chest_has_item_type and the
+-- scan add-on are the FURNI-chest slice (next) — left 'default' for now.
+-- =====================================================================
+
+UPDATE items_base SET interaction_type = 'wf_storage_coins1'
+    WHERE item_name = 'wf_storage_coins1'      AND interaction_type <> 'wf_storage_coins1';
+
+UPDATE items_base SET interaction_type = 'wf_storage_coins2'
+    WHERE item_name = 'wf_storage_coins2'      AND interaction_type <> 'wf_storage_coins2';
+
+UPDATE items_base SET interaction_type = 'wf_act_give_currency'
+    WHERE item_name = 'wf_act_give_currency'   AND interaction_type <> 'wf_act_give_currency';
+
+UPDATE items_base SET interaction_type = 'wf_cnd_chest_has_items'
+    WHERE item_name = 'wf_cnd_chest_has_items' AND interaction_type <> 'wf_cnd_chest_has_items';

--- a/Database Updates/018_wired_chest_furni.sql
+++ b/Database Updates/018_wired_chest_furni.sql
@@ -1,0 +1,30 @@
+-- =====================================================================
+-- 018_wired_chest_furni.sql
+-- =====================================================================
+-- Phase-2 chest/storage, furni slice. Point the items_base rows at their
+-- newly-registered classes. Same pattern as 013-017. Emulator restart req.
+-- Idempotent.
+--
+--   wf_storage_furni1/2/_starter -> InteractionWiredChestFurni  (Furni Chest, dialog code 101)
+--   wf_act_give_furni            -> WiredEffectGiveFurniFromChest (effect code 102)
+--   wf_cnd_chest_has_item_type   -> WiredConditionChestHasItemType (condition code 48)
+--
+-- NOTE: wf_storage_furni2 may already read 'wf_storage_furni2' (legacy) — the
+-- guard makes this a no-op there. wf_xtra_scan_chest_furni_by_type (scanner)
+-- is NOT in this slice (future).
+-- =====================================================================
+
+UPDATE items_base SET interaction_type = 'wf_storage_furni1'
+    WHERE item_name = 'wf_storage_furni1'        AND interaction_type <> 'wf_storage_furni1';
+
+UPDATE items_base SET interaction_type = 'wf_storage_furni2'
+    WHERE item_name = 'wf_storage_furni2'        AND interaction_type <> 'wf_storage_furni2';
+
+UPDATE items_base SET interaction_type = 'wf_storage_furni_starter'
+    WHERE item_name = 'wf_storage_furni_starter' AND interaction_type <> 'wf_storage_furni_starter';
+
+UPDATE items_base SET interaction_type = 'wf_act_give_furni'
+    WHERE item_name = 'wf_act_give_furni'        AND interaction_type <> 'wf_act_give_furni';
+
+UPDATE items_base SET interaction_type = 'wf_cnd_chest_has_item_type'
+    WHERE item_name = 'wf_cnd_chest_has_item_type' AND interaction_type <> 'wf_cnd_chest_has_item_type';

--- a/Database Updates/019_wired_transactions_scanner.sql
+++ b/Database Updates/019_wired_transactions_scanner.sql
@@ -1,0 +1,28 @@
+-- =====================================================================
+-- 019_wired_transactions_scanner.sql
+-- =====================================================================
+-- Phase-2: chest scanner add-on + transaction effects/triggers (v1).
+-- Point the inert items_base rows at their new classes. Pattern 013-018.
+-- Emulator restart required. Idempotent.
+--
+--   wf_xtra_scan_chest_furni_by_type -> WiredEffectScanChestFurniByType  (selector, code 103)
+--   wf_act_init_transaction          -> WiredEffectInitTransaction       (effect 104 -> fires complete)
+--   wf_act_cancel_transaction        -> WiredEffectCancelTransaction     (effect 105 -> fires fail)
+--   wf_trg_transaction_complete      -> WiredTriggerTransactionComplete  (trigger 27)
+--   wf_trg_transaction_fail          -> WiredTriggerTransactionFail      (trigger 28)
+-- =====================================================================
+
+UPDATE items_base SET interaction_type = 'wf_xtra_scan_chest_furni_by_type'
+    WHERE item_name = 'wf_xtra_scan_chest_furni_by_type' AND interaction_type <> 'wf_xtra_scan_chest_furni_by_type';
+
+UPDATE items_base SET interaction_type = 'wf_act_init_transaction'
+    WHERE item_name = 'wf_act_init_transaction'   AND interaction_type <> 'wf_act_init_transaction';
+
+UPDATE items_base SET interaction_type = 'wf_act_cancel_transaction'
+    WHERE item_name = 'wf_act_cancel_transaction' AND interaction_type <> 'wf_act_cancel_transaction';
+
+UPDATE items_base SET interaction_type = 'wf_trg_transaction_complete'
+    WHERE item_name = 'wf_trg_transaction_complete' AND interaction_type <> 'wf_trg_transaction_complete';
+
+UPDATE items_base SET interaction_type = 'wf_trg_transaction_fail'
+    WHERE item_name = 'wf_trg_transaction_fail'   AND interaction_type <> 'wf_trg_transaction_fail';

--- a/Database Updates/020_wired_place_remove_furni.sql
+++ b/Database Updates/020_wired_place_remove_furni.sql
@@ -1,0 +1,16 @@
+-- =====================================================================
+-- 020_wired_place_remove_furni.sql
+-- =====================================================================
+-- Deferred Phase-1 furni: spawn / remove a furni in the room.
+-- Point the inert items_base rows at their new classes. Pattern 013-019.
+-- Emulator restart required. Idempotent.
+--
+--   wf_act_place_furni  -> WiredEffectPlaceFurni   (effect, code 106) — mints a base-type furni onto the floor
+--   wf_act_remove_furni -> WiredEffectRemoveFurni  (effect, code 107) — picks up / deletes the selected furni
+-- =====================================================================
+
+UPDATE items_base SET interaction_type = 'wf_act_place_furni'
+    WHERE item_name = 'wf_act_place_furni'  AND interaction_type <> 'wf_act_place_furni';
+
+UPDATE items_base SET interaction_type = 'wf_act_remove_furni'
+    WHERE item_name = 'wf_act_remove_furni' AND interaction_type <> 'wf_act_remove_furni';

--- a/Database Updates/021_wired_contracts.sql
+++ b/Database Updates/021_wired_contracts.sql
@@ -1,0 +1,24 @@
+-- =====================================================================
+-- 021_wired_contracts.sql
+-- =====================================================================
+-- Phase-2 contracts (gen-3 Origins): config-holder term furni executed by
+-- the upgraded Init Transaction. Point the inert items_base rows at their
+-- new classes. Pattern 013-020. Emulator restart required. Idempotent.
+--
+--   wf_contract_payment     -> InteractionWiredContractPayment  (extra, dialog code 110)
+--   wf_contract_reward      -> InteractionWiredContractReward   (extra, dialog code 111)
+--   wf_contract_trade       -> InteractionWiredContractTrade    (extra, dialog code 112)
+--   wf_xtra_custom_contract -> InteractionWiredCustomContract   (extra, dialog code 113)
+-- =====================================================================
+
+UPDATE items_base SET interaction_type = 'wf_contract_payment'
+    WHERE item_name = 'wf_contract_payment'     AND interaction_type <> 'wf_contract_payment';
+
+UPDATE items_base SET interaction_type = 'wf_contract_reward'
+    WHERE item_name = 'wf_contract_reward'      AND interaction_type <> 'wf_contract_reward';
+
+UPDATE items_base SET interaction_type = 'wf_contract_trade'
+    WHERE item_name = 'wf_contract_trade'       AND interaction_type <> 'wf_contract_trade';
+
+UPDATE items_base SET interaction_type = 'wf_xtra_custom_contract'
+    WHERE item_name = 'wf_xtra_custom_contract' AND interaction_type <> 'wf_xtra_custom_contract';

--- a/Database Updates/022_wired_quests.sql
+++ b/Database Updates/022_wired_quests.sql
@@ -1,0 +1,16 @@
+-- =====================================================================
+-- 022_wired_quests.sql
+-- =====================================================================
+-- Gen-3 Wired 2.0 quest boxes (derived-variable definition add-ons).
+-- Point the inert items_base rows at their new classes. Pattern 013-021.
+-- Emulator restart required. Idempotent.
+--
+--   wf_var_quest       -> WiredExtraQuest       (extra, dialog code 108) — progress/target/is_complete/percent/remaining
+--   wf_var_quest_chain -> WiredExtraQuestChain  (extra, dialog code 109) — current_step/total_steps/is_complete/percent
+-- =====================================================================
+
+UPDATE items_base SET interaction_type = 'wf_var_quest'
+    WHERE item_name = 'wf_var_quest'       AND interaction_type <> 'wf_var_quest';
+
+UPDATE items_base SET interaction_type = 'wf_var_quest_chain'
+    WHERE item_name = 'wf_var_quest_chain' AND interaction_type <> 'wf_var_quest_chain';

--- a/Database Updates/fill_room_207_wiredlab.sql
+++ b/Database Updates/fill_room_207_wiredlab.sql
@@ -1,0 +1,52 @@
+-- =====================================================================
+-- fill_room_207_wiredlab.sql
+-- Riempi la room 207 ("wired room", owner tester = user_id 5) con UN furni
+-- per ogni tipo wired in items_base (309), separati a scacchiera in 7 isole
+-- per categoria, su un model aperto su misura (40x28 = 1120 tile).
+--
+-- REVERT:
+--   UPDATE rooms SET model='model_k' WHERE id=207;
+--   DELETE FROM items WHERE room_id=207;
+--   DELETE FROM room_models WHERE name='wiredlab';
+-- =====================================================================
+
+START TRANSACTION;
+
+-- 1) Model aperto 40x28, tutto pavimento, porta a sinistra-centro (0,14)
+REPLACE INTO room_models (name, door_x, door_y, door_dir, heightmap, public_items, club_only)
+VALUES ('wiredlab', 0, 14, 2,
+        TRIM(TRAILING CONCAT(CHAR(13),CHAR(10)) FROM REPEAT(CONCAT(REPEAT('0',40),CHAR(13),CHAR(10)),28)),
+        '', '0');
+
+-- 2) Assegna il model alla room 207
+UPDATE rooms SET model='wiredlab' WHERE id=207;
+
+-- 3) Svuota la room
+DELETE FROM items WHERE room_id=207;
+
+-- 4) Piazza i 309 wired in isole a scacchiera (ogni furni separato sui 4 lati),
+--    legati a tester = user_id 5. Formula: x=ox+col*2+(row%2), y=oy+row.
+INSERT INTO items (user_id, room_id, item_id, wall_pos, x, y, z, rot, extra_data, wired_data, limited_data, guild_id)
+SELECT 5, 207, t.id, '',
+       t.ox + ((t.k-1) % t.c)*2 + (FLOOR((t.k-1)/t.c) % 2) AS x,
+       t.oy + FLOOR((t.k-1)/t.c)                          AS y,
+       0, 0, '', '', '0:0', 0
+FROM (
+  SELECT g.id,
+    ROW_NUMBER() OVER (PARTITION BY g.cat ORDER BY g.interaction_type) AS k,
+    CASE g.cat WHEN 'act' THEN 1 WHEN 'trg' THEN 25 WHEN 'cnd' THEN 1
+               WHEN 'slc' THEN 25 WHEN 'xtra' THEN 25 WHEN 'var' THEN 25 ELSE 33 END AS ox,
+    CASE g.cat WHEN 'act' THEN 1 WHEN 'trg' THEN 1  WHEN 'cnd' THEN 15
+               WHEN 'slc' THEN 10 WHEN 'xtra' THEN 16 WHEN 'var' THEN 22 ELSE 22 END AS oy,
+    CASE g.cat WHEN 'act' THEN 11 WHEN 'trg' THEN 7 WHEN 'cnd' THEN 9
+               WHEN 'slc' THEN 5 WHEN 'xtra' THEN 4 WHEN 'var' THEN 3 ELSE 3 END AS c
+  FROM (
+    SELECT MIN(id) AS id, interaction_type,
+      CASE WHEN SUBSTRING_INDEX(SUBSTRING(interaction_type,4),'_',1) IN ('trg','cnd','act','slc','var','xtra')
+           THEN SUBSTRING_INDEX(SUBSTRING(interaction_type,4),'_',1) ELSE 'misc' END AS cat
+    FROM items_base WHERE interaction_type LIKE 'wf\_%'
+    GROUP BY interaction_type
+  ) g
+) t;
+
+COMMIT;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -75,6 +75,12 @@ import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraUnseen;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableReference;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem;
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableTextConnector;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraQuest;
+import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraQuestChain;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractPayment;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractReward;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContractTrade;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredCustomContract;
 import com.eu.habbo.habbohotel.items.interactions.wired.selector.*;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.*;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestCurrency;
@@ -378,6 +384,26 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_storage_furni1", InteractionWiredChestFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_storage_furni2", InteractionWiredChestFurni.class));
         this.interactionsList.add(new ItemInteraction("wf_storage_furni_starter", InteractionWiredChestFurni.class));
+
+        // Phase-2 chest-full wired: give-from-chest, has-item conditions, scanner, transactions,
+        // place/remove-furni, contracts, quests (chest storage furni above are from the #291 base).
+        this.interactionsList.add(new ItemInteraction("wf_act_give_currency", WiredEffectGiveCurrencyFromChest.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_chest_has_items", WiredConditionChestHasItems.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_give_furni", WiredEffectGiveFurniFromChest.class));
+        this.interactionsList.add(new ItemInteraction("wf_cnd_chest_has_item_type", WiredConditionChestHasItemType.class));
+        this.interactionsList.add(new ItemInteraction("wf_xtra_scan_chest_furni_by_type", WiredEffectScanChestFurniByType.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_init_transaction", WiredEffectInitTransaction.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_cancel_transaction", WiredEffectCancelTransaction.class));
+        this.interactionsList.add(new ItemInteraction("wf_trg_transaction_complete", WiredTriggerTransactionComplete.class));
+        this.interactionsList.add(new ItemInteraction("wf_trg_transaction_fail", WiredTriggerTransactionFail.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_place_furni", WiredEffectPlaceFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_act_remove_furni", WiredEffectRemoveFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_contract_payment", InteractionWiredContractPayment.class));
+        this.interactionsList.add(new ItemInteraction("wf_contract_reward", InteractionWiredContractReward.class));
+        this.interactionsList.add(new ItemInteraction("wf_contract_trade", InteractionWiredContractTrade.class));
+        this.interactionsList.add(new ItemInteraction("wf_xtra_custom_contract", InteractionWiredCustomContract.class));
+        this.interactionsList.add(new ItemInteraction("wf_var_quest", WiredExtraQuest.class));
+        this.interactionsList.add(new ItemInteraction("wf_var_quest_chain", WiredExtraQuestChain.class));
 
 
         this.interactionsList.add(new ItemInteraction("wf_xtra_random", WiredExtraRandom.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredComparison.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredComparison.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.habbohotel.items.interactions.wired;
+
+/**
+ * Comparison operators for wired chest conditions.
+ *
+ * <p>The integer encoding is the WIRE CONTRACT shared with the client
+ * ({@code ui/src/components/wired/views/WiredComparisonOperator.tsx}) and the
+ * official deobfuscated {@code ChestHasAmount}. It must be mapped by VALUE, never
+ * by ordinal:
+ *
+ * <pre>0 = &lt;    1 = =    2 = &gt;    3 = &lt;=    4 = !=    5 = &gt;=</pre>
+ *
+ * The default ({@code >=}) preserves the chest conditions' historical hard-coded
+ * behaviour for saves written before the operator existed.
+ */
+public final class WiredComparison {
+    public static final int LESS = 0;
+    public static final int EQUAL = 1;
+    public static final int GREATER = 2;
+    public static final int LESS_EQUAL = 3;
+    public static final int NOT_EQUAL = 4;
+    public static final int GREATER_EQUAL = 5;
+
+    private WiredComparison() {
+    }
+
+    public static int normalize(int value) {
+        return (value >= LESS && value <= GREATER_EQUAL) ? value : GREATER_EQUAL;
+    }
+
+    public static boolean compare(int left, int right, int operator) {
+        switch (operator) {
+            case LESS:
+                return left < right;
+            case EQUAL:
+                return left == right;
+            case GREATER:
+                return left > right;
+            case LESS_EQUAL:
+                return left <= right;
+            case NOT_EQUAL:
+                return left != right;
+            case GREATER_EQUAL:
+            default:
+                return left >= right;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionChestHasItemType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionChestHasItemType.java
@@ -1,0 +1,142 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Chest Contains Furni Type (furni classname {@code wf_cnd_chest_has_item_type}). Passes when the
+ * selected {@link InteractionWiredChest}(s) hold at least {@code amount} furni of base type
+ * {@code baseItemId}.
+ */
+public class WiredConditionChestHasItemType extends InteractionWiredCondition {
+    public static final WiredConditionType type = WiredConditionType.CHEST_HAS_ITEM_TYPE;
+
+    private final List<Integer> chestIds = new ArrayList<>();
+    private int baseItemId = 0;
+    private int amount = 1;
+
+    public WiredConditionChestHasItemType(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionChestHasItemType(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null || this.baseItemId <= 0) return false;
+
+        int total = 0;
+        for (Integer id : this.chestIds) {
+            HabboItem item = room.getHabboItem(id);
+            if (item instanceof InteractionWiredChest chest) {
+                total += chest.getContents().count(ChestStorage.KIND_FURNI, this.baseItemId);
+            }
+        }
+        return total >= this.amount;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.baseItemId = (params.length > 0) ? params[0] : 0;
+        this.amount = (params.length > 1) ? Math.max(1, params[1]) : 1;
+
+        this.chestIds.clear();
+        if (settings.getFurniIds() != null) {
+            for (int id : settings.getFurniIds()) {
+                this.chestIds.add(id);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.baseItemId, this.amount, this.chestIds));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) return;
+
+        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        if (data == null) return;
+
+        this.baseItemId = data.baseItemId;
+        this.amount = Math.max(1, data.amount);
+        if (data.chestIds != null) {
+            this.chestIds.addAll(data.chestIds);
+        }
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.chestIds.size());
+        for (Integer id : this.chestIds) {
+            message.appendInt(id);
+        }
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.baseItemId);
+        message.appendInt(this.amount);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.chestIds.clear();
+        this.baseItemId = 0;
+        this.amount = 1;
+    }
+
+    static class JsonData {
+        int baseItemId;
+        int amount;
+        List<Integer> chestIds;
+
+        public JsonData(int baseItemId, int amount, List<Integer> chestIds) {
+            this.baseItemId = baseItemId;
+            this.amount = amount;
+            this.chestIds = chestIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionChestHasItemType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionChestHasItemType.java
@@ -2,6 +2,7 @@ package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
 
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredComparison;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
@@ -29,6 +30,7 @@ public class WiredConditionChestHasItemType extends InteractionWiredCondition {
     private final List<Integer> chestIds = new ArrayList<>();
     private int baseItemId = 0;
     private int amount = 1;
+    private int comparison = WiredComparison.GREATER_EQUAL;
 
     public WiredConditionChestHasItemType(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
@@ -50,7 +52,7 @@ public class WiredConditionChestHasItemType extends InteractionWiredCondition {
                 total += chest.getContents().count(ChestStorage.KIND_FURNI, this.baseItemId);
             }
         }
-        return total >= this.amount;
+        return WiredComparison.compare(total, this.amount, this.comparison);
     }
 
     @Deprecated
@@ -64,6 +66,7 @@ public class WiredConditionChestHasItemType extends InteractionWiredCondition {
         int[] params = settings.getIntParams();
         this.baseItemId = (params.length > 0) ? params[0] : 0;
         this.amount = (params.length > 1) ? Math.max(1, params[1]) : 1;
+        this.comparison = (params.length > 2) ? WiredComparison.normalize(params[2]) : WiredComparison.GREATER_EQUAL;
 
         this.chestIds.clear();
         if (settings.getFurniIds() != null) {
@@ -81,7 +84,7 @@ public class WiredConditionChestHasItemType extends InteractionWiredCondition {
 
     @Override
     public String getWiredData() {
-        return WiredManager.getGson().toJson(new JsonData(this.baseItemId, this.amount, this.chestIds));
+        return WiredManager.getGson().toJson(new JsonData(this.baseItemId, this.amount, this.comparison, this.chestIds));
     }
 
     @Override
@@ -96,6 +99,7 @@ public class WiredConditionChestHasItemType extends InteractionWiredCondition {
 
         this.baseItemId = data.baseItemId;
         this.amount = Math.max(1, data.amount);
+        this.comparison = WiredComparison.normalize(data.comparison);
         if (data.chestIds != null) {
             this.chestIds.addAll(data.chestIds);
         }
@@ -112,9 +116,10 @@ public class WiredConditionChestHasItemType extends InteractionWiredCondition {
         message.appendInt(this.getBaseItem().getSpriteId());
         message.appendInt(this.getId());
         message.appendString("");
-        message.appendInt(2);
+        message.appendInt(3);
         message.appendInt(this.baseItemId);
         message.appendInt(this.amount);
+        message.appendInt(this.comparison);
         message.appendInt(0);
         message.appendInt(this.getType().code);
         message.appendInt(0);
@@ -126,16 +131,19 @@ public class WiredConditionChestHasItemType extends InteractionWiredCondition {
         this.chestIds.clear();
         this.baseItemId = 0;
         this.amount = 1;
+        this.comparison = WiredComparison.GREATER_EQUAL;
     }
 
     static class JsonData {
         int baseItemId;
         int amount;
+        int comparison;
         List<Integer> chestIds;
 
-        public JsonData(int baseItemId, int amount, List<Integer> chestIds) {
+        public JsonData(int baseItemId, int amount, int comparison, List<Integer> chestIds) {
             this.baseItemId = baseItemId;
             this.amount = amount;
+            this.comparison = comparison;
             this.chestIds = chestIds;
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionChestHasItems.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionChestHasItems.java
@@ -1,0 +1,134 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredConditionType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Chest Has X Items (furni classname {@code wf_cnd_chest_has_items}). Passes when the total contents
+ * (currency + furni) of the selected {@link InteractionWiredChest}(s) is at least {@code amount}.
+ */
+public class WiredConditionChestHasItems extends InteractionWiredCondition {
+    public static final WiredConditionType type = WiredConditionType.CHEST_HAS_ITEMS;
+
+    private final List<Integer> chestIds = new ArrayList<>();
+    private int amount = 1;
+
+    public WiredConditionChestHasItems(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredConditionChestHasItems(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean evaluate(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) return false;
+
+        int total = 0;
+        for (Integer id : this.chestIds) {
+            HabboItem item = room.getHabboItem(id);
+            if (item instanceof InteractionWiredChest chest) {
+                total += chest.getContents().total(ChestStorage.KIND_CURRENCY) + chest.getContents().total(ChestStorage.KIND_FURNI);
+            }
+        }
+        return total >= this.amount;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        int[] params = settings.getIntParams();
+        this.amount = (params.length > 0) ? Math.max(0, params[0]) : 1;
+
+        this.chestIds.clear();
+        if (settings.getFurniIds() != null) {
+            for (int id : settings.getFurniIds()) {
+                this.chestIds.add(id);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public WiredConditionType getType() {
+        return type;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.amount, this.chestIds));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) return;
+
+        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        if (data == null) return;
+
+        this.amount = Math.max(0, data.amount);
+        if (data.chestIds != null) {
+            this.chestIds.addAll(data.chestIds);
+        }
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.chestIds.size());
+        for (Integer id : this.chestIds) {
+            message.appendInt(id);
+        }
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.amount);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.chestIds.clear();
+        this.amount = 1;
+    }
+
+    static class JsonData {
+        int amount;
+        List<Integer> chestIds;
+
+        public JsonData(int amount, List<Integer> chestIds) {
+            this.amount = amount;
+            this.chestIds = chestIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionChestHasItems.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionChestHasItems.java
@@ -2,6 +2,7 @@ package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
 
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredComparison;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
@@ -27,6 +28,7 @@ public class WiredConditionChestHasItems extends InteractionWiredCondition {
 
     private final List<Integer> chestIds = new ArrayList<>();
     private int amount = 1;
+    private int comparison = WiredComparison.GREATER_EQUAL;
 
     public WiredConditionChestHasItems(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
@@ -48,7 +50,7 @@ public class WiredConditionChestHasItems extends InteractionWiredCondition {
                 total += chest.getContents().total(ChestStorage.KIND_CURRENCY) + chest.getContents().total(ChestStorage.KIND_FURNI);
             }
         }
-        return total >= this.amount;
+        return WiredComparison.compare(total, this.amount, this.comparison);
     }
 
     @Deprecated
@@ -61,6 +63,7 @@ public class WiredConditionChestHasItems extends InteractionWiredCondition {
     public boolean saveData(WiredSettings settings) {
         int[] params = settings.getIntParams();
         this.amount = (params.length > 0) ? Math.max(0, params[0]) : 1;
+        this.comparison = (params.length > 1) ? WiredComparison.normalize(params[1]) : WiredComparison.GREATER_EQUAL;
 
         this.chestIds.clear();
         if (settings.getFurniIds() != null) {
@@ -78,7 +81,7 @@ public class WiredConditionChestHasItems extends InteractionWiredCondition {
 
     @Override
     public String getWiredData() {
-        return WiredManager.getGson().toJson(new JsonData(this.amount, this.chestIds));
+        return WiredManager.getGson().toJson(new JsonData(this.amount, this.comparison, this.chestIds));
     }
 
     @Override
@@ -92,6 +95,7 @@ public class WiredConditionChestHasItems extends InteractionWiredCondition {
         if (data == null) return;
 
         this.amount = Math.max(0, data.amount);
+        this.comparison = WiredComparison.normalize(data.comparison);
         if (data.chestIds != null) {
             this.chestIds.addAll(data.chestIds);
         }
@@ -108,8 +112,9 @@ public class WiredConditionChestHasItems extends InteractionWiredCondition {
         message.appendInt(this.getBaseItem().getSpriteId());
         message.appendInt(this.getId());
         message.appendString("");
-        message.appendInt(1);
+        message.appendInt(2);
         message.appendInt(this.amount);
+        message.appendInt(this.comparison);
         message.appendInt(0);
         message.appendInt(this.getType().code);
         message.appendInt(0);
@@ -120,14 +125,17 @@ public class WiredConditionChestHasItems extends InteractionWiredCondition {
     public void onPickUp() {
         this.chestIds.clear();
         this.amount = 1;
+        this.comparison = WiredComparison.GREATER_EQUAL;
     }
 
     static class JsonData {
         int amount;
+        int comparison;
         List<Integer> chestIds;
 
-        public JsonData(int amount, List<Integer> chestIds) {
+        public JsonData(int amount, int comparison, List<Integer> chestIds) {
             this.amount = amount;
+            this.comparison = comparison;
             this.chestIds = chestIds;
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredContract.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredContract.java
@@ -1,0 +1,179 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.contract;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Base for gen-3 / Origins wired CONTRACT furni (config-holders, NOT stack add-ons). A contract holds
+ * only the TERMS of a transaction — a list of currency {@link Term}s (PAY = debit the user, RECEIVE =
+ * credit the user) plus optional linked chest(s) used as the deposit sink (PAY) / source pool (RECEIVE).
+ * Contracts never execute on their own; they are selected and EXECUTED atomically by the upgraded
+ * {@code WiredEffectInitTransaction}.
+ *
+ * <p>Concrete subclasses (payment / reward / trade / custom) differ only in their client dialog
+ * {@link #contractCode()} — the wire + persistence shape is identical so Init Transaction reads them
+ * uniformly. Currency-only v1 (credits {@code type<0} / points {@code type>=0}); furni terms are a
+ * future extension (the existing give-furni-from-chest primitive covers furni rewards meanwhile).</p>
+ */
+public abstract class InteractionWiredContract extends InteractionWiredExtra {
+    public static final int DIR_PAY = 0;
+    public static final int DIR_RECEIVE = 1;
+
+    private static final int MAX_TERMS = 8;
+
+    protected final List<Term> terms = new ArrayList<>();
+    protected final List<Integer> chestIds = new ArrayList<>();
+
+    protected InteractionWiredContract(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    protected InteractionWiredContract(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    /** The client {@code WiredActionLayoutCode} for this contract's dialog (110-113). */
+    protected abstract int contractCode();
+
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
+    }
+
+    @Override
+    public boolean hasConfiguration() {
+        return true;
+    }
+
+    public List<Term> getTerms() {
+        return this.terms;
+    }
+
+    public List<Integer> getChestIds() {
+        return this.chestIds;
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+
+        this.terms.clear();
+        if (params.length > 0) {
+            int count = Math.max(0, Math.min(MAX_TERMS, params[0]));
+            for (int i = 0; i < count; i++) {
+                int base = 1 + (i * 3);
+                if (base + 2 >= params.length) break;
+                int dir = (params[base] == DIR_RECEIVE) ? DIR_RECEIVE : DIR_PAY;
+                int type = params[base + 1];
+                int amount = Math.max(0, params[base + 2]);
+                if (amount > 0) this.terms.add(new Term(dir, type, amount));
+            }
+        }
+
+        this.chestIds.clear();
+        if (settings.getFurniIds() != null) {
+            for (int id : settings.getFurniIds()) this.chestIds.add(id);
+        }
+
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.terms, this.chestIds));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) return;
+
+        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        if (data == null) return;
+
+        if (data.terms != null) {
+            for (Term t : data.terms) {
+                if (t != null && t.amount > 0) this.terms.add(t);
+            }
+        }
+        if (data.chestIds != null) this.chestIds.addAll(data.chestIds);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.chestIds.size());
+        for (Integer id : this.chestIds) message.appendInt(id);
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+
+        message.appendInt(1 + (this.terms.size() * 3));
+        message.appendInt(this.terms.size());
+        for (Term t : this.terms) {
+            message.appendInt(t.direction);
+            message.appendInt(t.currencyType);
+            message.appendInt(t.amount);
+        }
+
+        message.appendInt(0);
+        message.appendInt(this.contractCode());
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.terms.clear();
+        this.chestIds.clear();
+    }
+
+    /** A single currency term. {@code currencyType}: -1 = credits, >=0 = points/seasonal type. */
+    public static class Term {
+        public int direction;
+        public int currencyType;
+        public int amount;
+
+        public Term() {
+        }
+
+        public Term(int direction, int currencyType, int amount) {
+            this.direction = direction;
+            this.currencyType = currencyType;
+            this.amount = amount;
+        }
+    }
+
+    static class JsonData {
+        List<Term> terms;
+        List<Integer> chestIds;
+
+        JsonData() {
+        }
+
+        JsonData(List<Term> terms, List<Integer> chestIds) {
+            this.terms = terms;
+            this.chestIds = chestIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredContractPayment.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredContractPayment.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.contract;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Payment Contract ({@code wf_contract_payment}) — configures what the triggering user must PAY for a
+ * transaction to pass (currency debited from the user, optionally deposited into a linked chest).
+ * Dialog code 110. Pure terms; executed by Init Transaction.
+ */
+public class InteractionWiredContractPayment extends InteractionWiredContract {
+    public static final int CODE = 110;
+
+    public InteractionWiredContractPayment(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionWiredContractPayment(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    protected int contractCode() {
+        return CODE;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredContractReward.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredContractReward.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.contract;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Reward Contract ({@code wf_contract_reward}) — configures what the user RECEIVES when a transaction
+ * completes (currency credited to the user, sourced from a linked chest pool). Dialog code 111.
+ * Pure terms; executed by Init Transaction.
+ */
+public class InteractionWiredContractReward extends InteractionWiredContract {
+    public static final int CODE = 111;
+
+    public InteractionWiredContractReward(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionWiredContractReward(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    protected int contractCode() {
+        return CODE;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredContractTrade.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredContractTrade.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.contract;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Trade Contract ({@code wf_contract_trade}) — an atomic exchange: the user PAYS one side and RECEIVES
+ * the other in a single transaction (cost in / return out, both committed together or not at all).
+ * Dialog code 112. Pure terms; executed atomically by Init Transaction.
+ */
+public class InteractionWiredContractTrade extends InteractionWiredContract {
+    public static final int CODE = 112;
+
+    public InteractionWiredContractTrade(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionWiredContractTrade(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    protected int contractCode() {
+        return CODE;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredCustomContract.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/contract/InteractionWiredCustomContract.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.contract;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Custom Contract add-on ({@code wf_xtra_custom_contract}) — the free-form "power user" contract: an
+ * arbitrary mix of PAY / RECEIVE currency terms in one box (superset of payment/reward/trade). Dialog
+ * code 113. Same term/persistence shape as the fixed contracts; executed atomically by Init Transaction.
+ */
+public class InteractionWiredCustomContract extends InteractionWiredContract {
+    public static final int CODE = 113;
+
+    public InteractionWiredCustomContract(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionWiredCustomContract(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    protected int contractCode() {
+        return CODE;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectCancelTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectCancelTransaction.java
@@ -1,0 +1,109 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Cancel Transaction (furni classname {@code wf_act_cancel_transaction}). v1 (outcome-signal model):
+ * raises a {@link WiredEvent.Type#TRANSACTION_FAIL} event in the room, firing every
+ * {@code wf_trg_transaction_fail} trigger (the "failure/rollback" branch). Pair with
+ * {@code wf_act_init_transaction} for the success branch.
+ */
+public class WiredEffectCancelTransaction extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.CANCEL_TRANSACTION;
+
+    public WiredEffectCancelTransaction(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectCancelTransaction(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null || room.getLayout() == null) return;
+
+        RoomTile tile = room.getLayout().getTile(this.getX(), this.getY());
+        WiredEvent.Builder builder = WiredEvent.builder(WiredEvent.Type.TRANSACTION_FAIL, room).sourceItem(this);
+        if (tile != null) builder.tile(tile);
+        ctx.actor().ifPresent(builder::actor);
+
+        WiredManager.dispatchEffectTriggeredEvent(builder.build());
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        this.setDelay(settings.getDelay());
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.getDelay()));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.setDelay(0);
+        String wiredData = set.getString("wired_data");
+        if (wiredData != null && wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            if (data != null) this.setDelay(data.delay);
+        }
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.setDelay(0);
+    }
+
+    static class JsonData {
+        int delay;
+
+        public JsonData(int delay) {
+            this.delay = delay;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveCurrencyFromChest.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveCurrencyFromChest.java
@@ -1,0 +1,190 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Give Currency From Chest (furni classname {@code wf_act_give_currency}). Dispenses up to
+ * {@code amount} currency from a selected {@link InteractionWiredChest} to the resolved user(s),
+ * decrementing and persisting the chest pool. If the chest is empty nothing is given. Safe: it only
+ * grants what the chest actually holds (no minting beyond the configured pool).
+ */
+public class WiredEffectGiveCurrencyFromChest extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.GIVE_CURRENCY_FROM_CHEST;
+
+    private final List<Integer> chestIds = new ArrayList<>();
+    private int amount = 0;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveCurrencyFromChest(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveCurrencyFromChest(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null || this.amount <= 0) return;
+
+        InteractionWiredChest chest = this.resolveChest(room);
+        if (chest == null) return;
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null) continue;
+
+            ChestStorage contents = chest.getContents();
+            // Take from the first currency entry that still has stock.
+            for (ChestStorage.Entry entry : new ArrayList<>(contents.entries())) {
+                if (entry.kind != ChestStorage.KIND_CURRENCY) continue;
+
+                int given = contents.take(ChestStorage.KIND_CURRENCY, entry.type, this.amount);
+                if (given > 0) {
+                    grant(habbo, entry.type, given);
+                    chest.persistContents();
+                }
+                break;
+            }
+        }
+    }
+
+    private InteractionWiredChest resolveChest(Room room) {
+        for (Integer id : this.chestIds) {
+            HabboItem item = room.getHabboItem(id);
+            if (item instanceof InteractionWiredChest chest) {
+                return chest;
+            }
+        }
+        return null;
+    }
+
+    private static void grant(Habbo habbo, int currencyType, int amount) {
+        if (currencyType < 0) {
+            habbo.giveCredits(amount);
+        } else {
+            habbo.givePoints(currencyType, amount);
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        if (params.length < 2) throw new WiredSaveException("invalid data");
+
+        this.amount = Math.max(0, params[0]);
+        this.userSource = params[1];
+
+        this.chestIds.clear();
+        if (settings.getFurniIds() != null) {
+            for (int id : settings.getFurniIds()) {
+                this.chestIds.add(id);
+            }
+        }
+
+        this.setDelay(settings.getDelay());
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.amount, this.userSource, this.getDelay(), this.chestIds));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) return;
+
+        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        if (data == null) return;
+
+        this.amount = Math.max(0, data.amount);
+        this.userSource = data.userSource;
+        this.setDelay(data.delay);
+        if (data.chestIds != null) {
+            this.chestIds.addAll(data.chestIds);
+        }
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.chestIds.size());
+        for (Integer id : this.chestIds) {
+            message.appendInt(id);
+        }
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.amount);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.chestIds.clear();
+        this.amount = 0;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        int amount;
+        int userSource;
+        int delay;
+        List<Integer> chestIds;
+
+        public JsonData(int amount, int userSource, int delay, List<Integer> chestIds) {
+            this.amount = amount;
+            this.userSource = userSource;
+            this.delay = delay;
+            this.chestIds = chestIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveFurniFromChest.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveFurniFromChest.java
@@ -1,0 +1,192 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Give Furni From Chest (furni classname {@code wf_act_give_furni}). Dispenses up to {@code amount}
+ * copies of the selected {@link InteractionWiredChest}'s stored furni type to the resolved user(s),
+ * decrementing + persisting the chest. Never gives more than the chest holds.
+ */
+public class WiredEffectGiveFurniFromChest extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.GIVE_FURNI_FROM_CHEST;
+
+    private final List<Integer> chestIds = new ArrayList<>();
+    private int amount = 1;
+    private int userSource = WiredSourceUtil.SOURCE_TRIGGER;
+
+    public WiredEffectGiveFurniFromChest(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectGiveFurniFromChest(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null || this.amount <= 0) return;
+
+        InteractionWiredChest chest = this.resolveChest(room);
+        if (chest == null) return;
+
+        for (RoomUnit unit : WiredSourceUtil.resolveUsers(ctx, this.userSource)) {
+            Habbo habbo = room.getHabbo(unit);
+            if (habbo == null || habbo.getClient() == null) continue;
+
+            ChestStorage contents = chest.getContents();
+            for (ChestStorage.Entry entry : new ArrayList<>(contents.entries())) {
+                if (entry.kind != ChestStorage.KIND_FURNI) continue;
+
+                Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(entry.type);
+                if (baseItem == null) break;
+
+                int given = contents.take(ChestStorage.KIND_FURNI, entry.type, this.amount);
+                if (given > 0) {
+                    for (int i = 0; i < given; i++) {
+                        HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getHabboInfo().getId(), baseItem, 0, 0, "");
+                        if (created == null) continue;
+                        habbo.getClient().sendResponse(new AddHabboItemComposer(created));
+                        habbo.getInventory().getItemsComponent().addItem(created);
+                    }
+                    habbo.getClient().sendResponse(new InventoryRefreshComposer());
+                    chest.persistContents();
+                }
+                break;
+            }
+        }
+    }
+
+    private InteractionWiredChest resolveChest(Room room) {
+        for (Integer id : this.chestIds) {
+            HabboItem item = room.getHabboItem(id);
+            if (item instanceof InteractionWiredChest chest) {
+                return chest;
+            }
+        }
+        return null;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        if (params.length < 2) throw new WiredSaveException("invalid data");
+
+        this.amount = Math.max(1, params[0]);
+        this.userSource = params[1];
+
+        this.chestIds.clear();
+        if (settings.getFurniIds() != null) {
+            for (int id : settings.getFurniIds()) {
+                this.chestIds.add(id);
+            }
+        }
+
+        this.setDelay(settings.getDelay());
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.amount, this.userSource, this.getDelay(), this.chestIds));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) return;
+
+        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        if (data == null) return;
+
+        this.amount = Math.max(1, data.amount);
+        this.userSource = data.userSource;
+        this.setDelay(data.delay);
+        if (data.chestIds != null) {
+            this.chestIds.addAll(data.chestIds);
+        }
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.chestIds.size());
+        for (Integer id : this.chestIds) {
+            message.appendInt(id);
+        }
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.amount);
+        message.appendInt(this.userSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.chestIds.clear();
+        this.amount = 1;
+        this.userSource = WiredSourceUtil.SOURCE_TRIGGER;
+        this.setDelay(0);
+    }
+
+    @Override
+    public boolean requiresTriggeringUser() {
+        return this.userSource == WiredSourceUtil.SOURCE_TRIGGER;
+    }
+
+    static class JsonData {
+        int amount;
+        int userSource;
+        int delay;
+        List<Integer> chestIds;
+
+        public JsonData(int amount, int userSource, int delay, List<Integer> chestIds) {
+            this.amount = amount;
+            this.userSource = userSource;
+            this.delay = delay;
+            this.chestIds = chestIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectInitTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectInitTransaction.java
@@ -1,0 +1,262 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.items.interactions.wired.contract.InteractionWiredContract;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Initiate Transaction (furni classname {@code wf_act_init_transaction}). Selects one or more wired
+ * CONTRACT furni ({@link InteractionWiredContract}) and executes their terms against the triggering
+ * user as ONE atomic unit: it pre-checks EVERY term (user balance for PAY, chest stock for chest-sourced
+ * RECEIVE) and only then mutates — so a transaction either fully happens or nothing changes. On success
+ * it raises {@link WiredEvent.Type#TRANSACTION_COMPLETE} (the success branch); on any unsatisfiable
+ * precondition it raises {@link WiredEvent.Type#TRANSACTION_FAIL} and commits nothing.
+ *
+ * <p>Atomicity is achieved synchronously on the room's single-threaded wired tick (compute all
+ * preconditions first, mutate last). With NO contracts selected it degrades to the v1 signal model
+ * (fires COMPLETE) for backward compatibility. Currency-only v1 (credits/points); the asset source/sink
+ * is the existing config-based wired chest ({@link InteractionWiredChest}).</p>
+ */
+public class WiredEffectInitTransaction extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.INIT_TRANSACTION;
+
+    private final List<Integer> contractIds = new ArrayList<>();
+
+    public WiredEffectInitTransaction(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectInitTransaction(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null || room.getLayout() == null) return;
+
+        List<InteractionWiredContract> contracts = new ArrayList<>();
+        for (Integer id : this.contractIds) {
+            HabboItem item = room.getHabboItem(id);
+            if (item instanceof InteractionWiredContract contract) contracts.add(contract);
+        }
+
+        // No contracts → v1 signal behaviour (fire COMPLETE unconditionally).
+        if (contracts.isEmpty()) {
+            this.fire(ctx, room, WiredEvent.Type.TRANSACTION_COMPLETE);
+            return;
+        }
+
+        // Contracts require a triggering user to charge/reward.
+        Habbo actor = ctx.actor().map(room::getHabbo).orElse(null);
+        if (actor == null) {
+            this.fire(ctx, room, WiredEvent.Type.TRANSACTION_FAIL);
+            return;
+        }
+
+        // --- Aggregate (cumulative, so multiple terms of the same currency can't bypass the check) ---
+        Map<Integer, Long> payTotal = new HashMap<>();                  // currencyType -> total to debit
+        Map<Integer, InteractionWiredChest> chestById = new HashMap<>();
+        Map<Integer, Map<Integer, Long>> chestTakeTotal = new HashMap<>(); // chestId -> (currencyType -> total to take)
+
+        for (InteractionWiredContract contract : contracts) {
+            InteractionWiredChest chest = this.resolveChest(room, contract.getChestIds());
+            if (chest != null) chestById.put(chest.getId(), chest);
+
+            for (InteractionWiredContract.Term term : contract.getTerms()) {
+                if (term.amount <= 0) continue;
+
+                if (term.direction == InteractionWiredContract.DIR_PAY) {
+                    payTotal.merge(term.currencyType, (long) term.amount, Long::sum);
+                } else if (chest != null) {
+                    chestTakeTotal
+                            .computeIfAbsent(chest.getId(), k -> new HashMap<>())
+                            .merge(term.currencyType, (long) term.amount, Long::sum);
+                }
+                // RECEIVE without a linked chest = direct mint (no precondition needed).
+            }
+        }
+
+        // --- Pre-check: nothing is mutated yet ---
+        for (Map.Entry<Integer, Long> entry : payTotal.entrySet()) {
+            if (balance(actor, entry.getKey()) < entry.getValue()) {
+                this.fire(ctx, room, WiredEvent.Type.TRANSACTION_FAIL);
+                return;
+            }
+        }
+        for (Map.Entry<Integer, Map<Integer, Long>> chestEntry : chestTakeTotal.entrySet()) {
+            InteractionWiredChest chest = chestById.get(chestEntry.getKey());
+            if (chest == null) {
+                this.fire(ctx, room, WiredEvent.Type.TRANSACTION_FAIL);
+                return;
+            }
+            for (Map.Entry<Integer, Long> typeEntry : chestEntry.getValue().entrySet()) {
+                if (chest.getContents().count(ChestStorage.KIND_CURRENCY, typeEntry.getKey()) < typeEntry.getValue()) {
+                    this.fire(ctx, room, WiredEvent.Type.TRANSACTION_FAIL);
+                    return;
+                }
+            }
+        }
+
+        // --- Commit: all preconditions passed ---
+        for (InteractionWiredContract contract : contracts) {
+            InteractionWiredChest chest = this.resolveChest(room, contract.getChestIds());
+            boolean chestDirty = false;
+
+            for (InteractionWiredContract.Term term : contract.getTerms()) {
+                if (term.amount <= 0) continue;
+
+                if (term.direction == InteractionWiredContract.DIR_PAY) {
+                    debit(actor, term.currencyType, term.amount);
+                    if (chest != null) {
+                        chest.getContents().add(ChestStorage.KIND_CURRENCY, term.currencyType, term.amount);
+                        chestDirty = true;
+                    }
+                } else {
+                    if (chest != null) {
+                        chest.getContents().take(ChestStorage.KIND_CURRENCY, term.currencyType, term.amount);
+                        chestDirty = true;
+                    }
+                    credit(actor, term.currencyType, term.amount);
+                }
+            }
+
+            if (chestDirty && chest != null) chest.persistContents();
+        }
+
+        this.fire(ctx, room, WiredEvent.Type.TRANSACTION_COMPLETE);
+    }
+
+    private InteractionWiredChest resolveChest(Room room, List<Integer> ids) {
+        if (ids == null) return null;
+        for (Integer id : ids) {
+            HabboItem item = room.getHabboItem(id);
+            if (item instanceof InteractionWiredChest chest) return chest;
+        }
+        return null;
+    }
+
+    private static int balance(Habbo habbo, int currencyType) {
+        return (currencyType < 0)
+                ? habbo.getHabboInfo().getCredits()
+                : habbo.getHabboInfo().getCurrencyAmount(currencyType);
+    }
+
+    private static void debit(Habbo habbo, int currencyType, int amount) {
+        if (currencyType < 0) {
+            habbo.giveCredits(-amount);
+        } else {
+            habbo.givePoints(currencyType, -amount);
+        }
+    }
+
+    private static void credit(Habbo habbo, int currencyType, int amount) {
+        if (currencyType < 0) {
+            habbo.giveCredits(amount);
+        } else {
+            habbo.givePoints(currencyType, amount);
+        }
+    }
+
+    private void fire(WiredContext ctx, Room room, WiredEvent.Type eventType) {
+        RoomTile tile = (room.getLayout() != null) ? room.getLayout().getTile(this.getX(), this.getY()) : null;
+        WiredEvent.Builder builder = WiredEvent.builder(eventType, room).sourceItem(this);
+        if (tile != null) builder.tile(tile);
+        ctx.actor().ifPresent(builder::actor);
+        WiredManager.dispatchEffectTriggeredEvent(builder.build());
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        this.contractIds.clear();
+        if (settings.getFurniIds() != null) {
+            for (int id : settings.getFurniIds()) this.contractIds.add(id);
+        }
+        this.setDelay(settings.getDelay());
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.getDelay(), this.contractIds));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) return;
+
+        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        if (data == null) return;
+
+        this.setDelay(data.delay);
+        if (data.contractIds != null) this.contractIds.addAll(data.contractIds);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.contractIds.size());
+        for (Integer id : this.contractIds) message.appendInt(id);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.contractIds.clear();
+        this.setDelay(0);
+    }
+
+    static class JsonData {
+        int delay;
+        List<Integer> contractIds;
+
+        public JsonData(int delay, List<Integer> contractIds) {
+            this.delay = delay;
+            this.contractIds = contractIds;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectPlaceFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectPlaceFurni.java
@@ -1,0 +1,214 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.FurnitureMovementError;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomTile;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Spawns ("builds") a fresh floor furni into the room when the stack fires — the in-room analogue of
+ * {@link WiredEffectGiveOrTakeFurni} (which mints into a user's inventory). The furni is a freshly minted,
+ * persisted item owned by the ROOM OWNER, placed either on this effect furni's own tile or at a stored x/y.
+ *
+ * <p>Carries six ints — {@code [baseItemId, quantity, placementMode, storedX, storedY, rotation]} — and so needs the
+ * matching Nitro {@code WiredActionLayoutCode.PLACE_FURNI} (106) dialog. Each fire is capped (quantity 1..10) and the
+ * room's furniture ceiling is honoured so a repeater trigger + place loop cannot flood/OOM the room.</p>
+ */
+public class WiredEffectPlaceFurni extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.PLACE_FURNI;
+
+    public static final int MODE_THIS_TILE = 0;
+    public static final int MODE_STORED_XY = 1;
+
+    private static final int MIN_QUANTITY = 1;
+    private static final int MAX_QUANTITY = 10;
+    private static final int DEFAULT_QUANTITY = 1;
+
+    private int baseItemId = 0;
+    private int quantity = DEFAULT_QUANTITY;
+    private int placementMode = MODE_THIS_TILE;
+    private int storedX = 0;
+    private int storedY = 0;
+    private int rotation = 0;
+
+    public WiredEffectPlaceFurni(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectPlaceFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null || room.getLayout() == null) return;
+
+        Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(this.baseItemId);
+        if (baseItem == null || baseItem.getType() != FurnitureType.FLOOR) return;
+
+        RoomTile tile = (this.placementMode == MODE_STORED_XY)
+                ? room.getLayout().getTile((short) this.storedX, (short) this.storedY)
+                : room.getLayout().getTile(this.getX(), this.getY());
+
+        if (tile == null) return;
+
+        int ceiling = Emulator.getConfig().getInt("hotel.rooms.max.furniture", 2500);
+        Habbo owner = Emulator.getGameEnvironment().getHabboManager().getHabbo(room.getOwnerId());
+
+        for (int i = 0; i < this.quantity; i++) {
+            if (room.getFloorItems().size() >= ceiling) break;
+
+            HabboItem item = Emulator.getGameEnvironment().getItemManager().createItem(room.getOwnerId(), baseItem, 0, 0, "");
+            if (item == null) continue;
+
+            FurnitureMovementError error = room.placeFloorFurniAt(item, tile, this.rotation, owner);
+
+            if (error != FurnitureMovementError.NONE) {
+                // Placement failed (no fit / blocked) — destroy the orphan instead of leaking a roomless item.
+                Emulator.getGameEnvironment().getItemManager().deleteItem(item);
+            }
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(6);
+        message.appendInt(this.baseItemId);
+        message.appendInt(this.quantity);
+        message.appendInt(this.placementMode);
+        message.appendInt(this.storedX);
+        message.appendInt(this.storedY);
+        message.appendInt(this.rotation);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        if (params.length < 6) {
+            throw new WiredSaveException("Invalid data");
+        }
+
+        int nextBaseItemId = params[0];
+        Item base = Emulator.getGameEnvironment().getItemManager().getItem(nextBaseItemId);
+        if (nextBaseItemId <= 0 || base == null || base.getType() != FurnitureType.FLOOR) {
+            throw new WiredSaveException("Invalid furni");
+        }
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+
+        this.baseItemId = nextBaseItemId;
+        this.quantity = clampQuantity(params[1]);
+        this.placementMode = (params[2] == MODE_STORED_XY) ? MODE_STORED_XY : MODE_THIS_TILE;
+        this.storedX = Math.max(0, params[3]);
+        this.storedY = Math.max(0, params[4]);
+        this.rotation = ((params[5] % 8) + 8) % 8;
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    private static int clampQuantity(int value) {
+        return Math.max(MIN_QUANTITY, Math.min(MAX_QUANTITY, value));
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.baseItemId, this.quantity, this.placementMode, this.storedX, this.storedY, this.rotation, this.getDelay()));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData != null && wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.baseItemId = data.baseItemId;
+            this.quantity = clampQuantity(data.quantity);
+            this.placementMode = (data.placementMode == MODE_STORED_XY) ? MODE_STORED_XY : MODE_THIS_TILE;
+            this.storedX = Math.max(0, data.storedX);
+            this.storedY = Math.max(0, data.storedY);
+            this.rotation = ((data.rotation % 8) + 8) % 8;
+            this.setDelay(data.delay);
+        } else {
+            this.baseItemId = 0;
+            this.quantity = DEFAULT_QUANTITY;
+            this.placementMode = MODE_THIS_TILE;
+            this.storedX = 0;
+            this.storedY = 0;
+            this.rotation = 0;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.baseItemId = 0;
+        this.quantity = DEFAULT_QUANTITY;
+        this.placementMode = MODE_THIS_TILE;
+        this.storedX = 0;
+        this.storedY = 0;
+        this.rotation = 0;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        int baseItemId;
+        int quantity;
+        int placementMode;
+        int storedX;
+        int storedY;
+        int rotation;
+        int delay;
+
+        public JsonData(int baseItemId, int quantity, int placementMode, int storedX, int storedY, int rotation, int delay) {
+            this.baseItemId = baseItemId;
+            this.quantity = quantity;
+            this.placementMode = placementMode;
+            this.storedX = storedX;
+            this.storedY = storedY;
+            this.rotation = rotation;
+            this.delay = delay;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectRemoveFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectRemoveFurni.java
@@ -1,0 +1,227 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWired;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.BuildersClubRoomSupport;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Removes the resolved furni from the room when the stack fires — the inverse of {@link WiredEffectPlaceFurni}.
+ * Targets are the builder-selected furni (resolved through {@link WiredSourceUtil#resolveItems}); two modes:
+ * RETURN_TO_INVENTORY (default, non-destructive — picks the item up to its owner's inventory) or DELETE
+ * (permanently destroys it). It never removes WIRED furni or itself (stack-safety) and is bounded per fire.
+ *
+ * <p>Carries two ints — {@code [mode, furniSource]} — plus the furni-id selection block, so it needs the matching
+ * Nitro {@code WiredActionLayoutCode.REMOVE_FURNI} (107) dialog with the room-furni picker.</p>
+ */
+public class WiredEffectRemoveFurni extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.REMOVE_FURNI;
+
+    public static final int MODE_RETURN = 0;
+    public static final int MODE_DELETE = 1;
+
+    private static final int MAX_REMOVE_PER_FIRE = 100;
+
+    private final Set<Integer> selectedItemIds = new HashSet<>();
+    private int mode = MODE_RETURN;
+    private int furniSource = WiredSourceUtil.SOURCE_SELECTED;
+
+    public WiredEffectRemoveFurni(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectRemoveFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) return;
+
+        this.refresh();
+
+        List<HabboItem> selected = new ArrayList<>();
+        for (int id : this.selectedItemIds) {
+            HabboItem it = room.getHabboItem(id);
+            if (it != null) selected.add(it);
+        }
+
+        List<HabboItem> targets = WiredSourceUtil.resolveItems(ctx, this.furniSource, selected);
+        if (targets.isEmpty()) return;
+
+        int removed = 0;
+        for (HabboItem target : targets) {
+            if (target == null) continue;
+            if (target.getId() == this.getId()) continue;       // never remove self
+            if (target instanceof InteractionWired) continue;   // never remove other wired furni (stack-safety)
+            if (target.getRoomId() != room.getId()) continue;   // only items currently in this room
+            if (removed >= MAX_REMOVE_PER_FIRE) break;
+
+            if (this.mode == MODE_DELETE) {
+                room.pickUpItem(target, null);
+                Emulator.getGameEnvironment().getItemManager().deleteItem(target);
+            } else {
+                int ownerId = target.getUserId();
+                Habbo ownerHabbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(ownerId);
+                boolean tracked = BuildersClubRoomSupport.isTrackedItem(target.getId());
+
+                room.pickUpItem(target, ownerHabbo);
+
+                if (ownerHabbo != null && ownerHabbo.getClient() != null && !tracked) {
+                    ownerHabbo.getInventory().getItemsComponent().addItem(target);
+                    ownerHabbo.getClient().sendResponse(new AddHabboItemComposer(target));
+                    ownerHabbo.getClient().sendResponse(new InventoryRefreshComposer());
+                }
+            }
+
+            removed++;
+        }
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        this.refresh();
+
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(this.selectedItemIds.size());
+
+        for (int id : this.selectedItemIds) {
+            message.appendInt(id);
+        }
+
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.mode);
+        message.appendInt(this.furniSource);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        int[] params = settings.getIntParams();
+        this.mode = (params.length > 0 && params[0] == MODE_DELETE) ? MODE_DELETE : MODE_RETURN;
+        this.furniSource = (params.length > 1) ? params[1] : WiredSourceUtil.SOURCE_SELECTED;
+
+        Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+        if (room == null) {
+            throw new WiredSaveException("Trying to save wired in unloaded room");
+        }
+
+        int itemsCount = settings.getFurniIds().length;
+        if (itemsCount > Emulator.getConfig().getInt("hotel.wired.furni.selection.count")) {
+            throw new WiredSaveException("Too many furni selected");
+        }
+
+        this.selectedItemIds.clear();
+        for (int i = 0; i < itemsCount; i++) {
+            int itemId = settings.getFurniIds()[i];
+            HabboItem it = room.getHabboItem(itemId);
+            if (it == null) {
+                throw new WiredSaveException(String.format("Item %s not found", itemId));
+            }
+            this.selectedItemIds.add(itemId);
+        }
+
+        int delay = settings.getDelay();
+        if (delay > Emulator.getConfig().getInt("hotel.wired.max_delay", 20)) {
+            throw new WiredSaveException("Delay too long");
+        }
+        this.setDelay(delay);
+
+        return true;
+    }
+
+    private void refresh() {
+        Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(this.getRoomId());
+        if (room != null && room.isLoaded()) {
+            this.selectedItemIds.removeIf(id -> room.getHabboItem(id) == null);
+        }
+    }
+
+    @Override
+    public String getWiredData() {
+        this.refresh();
+        return WiredManager.getGson().toJson(new JsonData(new ArrayList<>(this.selectedItemIds), this.mode, this.furniSource, this.getDelay()));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        String wiredData = set.getString("wired_data");
+
+        if (wiredData != null && wiredData.startsWith("{")) {
+            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            this.selectedItemIds.clear();
+            if (data.items != null) this.selectedItemIds.addAll(data.items);
+            this.mode = (data.mode == MODE_DELETE) ? MODE_DELETE : MODE_RETURN;
+            this.furniSource = data.furniSource;
+            this.setDelay(data.delay);
+        } else {
+            this.selectedItemIds.clear();
+            this.mode = MODE_RETURN;
+            this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+            this.setDelay(0);
+        }
+    }
+
+    @Override
+    public void onPickUp() {
+        this.selectedItemIds.clear();
+        this.mode = MODE_RETURN;
+        this.furniSource = WiredSourceUtil.SOURCE_SELECTED;
+        this.setDelay(0);
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    static class JsonData {
+        List<Integer> items;
+        int mode;
+        int furniSource;
+        int delay;
+
+        public JsonData(List<Integer> items, int mode, int furniSource, int delay) {
+            this.items = items;
+            this.mode = mode;
+            this.furniSource = furniSource;
+            this.delay = delay;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraQuest.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraQuest.java
@@ -1,0 +1,69 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.extra;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Quest box ({@code wf_var_quest}, dialog code 108). Exposes derived read-only sub-variables of its
+ * co-located base counter against a configured target:
+ * {@code progress, target, is_complete, percent, remaining}.
+ */
+public class WiredExtraQuest extends WiredExtraQuestBase {
+    public static final int CODE = 108;
+
+    public static final int SUB_PROGRESS = 0;
+    public static final int SUB_TARGET = 1;
+    public static final int SUB_IS_COMPLETE = 2;
+    public static final int SUB_PERCENT = 3;
+    public static final int SUB_REMAINING = 4;
+    public static final int SUBVARIABLE_COUNT = 5;
+
+    public WiredExtraQuest(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredExtraQuest(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    protected int code() {
+        return CODE;
+    }
+
+    @Override
+    public int subvariableCount() {
+        return SUBVARIABLE_COUNT;
+    }
+
+    @Override
+    public String subvariableKey(int subType) {
+        return switch (subType) {
+            case SUB_PROGRESS -> "progress";
+            case SUB_TARGET -> "target";
+            case SUB_IS_COMPLETE -> "is_complete";
+            case SUB_PERCENT -> "percent";
+            case SUB_REMAINING -> "remaining";
+            default -> "value";
+        };
+    }
+
+    @Override
+    public Integer derive(int subType, Integer baseValue) {
+        if (baseValue == null) return null;
+
+        int progress = Math.max(0, baseValue);
+        int target = Math.max(0, this.targetValue);
+
+        return switch (subType) {
+            case SUB_PROGRESS -> progress;
+            case SUB_TARGET -> target;
+            case SUB_IS_COMPLETE -> (target > 0 && progress >= target) ? 1 : 0;
+            case SUB_PERCENT -> (target <= 0) ? 100 : Math.max(0, Math.min(100, (int) Math.floor((progress * 100D) / target)));
+            case SUB_REMAINING -> Math.max(0, target - progress);
+            default -> null;
+        };
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraQuestBase.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraQuestBase.java
@@ -1,0 +1,129 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.extra;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.wired.core.WiredDerivedVariableBox;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Base for the gen-3 Wired 2.0 QUEST boxes ({@code wf_var_quest} / {@code wf_var_quest_chain}). A quest
+ * box is a variable-definition add-on (config-holder, like the level-up box): placed on the SAME stack as
+ * a base counter variable, it exposes DERIVED read-only sub-variables (progress / is_complete / …)
+ * computed from that counter against a configured {@code targetValue}. Completion is detected for free via
+ * the existing {@code VARIABLE_CHANGED} event on the backing counter.
+ *
+ * <p>Subclasses define the dialog {@link #code()} and the derived sub-variable set + formulas. All
+ * sub-variables are always exposed (no selection UI in v1). Config = a single {@code targetValue} int.</p>
+ */
+public abstract class WiredExtraQuestBase extends InteractionWiredExtra implements WiredDerivedVariableBox {
+    protected int targetValue = 0;
+
+    protected WiredExtraQuestBase(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    protected WiredExtraQuestBase(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    /** Client {@code WiredActionLayoutCode} for this box's dialog (108 quest / 109 quest-chain). */
+    protected abstract int code();
+
+    /** Number of derived sub-variables this box exposes. */
+    public abstract int subvariableCount();
+
+    public int getTargetValue() {
+        return this.targetValue;
+    }
+
+    @Override
+    public List<Integer> getSelectedSubvariables() {
+        List<Integer> result = new ArrayList<>();
+        for (int i = 0; i < this.subvariableCount(); i++) result.add(i);
+        return result;
+    }
+
+    @Override
+    public boolean hasSubvariable(int subType) {
+        return subType >= 0 && subType < this.subvariableCount();
+    }
+
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) {
+    }
+
+    @Override
+    public boolean hasConfiguration() {
+        return true;
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int[] params = settings.getIntParams();
+        this.targetValue = (params.length > 0) ? Math.max(0, params[0]) : 0;
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.targetValue));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) return;
+
+        JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        if (data != null) this.targetValue = Math.max(0, data.targetValue);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(1);
+        message.appendInt(this.targetValue);
+        message.appendInt(0);
+        message.appendInt(this.code());
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public void onPickUp() {
+        this.targetValue = 0;
+    }
+
+    static class JsonData {
+        int targetValue;
+
+        JsonData() {
+        }
+
+        JsonData(int targetValue) {
+            this.targetValue = targetValue;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraQuestChain.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraQuestChain.java
@@ -1,0 +1,71 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.extra;
+
+import com.eu.habbo.habbohotel.items.Item;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Quest Chain box ({@code wf_var_quest_chain}, dialog code 109). Sequences a multi-step quest: its
+ * co-located base counter is the "current step" (designers increment it as each sub-quest completes),
+ * and {@code targetValue} is the total number of steps. Exposes derived read-only sub-variables:
+ * {@code current_step, total_steps, is_complete, percent}.
+ *
+ * <p>v1 uses the manual-advance model (a sub-quest's {@code is_complete} drives a change-var-val that
+ * bumps the step counter), which fits the derived-variable pattern cleanly; automatic advance by reading
+ * member quests is a future enhancement.</p>
+ */
+public class WiredExtraQuestChain extends WiredExtraQuestBase {
+    public static final int CODE = 109;
+
+    public static final int SUB_CURRENT_STEP = 0;
+    public static final int SUB_TOTAL_STEPS = 1;
+    public static final int SUB_IS_COMPLETE = 2;
+    public static final int SUB_PERCENT = 3;
+    public static final int SUBVARIABLE_COUNT = 4;
+
+    public WiredExtraQuestChain(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredExtraQuestChain(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    protected int code() {
+        return CODE;
+    }
+
+    @Override
+    public int subvariableCount() {
+        return SUBVARIABLE_COUNT;
+    }
+
+    @Override
+    public String subvariableKey(int subType) {
+        return switch (subType) {
+            case SUB_CURRENT_STEP -> "current_step";
+            case SUB_TOTAL_STEPS -> "total_steps";
+            case SUB_IS_COMPLETE -> "is_complete";
+            case SUB_PERCENT -> "percent";
+            default -> "value";
+        };
+    }
+
+    @Override
+    public Integer derive(int subType, Integer baseValue) {
+        if (baseValue == null) return null;
+
+        int step = Math.max(0, baseValue);
+        int total = Math.max(0, this.targetValue);
+
+        return switch (subType) {
+            case SUB_CURRENT_STEP -> (total > 0) ? Math.min(step, total) : step;
+            case SUB_TOTAL_STEPS -> total;
+            case SUB_IS_COMPLETE -> (total > 0 && step >= total) ? 1 : 0;
+            case SUB_PERCENT -> (total <= 0) ? 100 : Math.max(0, Math.min(100, (int) Math.floor((step * 100D) / total)));
+            default -> null;
+        };
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectScanChestFurniByType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/selector/WiredEffectScanChestFurniByType.java
@@ -1,0 +1,180 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.selector;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWired;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredEffectType;
+import com.eu.habbo.habbohotel.wired.core.WiredContext;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Chest Furni-of-Type scanner (furni classname {@code wf_xtra_scan_chest_furni_by_type}). A read-only
+ * selector that picks the room furni whose base-type matches a type stored in a selected
+ * {@link InteractionWiredChest}. (The config-based chest holds virtual contents, not real instances —
+ * so "scan chest furni by type" resolves to room furni of the chest's stored types. When an authentic
+ * drag-to-fill chest exists, this can be upgraded to scan real deposited furni.)
+ */
+public class WiredEffectScanChestFurniByType extends InteractionWiredEffect {
+    public static final WiredEffectType type = WiredEffectType.SCAN_CHEST_FURNI_BY_TYPE;
+    private static final int MAX_PICKED_FURNI = 20;
+
+    private boolean filterExisting = false;
+    private boolean invert = false;
+    private List<Integer> chestIds = new ArrayList<>();
+
+    public WiredEffectScanChestFurniByType(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredEffectScanChestFurniByType(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public void execute(WiredContext ctx) {
+        Room room = ctx.room();
+        if (room == null) return;
+
+        boolean includeWiredItems = this.includeWiredTargets(ctx);
+
+        // Collect the distinct furni base-types stored across the selected chest(s).
+        Set<Integer> chestTypes = new HashSet<>();
+        for (Integer id : this.chestIds) {
+            HabboItem item = room.getHabboItem(id);
+            if (item instanceof InteractionWiredChest chest) {
+                chestTypes.addAll(chest.getContents().distinctTypes(ChestStorage.KIND_FURNI));
+            }
+        }
+
+        Set<HabboItem> matched = new LinkedHashSet<>();
+        if (!chestTypes.isEmpty()) {
+            room.getFloorItems().forEach(item -> {
+                if (item == null) return;
+                if (!includeWiredItems && item instanceof InteractionWired) return;
+                if (chestTypes.contains(item.getBaseItem().getId())) {
+                    matched.add(item);
+                }
+            });
+        }
+
+        Set<HabboItem> result = this.applySelectorModifiers(matched, this.getSelectableFloorItems(room, ctx), ctx.targets().items(), this.filterExisting, this.invert);
+        ctx.targets().setItems(result);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int[] params = settings.getIntParams();
+        this.filterExisting = params.length > 0 && params[0] == 1;
+        this.invert = params.length > 1 && params[1] == 1;
+
+        this.chestIds = new ArrayList<>();
+        if (settings.getFurniIds() != null) {
+            for (int id : settings.getFurniIds()) {
+                if (this.chestIds.size() >= MAX_PICKED_FURNI) break;
+                this.chestIds.add(id);
+            }
+        }
+
+        this.setDelay(settings.getDelay());
+        return true;
+    }
+
+    @Override
+    public WiredEffectType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean isSelector() {
+        return true;
+    }
+
+    @Override
+    public boolean usesExistingSelectorTargets() {
+        return this.filterExisting;
+    }
+
+    @Override
+    public String getWiredData() {
+        return WiredManager.getGson().toJson(new JsonData(this.filterExisting, this.invert, this.chestIds, this.getDelay()));
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.onPickUp();
+
+        String wiredData = set.getString("wired_data");
+        if (wiredData == null || !wiredData.startsWith("{")) return;
+
+        JsonData data = WiredSelectorPayloadGuard.fromJson(wiredData, JsonData.class);
+        if (data == null) return;
+
+        this.filterExisting = data.filterExisting;
+        this.invert = data.invert;
+        this.chestIds = (data.chestIds != null) ? data.chestIds : new ArrayList<>();
+        this.setDelay(data.delay);
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(MAX_PICKED_FURNI);
+        message.appendInt(this.chestIds.size());
+        for (Integer id : this.chestIds) {
+            message.appendInt(id);
+        }
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(this.filterExisting ? 1 : 0);
+        message.appendInt(this.invert ? 1 : 0);
+        message.appendInt(0);
+        message.appendInt(this.getType().code);
+        message.appendInt(this.getDelay());
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public void onPickUp() {
+        this.filterExisting = false;
+        this.invert = false;
+        this.chestIds = new ArrayList<>();
+        this.setDelay(0);
+    }
+
+    static class JsonData {
+        boolean filterExisting;
+        boolean invert;
+        List<Integer> chestIds;
+        int delay;
+
+        JsonData(boolean filterExisting, boolean invert, List<Integer> chestIds, int delay) {
+            this.filterExisting = filterExisting;
+            this.invert = invert;
+            this.chestIds = chestIds;
+            this.delay = delay;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerTransactionComplete.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerTransactionComplete.java
@@ -1,0 +1,87 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Transaction Completed trigger (furni classname {@code wf_trg_transaction_complete}). Fires when an
+ * {@code Initiate Transaction} effect ({@code wf_act_init_transaction}) raises a
+ * {@link WiredEvent.Type#TRANSACTION_COMPLETE} event in the room. No configuration (v1: any complete
+ * event fires it; the engine already routes by trigger type).
+ */
+public class WiredTriggerTransactionComplete extends InteractionWiredTrigger {
+    public static final WiredTriggerType type = WiredTriggerType.TRANSACTION_COMPLETE;
+
+    public WiredTriggerTransactionComplete(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerTransactionComplete(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        return true;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return "";
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+    }
+
+    @Override
+    public void onPickUp() {
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return false;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerTransactionFail.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerTransactionFail.java
@@ -1,0 +1,86 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.triggers;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.wired.WiredTriggerType;
+import com.eu.habbo.habbohotel.wired.core.WiredEvent;
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+import com.eu.habbo.messages.ServerMessage;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Transaction Failed trigger (furni classname {@code wf_trg_transaction_fail}). Fires when a
+ * {@code Cancel Transaction} effect ({@code wf_act_cancel_transaction}) raises a
+ * {@link WiredEvent.Type#TRANSACTION_FAIL} event in the room. No configuration (v1).
+ */
+public class WiredTriggerTransactionFail extends InteractionWiredTrigger {
+    public static final WiredTriggerType type = WiredTriggerType.TRANSACTION_FAIL;
+
+    public WiredTriggerTransactionFail(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public WiredTriggerTransactionFail(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean matches(HabboItem triggerItem, WiredEvent event) {
+        return true;
+    }
+
+    @Deprecated
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public WiredTriggerType getType() {
+        return type;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        message.appendBoolean(false);
+        message.appendInt(WiredManager.MAXIMUM_FURNI_SELECTION);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(type.code);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings) {
+        return true;
+    }
+
+    @Override
+    public String getWiredData() {
+        return "";
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+    }
+
+    @Override
+    public void onPickUp() {
+    }
+
+    @Override
+    public boolean isTriggeredByRoomUnit() {
+        return false;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredConditionType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredConditionType.java
@@ -42,7 +42,10 @@ public enum WiredConditionType {
     HAS_VAR(40),
     NOT_HAS_VAR(41),
     VAR_VAL_MATCH(42),
-    VAR_AGE_MATCH(43);
+    VAR_AGE_MATCH(43),
+    // Phase-2 chest/storage conditions. Require the matching Nitro WiredConditionLayoutCode.
+    CHEST_HAS_ITEMS(47),
+    CHEST_HAS_ITEM_TYPE(48);
 
     public final int code;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredEffectType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredEffectType.java
@@ -61,7 +61,15 @@ public enum WiredEffectType {
     FURNI_WITH_VAR_SELECTOR(75),
     USERS_WITH_VAR_SELECTOR(76),
     NEG_CALL_STACKS(86),
-    NEG_SEND_SIGNAL(87);
+    NEG_SEND_SIGNAL(87),
+    // Phase-2 chest/storage + transactions + place/remove-furni (action/selector codes).
+    GIVE_CURRENCY_FROM_CHEST(99),
+    GIVE_FURNI_FROM_CHEST(102),
+    SCAN_CHEST_FURNI_BY_TYPE(103),
+    INIT_TRANSACTION(104),
+    CANCEL_TRANSACTION(105),
+    PLACE_FURNI(106),
+    REMOVE_FURNI(107);
 
     public final int code;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredTriggerType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/WiredTriggerType.java
@@ -29,7 +29,10 @@ public enum WiredTriggerType {
     CUSTOM(13),
     STARTS_DANCING(11),
     STOPS_DANCING(11),
-    RECEIVE_SIGNAL(15);
+    RECEIVE_SIGNAL(15),
+    // Phase-2 transaction outcome triggers. Each requires the matching Nitro WiredTriggerLayoutCode value.
+    TRANSACTION_COMPLETE(27),
+    TRANSACTION_FAIL(28);
 
     public final int code;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredDerivedVariableBox.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredDerivedVariableBox.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.habbohotel.wired.core;
+
+import java.util.List;
+
+/**
+ * A wired config-box that, when co-located with a base counter variable, exposes DERIVED read-only
+ * sub-variables computed from that counter (e.g. a Quest box exposing {@code counter.is_complete}).
+ * {@link WiredVariableLevelSystemSupport} registers these as synthetic read-only variables and reads
+ * them through this interface. The level-up box predates the interface and is special-cased; new
+ * derived boxes (quest / quest-chain) implement this directly.
+ */
+public interface WiredDerivedVariableBox {
+    /** The selected sub-variable indices this box exposes (0-based). */
+    List<Integer> getSelectedSubvariables();
+
+    /** Whether a given sub-variable index is exposed. */
+    boolean hasSubvariable(int subType);
+
+    /** The variable-name suffix for a sub-variable (e.g. {@code "is_complete"}). */
+    String subvariableKey(int subType);
+
+    /** Compute the derived value for a sub-variable from the base counter value (null base → null). */
+    Integer derive(int subType, Integer baseValue);
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredEvent.java
@@ -121,6 +121,12 @@ public final class WiredEvent {
         /** Signal received from a Send Signal effect */
         SIGNAL_RECEIVED(WiredTriggerType.RECEIVE_SIGNAL),
 
+        /** A wired transaction completed (fired by Initiate Transaction) */
+        TRANSACTION_COMPLETE(WiredTriggerType.TRANSACTION_COMPLETE),
+
+        /** A wired transaction failed / was cancelled (fired by Cancel Transaction) */
+        TRANSACTION_FAIL(WiredTriggerType.TRANSACTION_FAIL),
+
         /** Custom trigger type for plugins */
         CUSTOM(WiredTriggerType.CUSTOM);
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredVariableLevelSystemSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredVariableLevelSystemSupport.java
@@ -49,22 +49,62 @@ public final class WiredVariableLevelSystemSupport {
         return null;
     }
 
+    /**
+     * Find the co-located derived-variable box (the level-up box OR any {@link WiredDerivedVariableBox},
+     * e.g. a quest box) for a base variable definition. At most one box per definition; first wins.
+     */
+    public static InteractionWiredExtra getDerivedBox(Room room, InteractionWiredExtra definition) {
+        if (room == null || definition == null || room.getRoomSpecialTypes() == null) {
+            return null;
+        }
+
+        Collection<InteractionWiredExtra> extras = room.getRoomSpecialTypes().getExtras(definition.getX(), definition.getY());
+        if (extras == null || extras.isEmpty()) {
+            return null;
+        }
+
+        for (InteractionWiredExtra extra : WiredExecutionOrderUtil.sort(extras)) {
+            if (extra instanceof WiredExtraVariableLevelUpSystem || extra instanceof WiredDerivedVariableBox) {
+                return extra;
+            }
+        }
+
+        return null;
+    }
+
+    private static List<Integer> boxSubvariables(InteractionWiredExtra box) {
+        if (box instanceof WiredExtraVariableLevelUpSystem lvl) return lvl.getSelectedSubvariables();
+        if (box instanceof WiredDerivedVariableBox derived) return derived.getSelectedSubvariables();
+        return Collections.emptyList();
+    }
+
+    private static boolean boxHasSubvariable(InteractionWiredExtra box, int subType) {
+        if (box instanceof WiredExtraVariableLevelUpSystem lvl) return lvl.hasSubvariable(subType);
+        if (box instanceof WiredDerivedVariableBox derived) return derived.hasSubvariable(subType);
+        return false;
+    }
+
+    private static String boxSubvariableKey(InteractionWiredExtra box, int subType) {
+        if (box instanceof WiredDerivedVariableBox derived) return derived.subvariableKey(subType);
+        return getSubvariableKey(subType);
+    }
+
     public static List<WiredVariableDefinitionInfo> getDerivedDefinitions(Room room, int targetType, InteractionWiredExtra definitionExtra, WiredVariableDefinitionInfo baseDefinition) {
         if (room == null || definitionExtra == null || baseDefinition == null || !baseDefinition.hasValue()) {
             return Collections.emptyList();
         }
 
-        WiredExtraVariableLevelUpSystem levelSystem = getLevelSystem(room, definitionExtra);
-        if (levelSystem == null) {
+        InteractionWiredExtra box = getDerivedBox(room, definitionExtra);
+        if (box == null) {
             return Collections.emptyList();
         }
 
         List<WiredVariableDefinitionInfo> result = new ArrayList<>();
 
-        for (int subvariableType : levelSystem.getSelectedSubvariables()) {
+        for (int subvariableType : boxSubvariables(box)) {
             result.add(new WiredVariableDefinitionInfo(
                 createSyntheticItemId(targetType, baseDefinition.getItemId(), subvariableType),
-                baseDefinition.getName() + "." + getSubvariableKey(subvariableType),
+                baseDefinition.getName() + "." + boxSubvariableKey(box, subvariableType),
                 true,
                 baseDefinition.getAvailability(),
                 false,
@@ -109,8 +149,8 @@ public final class WiredVariableLevelSystemSupport {
             return null;
         }
 
-        WiredExtraVariableLevelUpSystem levelSystem = getLevelSystem(room, baseExtra);
-        if (levelSystem == null || !levelSystem.hasSubvariable(decoded.subvariableType)) {
+        InteractionWiredExtra box = getDerivedBox(room, baseExtra);
+        if (box == null || !boxHasSubvariable(box, decoded.subvariableType)) {
             return null;
         }
 
@@ -118,14 +158,22 @@ public final class WiredVariableLevelSystemSupport {
             syntheticItemId,
             decoded.baseDefinitionItemId,
             decoded.subvariableType,
-            baseDefinition.getName() + "." + getSubvariableKey(decoded.subvariableType),
+            baseDefinition.getName() + "." + boxSubvariableKey(box, decoded.subvariableType),
             baseDefinition,
-            levelSystem
+            box
         );
     }
 
-    public static Integer getDerivedValue(WiredExtraVariableLevelUpSystem levelSystem, int subvariableType, Integer baseValue) {
-        if (levelSystem == null || baseValue == null) {
+    public static Integer getDerivedValue(InteractionWiredExtra box, int subvariableType, Integer baseValue) {
+        if (box == null || baseValue == null) {
+            return null;
+        }
+
+        if (box instanceof WiredDerivedVariableBox derived) {
+            return derived.derive(subvariableType, baseValue);
+        }
+
+        if (!(box instanceof WiredExtraVariableLevelUpSystem levelSystem)) {
             return null;
         }
 
@@ -482,9 +530,9 @@ public final class WiredVariableLevelSystemSupport {
         private final int subvariableType;
         private final String variableName;
         private final WiredVariableDefinitionInfo baseDefinition;
-        private final WiredExtraVariableLevelUpSystem levelSystem;
+        private final InteractionWiredExtra levelSystem;
 
-        public DerivedDefinition(int syntheticItemId, int baseDefinitionItemId, int subvariableType, String variableName, WiredVariableDefinitionInfo baseDefinition, WiredExtraVariableLevelUpSystem levelSystem) {
+        public DerivedDefinition(int syntheticItemId, int baseDefinitionItemId, int subvariableType, String variableName, WiredVariableDefinitionInfo baseDefinition, InteractionWiredExtra levelSystem) {
             this.syntheticItemId = syntheticItemId;
             this.baseDefinitionItemId = baseDefinitionItemId;
             this.subvariableType = subvariableType;
@@ -505,7 +553,7 @@ public final class WiredVariableLevelSystemSupport {
             return this.baseDefinition;
         }
 
-        public WiredExtraVariableLevelUpSystem getLevelSystem() {
+        public InteractionWiredExtra getLevelSystem() {
             return this.levelSystem;
         }
     }


### PR DESCRIPTION
Server side of the chest has-items **comparison operators** (the one real gap found by the UI wired audit). Replaces the hard-coded `>=` in the chest conditions with selectable operators.

## ⚠️ Stacked on #299
The chest has-items conditions live in **#299** — merge #299 first. Pairs with the Nitro client PR (`WiredComparisonOperator`), same wire encoding.

## What
- `WiredComparison` — shared int-by-value encoding `0=< 1== 2=> 3=<= 4=!= 5=>=` + `normalize`/`compare`. Default `>=` preserves historical behaviour for saves written before the operator existed.
- `WiredConditionChestHasItems` → serializes `[amount, comparison]`; `WiredConditionChestHasItemType` → `[baseId, amount, comparison]`. Backward-compatible: a 1-int old save reads comparison as default `>=`.

`mvn clean compile`: **BUILD SUCCESS**. Draft pending runtime test + the paired client PR.