### PR TITLE
fix(lovelock): require both confirms before lock

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionLoveLock.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/InteractionLoveLock.java
@@ -10,6 +10,7 @@ import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.rooms.items.lovelock.LoveLockFurniFinishedComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.lovelock.LoveLockFurniStartComposer;
 
 import java.sql.ResultSet;
@@ -19,6 +20,8 @@ import java.util.Calendar;
 public class InteractionLoveLock extends HabboItem {
     public int userOneId;
     public int userTwoId;
+    public boolean userOneConfirmed;
+    public boolean userTwoConfirmed;
 
     public InteractionLoveLock(ResultSet set, Item baseItem) throws SQLException {
         super(set, baseItem);
@@ -77,21 +80,56 @@ public class InteractionLoveLock extends HabboItem {
         if (client == null)
             return;
 
-        if (RoomLayout.tilesAdjecent(client.getHabbo().getRoomUnit().getCurrentLocation(), room.getLayout().getTile(this.getX(), this.getY()))) {
-            if (this.userOneId == 0) {
-                this.userOneId = client.getHabbo().getHabboInfo().getId();
-                client.sendResponse(new LoveLockFurniStartComposer(this));
-            } else {
-                if (this.userOneId != client.getHabbo().getHabboInfo().getId()) {
-                    Habbo habbo = room.getHabbo(this.userOneId);
+        if (!RoomLayout.tilesAdjecent(client.getHabbo().getRoomUnit().getCurrentLocation(), room.getLayout().getTile(this.getX(), this.getY())))
+            return;
 
-                    if (habbo != null) {
-                        this.userTwoId = client.getHabbo().getHabboInfo().getId();
-                        client.sendResponse(new LoveLockFurniStartComposer(this));
-                    }
-                }
+        int habboId = client.getHabbo().getHabboInfo().getId();
+
+        if (this.userOneId == 0) {
+            this.userOneId = habboId;
+            client.sendResponse(new LoveLockFurniStartComposer(this, true));
+            return;
+        }
+
+        if (this.userOneId == habboId)
+            return;
+
+        if (this.userTwoId == 0) {
+            Habbo first = room.getHabbo(this.userOneId);
+
+            if (first != null) {
+                this.userTwoId = habboId;
+                client.sendResponse(new LoveLockFurniStartComposer(this, false));
             }
         }
+    }
+
+    public void cancel(Habbo habbo) {
+        int partnerId = 0;
+
+        if (this.userOneId == habbo.getHabboInfo().getId()) {
+            partnerId = this.userTwoId;
+        } else if (this.userTwoId == habbo.getHabboInfo().getId()) {
+            partnerId = this.userOneId;
+        }
+
+        this.resetSession();
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null || partnerId <= 0)
+            return;
+
+        Habbo partner = room.getHabbo(partnerId);
+        if (partner != null && partner.getClient() != null) {
+            partner.getClient().sendResponse(new LoveLockFurniFinishedComposer(this));
+        }
+    }
+
+    public void resetSession() {
+        this.userOneId = 0;
+        this.userTwoId = 0;
+        this.userOneConfirmed = false;
+        this.userTwoConfirmed = false;
     }
 
     public boolean lock(Habbo userOne, Habbo userTwo, Room room) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/lovelock/LoveLockStartConfirmEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/lovelock/LoveLockStartConfirmEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.rooms.items.lovelock;
 
 import com.eu.habbo.habbohotel.items.interactions.InteractionLoveLock;
+import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
@@ -16,37 +17,58 @@ public class LoveLockStartConfirmEvent extends MessageHandler {
         if (!RoomItemInputGuard.isPositiveId(itemId))
             return;
 
-        if (this.packet.readBoolean()) {
-            if (this.client.getHabbo().getHabboInfo().getCurrentRoom() == null)
-                return;
+        boolean confirmed = this.packet.readBoolean();
 
-            HabboItem item = this.client.getHabbo().getHabboInfo().getCurrentRoom().getHabboItem(itemId);
+        Room room = this.client.getHabbo().getHabboInfo().getCurrentRoom();
+        if (room == null)
+            return;
 
-            if (item == null)
-                return;
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionLoveLock loveLock))
+            return;
 
-            if (item instanceof InteractionLoveLock) {
-                int userId = 0;
+        Habbo self = this.client.getHabbo();
+        if (self == null)
+            return;
 
-                if (((InteractionLoveLock) item).userOneId == this.client.getHabbo().getHabboInfo().getId() && ((InteractionLoveLock) item).userTwoId != 0) {
-                    userId = ((InteractionLoveLock) item).userTwoId;
-                } else if (((InteractionLoveLock) item).userOneId != 0 && ((InteractionLoveLock) item).userTwoId == this.client.getHabbo().getHabboInfo().getId()) {
-                    userId = ((InteractionLoveLock) item).userOneId;
-                }
-
-                if (userId > 0) {
-                    Habbo habbo = this.client.getHabbo().getHabboInfo().getCurrentRoom().getHabbo(userId);
-
-                    if (habbo != null) {
-                        habbo.getClient().sendResponse(new LoveLockFurniFriendConfirmedComposer((InteractionLoveLock) item));
-
-                        habbo.getClient().sendResponse(new LoveLockFurniFinishedComposer((InteractionLoveLock) item));
-                        this.client.sendResponse(new LoveLockFurniFinishedComposer((InteractionLoveLock) item));
-
-                        ((InteractionLoveLock) item).lock(habbo, this.client.getHabbo(), this.client.getHabbo().getHabboInfo().getCurrentRoom());
-                    }
-                }
-            }
+        if (!confirmed) {
+            loveLock.cancel(self);
+            return;
         }
+
+        int selfId = self.getHabboInfo().getId();
+        int partnerId = 0;
+
+        if (loveLock.userOneId == selfId) {
+            loveLock.userOneConfirmed = true;
+            partnerId = loveLock.userTwoId;
+        } else if (loveLock.userTwoId == selfId) {
+            loveLock.userTwoConfirmed = true;
+            partnerId = loveLock.userOneId;
+        } else {
+            return;
+        }
+
+        if (partnerId <= 0)
+            return;
+
+        Habbo partner = room.getHabbo(partnerId);
+        if (partner == null || partner.getClient() == null)
+            return;
+
+        if (loveLock.userOneConfirmed && loveLock.userTwoConfirmed) {
+            Habbo userOne = room.getHabbo(loveLock.userOneId);
+            Habbo userTwo = room.getHabbo(loveLock.userTwoId);
+
+            if (userOne != null && userTwo != null && loveLock.lock(userOne, userTwo, room)) {
+                userOne.getClient().sendResponse(new LoveLockFurniFinishedComposer(loveLock));
+                userTwo.getClient().sendResponse(new LoveLockFurniFinishedComposer(loveLock));
+            }
+
+            loveLock.resetSession();
+            return;
+        }
+
+        partner.getClient().sendResponse(new LoveLockFurniFriendConfirmedComposer(loveLock));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/lovelock/LoveLockFurniStartComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/lovelock/LoveLockFurniStartComposer.java
@@ -7,16 +7,19 @@ import com.eu.habbo.messages.outgoing.Outgoing;
 
 public class LoveLockFurniStartComposer extends MessageComposer {
     private final InteractionLoveLock loveLock;
+    /** {@code true} for the first clicker (owner), {@code false} for the partner — official {@code isOwner} wire. */
+    private final boolean isOwner;
 
-    public LoveLockFurniStartComposer(InteractionLoveLock loveLock) {
+    public LoveLockFurniStartComposer(InteractionLoveLock loveLock, boolean isOwner) {
         this.loveLock = loveLock;
+        this.isOwner = isOwner;
     }
 
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.LoveLockFurniStartComposer);
         this.response.appendInt(this.loveLock.getId());
-        this.response.appendBoolean(true);
+        this.response.appendBoolean(this.isOwner);
         return this.response;
     }
 


### PR DESCRIPTION
## Summary
**1 commit** — fixes love lock (friend furni) two-player confirm flow.

- Track \userOneConfirmed\ / \userTwoConfirmed\; lock only when **both** confirm
- First confirm → \LoveLockFurniFriendConfirmed\ to partner (not immediate lock)
- \LoveLockFurniStart\: \isOwner=true\ first clicker, \alse\ partner (official wire)
- Cancel resets session and notifies partner with \Finished\

## Diff
https://github.com/simoleo89/Arcturus-Morningstar-Extended/compare/dev...fix/love-lock-confirm-flow

**3 file** — InteractionLoveLock + LoveLockStartConfirmEvent + LoveLockFurniStartComposer

## Test plan
- [ ] Two users adjacent → click lock → both confirm → engraved extradata
- [ ] Cancel on either side closes partner dialog
- [ ] Deploy with UI **#295**
