### PR TITLE
feat(chest): ChestOpen 9327 flow + navigator category user counts

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -77,6 +77,8 @@ import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariable
 import com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableTextConnector;
 import com.eu.habbo.habbohotel.items.interactions.wired.selector.*;
 import com.eu.habbo.habbohotel.items.interactions.wired.triggers.*;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestCurrency;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestFurni;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.highscores.WiredHighscoreManager;
@@ -370,6 +372,12 @@ public class ItemManager {
         this.interactionsList.add(new ItemInteraction("wf_cnd_neg_has_var", WiredConditionNotHasVariable.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_var_val_match", WiredConditionVariableValueMatch.class));
         this.interactionsList.add(new ItemInteraction("wf_cnd_var_age_match", WiredConditionVariableAgeMatch.class));
+        // Player-facing wired chest (Scrigno) — currency + furni storage
+        this.interactionsList.add(new ItemInteraction("wf_storage_coins1", InteractionWiredChestCurrency.class));
+        this.interactionsList.add(new ItemInteraction("wf_storage_coins2", InteractionWiredChestCurrency.class));
+        this.interactionsList.add(new ItemInteraction("wf_storage_furni1", InteractionWiredChestFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_storage_furni2", InteractionWiredChestFurni.class));
+        this.interactionsList.add(new ItemInteraction("wf_storage_furni_starter", InteractionWiredChestFurni.class));
 
 
         this.interactionsList.add(new ItemInteraction("wf_xtra_random", WiredExtraRandom.class));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestDepositSession.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestDepositSession.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Tracks which chest a user is depositing into (official Kigike / start-deposit flow). */
+public final class ChestDepositSession {
+    private static final Map<Integer, Integer> ACTIVE = new ConcurrentHashMap<>();
+
+    private ChestDepositSession() {
+    }
+
+    public static void start(int userId, int chestItemId) {
+        if (userId <= 0 || chestItemId <= 0) return;
+        ACTIVE.put(userId, chestItemId);
+    }
+
+    public static int getChestItemId(int userId) {
+        return ACTIVE.getOrDefault(userId, 0);
+    }
+
+    public static void clear(int userId) {
+        ACTIVE.remove(userId);
+    }
+
+    public static boolean isDepositingInto(int userId, int chestItemId) {
+        return ACTIVE.getOrDefault(userId, 0) == chestItemId;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniDepositHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniDepositHelper.java
@@ -1,0 +1,53 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+import com.eu.habbo.threading.runnables.QueryDeleteHabboItems;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Shared deposit logic for wired furni chests (bulk + per-inventory-item). */
+public final class ChestFurniDepositHelper {
+    private ChestFurniDepositHelper() {
+    }
+
+    public static boolean depositInventoryItem(Habbo habbo, InteractionWiredChest chest, HabboItem inventoryItem) {
+        if (habbo == null || chest == null || inventoryItem == null) return false;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return false;
+
+        ChestStorage contents = chest.getContents();
+        if (!contents.isAccessDonate() && !room.hasRights(habbo)) return false;
+        if (contents.furniItemCount() >= contents.getCapacityMax()) return false;
+
+        Item baseItem = inventoryItem.getBaseItem();
+        if (baseItem == null || baseItem.getType() != FurnitureType.FLOOR) return false;
+
+        HabboItem removed = habbo.getInventory().getItemsComponent().getHabboItem(inventoryItem.getId());
+        if (removed == null) return false;
+        habbo.getInventory().getItemsComponent().removeHabboItem(removed);
+
+        ChestFurniStoredItem stored = ChestFurniStoredItem.fromHabboItem(removed, 0);
+        contents.addFurniItem(stored);
+        contents.addLog(new ChestStorage.LogEntry("deposit", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), 0, 1));
+        chest.persistContents();
+
+        habbo.getClient().sendResponse(new RemoveHabboItemComposer(removed.getGiftAdjustedId()));
+        habbo.getClient().sendResponse(new InventoryRefreshComposer());
+        Emulator.getThreading().run(new QueryDeleteHabboItems(List.of(removed)));
+
+        habbo.getClient().sendResponse(new ChestDataComposer(chest));
+        ChestFurniPackets.sendDelta(habbo.getClient(), chest.getId(), List.of(), List.of(stored));
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniPackets.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniPackets.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestFurniChunkComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestFurniDeltaComposer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Helpers for furni-chest v2 chunk/delta protocol (headers 9322/9323). */
+public final class ChestFurniPackets {
+    private ChestFurniPackets() {
+    }
+
+    public static void sendFullChunks(GameClient client, int chestId, ChestStorage storage) {
+        if (client == null || storage == null) return;
+
+        List<ChestFurniStoredItem> items = storage.furniItems();
+        int total = Math.max(1, (int) Math.ceil(items.size() / (double) ChestFurniChunkComposer.CHUNK_SIZE));
+        if (items.isEmpty()) {
+            client.sendResponse(new ChestFurniChunkComposer(chestId, 1, 0, List.of()));
+            return;
+        }
+        for (int fragment = 0; fragment < total; fragment++) {
+            int from = fragment * ChestFurniChunkComposer.CHUNK_SIZE;
+            int to = Math.min(from + ChestFurniChunkComposer.CHUNK_SIZE, items.size());
+            client.sendResponse(new ChestFurniChunkComposer(chestId, total, fragment, items.subList(from, to)));
+        }
+    }
+
+    public static void sendDelta(GameClient client, int chestId, List<Integer> removedIds, List<ChestFurniStoredItem> added) {
+        if (client == null) return;
+        client.sendResponse(new ChestFurniDeltaComposer(
+                chestId,
+                removedIds == null ? List.of() : removedIds,
+                added == null ? List.of() : added));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniStoredItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniStoredItem.java
@@ -1,0 +1,58 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.ServerMessage;
+
+/**
+ * One furni row inside a wired furni chest. Wire layout matches official {@code gypyli.ChestStorage}
+ * (client 6): inventoryId, lockState, transactionId, ChestItemType, groupable, specialType, stuffData, extra.
+ */
+public class ChestFurniStoredItem {
+    public int inventoryId;
+    public int lockState;
+    public long transactionId;
+    public boolean wallItem;
+    public int baseItemId;
+    public String legacyPosterId = "";
+    public boolean groupable = true;
+    public int specialType;
+    /** Nitro object-data format key ({@link com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniWireUtil#LEGACY_FORMAT}). */
+    public int stuffDataFormat;
+    public String extradata = "";
+    public int limitedSells;
+    public int limitedStack;
+    /** Floor-item state (official {@code extra} int after stuffData). */
+    public int extra;
+
+    public ChestFurniStoredItem() {
+    }
+
+    public static ChestFurniStoredItem fromHabboItem(HabboItem item, int inventoryId) {
+        ChestFurniStoredItem stored = new ChestFurniStoredItem();
+        Item base = item.getBaseItem();
+        stored.inventoryId = inventoryId;
+        stored.wallItem = base.getType() == FurnitureType.WALL;
+        stored.baseItemId = base.getId();
+        stored.groupable = base.allowInventoryStack();
+        stored.extradata = item.getExtradata() == null ? "" : item.getExtradata();
+        stored.stuffDataFormat = ChestFurniWireUtil.LEGACY_FORMAT;
+        if (item.isLimited()) {
+            stored.limitedSells = item.getLimitedSells();
+            stored.limitedStack = item.getLimitedStack();
+        }
+        if (!stored.wallItem) {
+            try {
+                stored.extra = Integer.parseInt(stored.extradata);
+            } catch (NumberFormatException ignored) {
+                stored.extra = 0;
+            }
+        }
+        return stored;
+    }
+
+    public void appendToMessage(ServerMessage message) {
+        ChestFurniWireUtil.appendStoredItem(message, this);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniWireUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniWireUtil.java
@@ -1,0 +1,46 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.messages.ServerMessage;
+
+/** Serializes chest furni rows using the official client-6 {@code ChestStorage} wire shape. */
+public final class ChestFurniWireUtil {
+    public static final int LEGACY_FORMAT = 0;
+    private static final int UNIQUE_FLAG = 256;
+
+    private ChestFurniWireUtil() {
+    }
+
+    public static void appendStoredItem(ServerMessage message, ChestFurniStoredItem item) {
+        message.appendInt(item.inventoryId);
+        message.appendInt(item.lockState);
+        appendLong(message, item.transactionId);
+        message.appendBoolean(item.wallItem);
+        message.appendInt(item.baseItemId);
+        message.appendString(item.legacyPosterId == null ? "" : item.legacyPosterId);
+        message.appendBoolean(item.groupable);
+        message.appendInt(item.specialType);
+        appendStuffData(message, item);
+        if (!item.wallItem) {
+            message.appendInt(item.extra);
+        }
+    }
+
+    private static void appendStuffData(ServerMessage message, ChestFurniStoredItem item) {
+        int flags = 0;
+        if (item.limitedStack > 0) {
+            flags |= UNIQUE_FLAG;
+        }
+        message.appendInt((flags & 0xFF00) | (item.stuffDataFormat & 0xFF));
+        message.appendString(item.extradata == null ? "" : item.extradata);
+        if ((flags & UNIQUE_FLAG) != 0) {
+            message.appendInt(item.limitedSells);
+            message.appendInt(item.limitedStack);
+        }
+    }
+
+    /** Flash {@code readLong()} wire shape (two big-endian ints). */
+    private static void appendLong(ServerMessage message, long value) {
+        message.appendInt((int) (value >>> 32));
+        message.appendInt((int) value);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestOpenHelper.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestOpenHelper.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestOpenComposer;
+
+/**
+ * Shared open flow for wired chests (official Nod → Syhytarer → shell + chunks).
+ */
+public final class ChestOpenHelper {
+    private ChestOpenHelper() {
+    }
+
+    public static void open(GameClient client, InteractionWiredChest chest, Room room) {
+        if (client == null || chest == null || room == null) return;
+        if (!chest.getContents().isAccessOpen() && !room.hasRights(client.getHabbo())) return;
+
+        client.sendResponse(new ChestOpenComposer(chest.getId()));
+        client.sendResponse(new ChestDataComposer(chest));
+
+        if (chest instanceof InteractionWiredChestFurni) {
+            ChestFurniPackets.sendFullChunks(client, chest.getId(), chest.getContents());
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestStorage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestStorage.java
@@ -102,6 +102,17 @@ public class ChestStorage {
         return item;
     }
 
+    /** Remove every stored furni row and clear aggregate {@link #KIND_FURNI} entries. */
+    public List<ChestFurniStoredItem> removeAllFurniItems() {
+        if (this.furniItems.isEmpty()) {
+            return List.of();
+        }
+        List<ChestFurniStoredItem> removed = new ArrayList<>(this.furniItems);
+        this.furniItems.clear();
+        this.entries.removeIf(e -> e.kind == KIND_FURNI);
+        return removed;
+    }
+
     /** Remove up to {@code amount} rows matching a {@link ChestItemType} wire identity. */
     public List<ChestFurniStoredItem> removeFurniByType(boolean wallItem, int baseItemId, String legacyPosterId, int amount) {
         List<ChestFurniStoredItem> removed = new ArrayList<>();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestStorage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestStorage.java
@@ -65,6 +65,8 @@ public class ChestStorage {
 
     private final List<Entry> entries = new ArrayList<>();
     private final List<LogEntry> log = new ArrayList<>();
+    private final List<ChestFurniStoredItem> furniItems = new ArrayList<>();
+    private int nextFurniInventoryId = 1;
 
     // --- player-facing config ---
     private String name = "";
@@ -82,6 +84,72 @@ public class ChestStorage {
 
     public List<Entry> entries() {
         return this.entries;
+    }
+
+    public List<ChestFurniStoredItem> furniItems() {
+        return this.furniItems;
+    }
+
+    public int furniItemCount() {
+        return this.furniItems.size();
+    }
+
+    /** Add one stored furni row (v2). Keeps aggregate {@link #KIND_FURNI} entries in sync for wired conditions. */
+    public ChestFurniStoredItem addFurniItem(ChestFurniStoredItem item) {
+        this.assignInventoryId(item);
+        this.furniItems.add(item);
+        this.add(KIND_FURNI, item.baseItemId, 1);
+        return item;
+    }
+
+    /** Remove up to {@code amount} rows matching a {@link ChestItemType} wire identity. */
+    public List<ChestFurniStoredItem> removeFurniByType(boolean wallItem, int baseItemId, String legacyPosterId, int amount) {
+        List<ChestFurniStoredItem> removed = new ArrayList<>();
+        if (amount <= 0) return removed;
+
+        String poster = legacyPosterId == null ? "" : legacyPosterId;
+        var it = this.furniItems.iterator();
+        while (it.hasNext() && removed.size() < amount) {
+            ChestFurniStoredItem item = it.next();
+            if (item.wallItem != wallItem || item.baseItemId != baseItemId) continue;
+            String itemPoster = item.legacyPosterId == null ? "" : item.legacyPosterId;
+            if (wallItem && !poster.equals(itemPoster)) continue;
+            removed.add(item);
+            it.remove();
+            this.take(KIND_FURNI, baseItemId, 1);
+        }
+        return removed;
+    }
+
+    /** Floor-item shortcut for legacy withdraw wire [baseItemId, amount]. */
+    public List<ChestFurniStoredItem> removeFurniByBaseItemId(int baseItemId, int amount) {
+        return removeFurniByType(false, baseItemId, "", amount);
+    }
+
+    /** Expand legacy aggregate furni rows into per-item storage (called once on load). */
+    public void migrateAggregatedFurniToItems() {
+        if (!this.furniItems.isEmpty()) return;
+
+        for (Entry e : this.entries) {
+            if (e.kind != KIND_FURNI || e.quantity <= 0) continue;
+            for (int i = 0; i < e.quantity; i++) {
+                ChestFurniStoredItem item = new ChestFurniStoredItem();
+                item.baseItemId = e.type;
+                item.stuffDataFormat = ChestFurniWireUtil.LEGACY_FORMAT;
+                item.extradata = "0";
+                item.extra = 0;
+                this.assignInventoryId(item);
+                this.furniItems.add(item);
+            }
+        }
+    }
+
+    private void assignInventoryId(ChestFurniStoredItem item) {
+        if (item.inventoryId <= 0) {
+            item.inventoryId = this.nextFurniInventoryId++;
+        } else if (item.inventoryId >= this.nextFurniInventoryId) {
+            this.nextFurniInventoryId = item.inventoryId + 1;
+        }
     }
 
     public boolean isEmpty() {
@@ -227,6 +295,8 @@ public class ChestStorage {
         data.notifyWired = this.notifyWired;
         data.notifyMode = this.notifyMode;
         data.log = this.log;
+        data.furniItems = this.furniItems;
+        data.nextFurniInventoryId = this.nextFurniInventoryId;
         return WiredManager.getGson().toJson(data);
     }
 
@@ -263,7 +333,19 @@ public class ChestStorage {
                         if (le != null) chest.log.add(le);
                     }
                 }
+                if (data.furniItems != null) {
+                    for (ChestFurniStoredItem fi : data.furniItems) {
+                        if (fi != null) {
+                            chest.assignInventoryId(fi);
+                            chest.furniItems.add(fi);
+                        }
+                    }
+                }
+                if (data.nextFurniInventoryId > 0) {
+                    chest.nextFurniInventoryId = data.nextFurniInventoryId;
+                }
             }
+            chest.migrateAggregatedFurniToItems();
         } catch (Exception ignored) {
             // malformed payload → empty chest
         }
@@ -285,6 +367,8 @@ public class ChestStorage {
         boolean notifyWired = false;
         int notifyMode = 0;
         List<LogEntry> log;
+        List<ChestFurniStoredItem> furniItems;
+        int nextFurniInventoryId = 1;
 
         JsonData() {
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestStorage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestStorage.java
@@ -1,0 +1,296 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.wired.core.WiredManager;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * State of a player-facing wired chest (Scrigno). Holds the stored CONTENTS (a list of {@link Entry}
+ * rows — currency {@link #KIND_CURRENCY} or furni base-types {@link #KIND_FURNI}) PLUS the chest's
+ * player-facing CONFIG (name / description / access flags / capacity / appearance / notification prefs).
+ * Persisted as JSON in the chest furni's own {@code items.wired_data}, serialized via
+ * {@link WiredManager#getGson()}. Old payloads ({@code {entries:[...]}}) still load — the config fields
+ * just default.
+ *
+ * <p>Pure model — no room/DB access — so it stays unit-testable.</p>
+ */
+public class ChestStorage {
+    public static final int KIND_CURRENCY = 0;
+    public static final int KIND_FURNI = 1;
+
+    public static final int DEFAULT_CAPACITY = 5000;
+    public static final int CAPACITY_STEP = 5000;
+    public static final int MAX_CAPACITY = 1_000_000;
+
+    /** A single chest row. {@code type} is the currency type (KIND_CURRENCY) or base item id (KIND_FURNI). */
+    public static class Entry {
+        public int kind;
+        public int type;
+        public int quantity;
+
+        public Entry() {
+        }
+
+        public Entry(int kind, int type, int quantity) {
+            this.kind = kind;
+            this.type = type;
+            this.quantity = quantity;
+        }
+    }
+
+    public static final int MAX_LOG = 50;
+
+    /** A transaction-log row (deposit / withdraw), newest first. */
+    public static class LogEntry {
+        public String type;      // "deposit" | "withdraw"
+        public long timestamp;   // epoch millis
+        public String userName;
+        public int withdrawn;
+        public int deposited;
+
+        public LogEntry() {
+        }
+
+        public LogEntry(String type, long timestamp, String userName, int withdrawn, int deposited) {
+            this.type = type;
+            this.timestamp = timestamp;
+            this.userName = userName;
+            this.withdrawn = withdrawn;
+            this.deposited = deposited;
+        }
+    }
+
+    private final List<Entry> entries = new ArrayList<>();
+    private final List<LogEntry> log = new ArrayList<>();
+
+    // --- player-facing config ---
+    private String name = "";
+    private String description = "";
+    private boolean accessOpen = true;       // everyone can open
+    private boolean accessDonate = false;    // everyone can donate
+    private int capacityMax = DEFAULT_CAPACITY;
+    private int appearanceState = 0;         // 0 = open when someone looks inside
+    private boolean notifyFull = false;
+    private boolean notifyDonation = false;
+    private boolean notifyWithdraw = false;
+    private boolean notifyEmpty = false;
+    private boolean notifyWired = false;
+    private int notifyMode = 0;              // 0 = always
+
+    public List<Entry> entries() {
+        return this.entries;
+    }
+
+    public boolean isEmpty() {
+        return this.entries.isEmpty();
+    }
+
+    /** Total quantity across every entry of a kind. */
+    public int total(int kind) {
+        int sum = 0;
+        for (Entry e : this.entries) {
+            if (e.kind == kind) {
+                sum += Math.max(0, e.quantity);
+            }
+        }
+        return sum;
+    }
+
+    /** Quantity held for a specific kind+type. */
+    public int count(int kind, int type) {
+        int sum = 0;
+        for (Entry e : this.entries) {
+            if (e.kind == kind && e.type == type) {
+                sum += Math.max(0, e.quantity);
+            }
+        }
+        return sum;
+    }
+
+    public boolean has(int kind, int type, int quantity) {
+        return this.count(kind, type) >= quantity;
+    }
+
+    /** Distinct types present for a kind, in insertion order. */
+    public List<Integer> distinctTypes(int kind) {
+        Set<Integer> seen = new LinkedHashSet<>();
+        for (Entry e : this.entries) {
+            if (e.kind == kind && e.quantity > 0) {
+                seen.add(e.type);
+            }
+        }
+        return new ArrayList<>(seen);
+    }
+
+    /** Add quantity to a kind+type, merging into the existing entry if present. No-op for quantity &lt;= 0. */
+    public void add(int kind, int type, int quantity) {
+        if (quantity <= 0) {
+            return;
+        }
+        for (Entry e : this.entries) {
+            if (e.kind == kind && e.type == type) {
+                e.quantity += quantity;
+                return;
+            }
+        }
+        this.entries.add(new Entry(kind, type, quantity));
+    }
+
+    /**
+     * Remove up to {@code quantity} of a specific kind+type. Returns how many were actually removed
+     * (capped by what's available). Entries that reach zero are dropped. Never goes negative.
+     */
+    public int take(int kind, int type, int quantity) {
+        if (quantity <= 0) {
+            return 0;
+        }
+        int taken = 0;
+        var it = this.entries.iterator();
+        while (it.hasNext() && taken < quantity) {
+            Entry e = it.next();
+            if (e.kind != kind || e.type != type || e.quantity <= 0) {
+                continue;
+            }
+            int remove = Math.min(e.quantity, quantity - taken);
+            e.quantity -= remove;
+            taken += remove;
+            if (e.quantity <= 0) {
+                it.remove();
+            }
+        }
+        return taken;
+    }
+
+    // --- config getters/setters ---
+    public String getName() { return this.name == null ? "" : this.name; }
+    public void setName(String value) { this.name = (value == null) ? "" : value; }
+
+    public String getDescription() { return this.description == null ? "" : this.description; }
+    public void setDescription(String value) { this.description = (value == null) ? "" : value; }
+
+    public boolean isAccessOpen() { return this.accessOpen; }
+    public void setAccessOpen(boolean value) { this.accessOpen = value; }
+
+    public boolean isAccessDonate() { return this.accessDonate; }
+    public void setAccessDonate(boolean value) { this.accessDonate = value; }
+
+    public int getCapacityMax() { return this.capacityMax <= 0 ? DEFAULT_CAPACITY : this.capacityMax; }
+    public void setCapacityMax(int value) { this.capacityMax = Math.max(DEFAULT_CAPACITY, Math.min(MAX_CAPACITY, value)); }
+
+    public int getAppearanceState() { return this.appearanceState; }
+    public void setAppearanceState(int value) { this.appearanceState = value; }
+
+    public boolean isNotifyFull() { return this.notifyFull; }
+    public boolean isNotifyDonation() { return this.notifyDonation; }
+    public boolean isNotifyWithdraw() { return this.notifyWithdraw; }
+    public boolean isNotifyEmpty() { return this.notifyEmpty; }
+    public boolean isNotifyWired() { return this.notifyWired; }
+    public int getNotifyMode() { return this.notifyMode; }
+
+    public void setNotifications(boolean full, boolean donation, boolean withdraw, boolean empty, boolean wired, int mode) {
+        this.notifyFull = full;
+        this.notifyDonation = donation;
+        this.notifyWithdraw = withdraw;
+        this.notifyEmpty = empty;
+        this.notifyWired = wired;
+        this.notifyMode = mode;
+    }
+
+    public List<LogEntry> getLog() {
+        return this.log;
+    }
+
+    /** Record a transaction at the head of the log, keeping at most {@link #MAX_LOG} rows. */
+    public void addLog(LogEntry entry) {
+        if (entry == null) return;
+        this.log.add(0, entry);
+        while (this.log.size() > MAX_LOG) {
+            this.log.remove(this.log.size() - 1);
+        }
+    }
+
+    public String toJson() {
+        JsonData data = new JsonData(this.entries);
+        data.name = this.name;
+        data.description = this.description;
+        data.accessOpen = this.accessOpen;
+        data.accessDonate = this.accessDonate;
+        data.capacityMax = this.capacityMax;
+        data.appearanceState = this.appearanceState;
+        data.notifyFull = this.notifyFull;
+        data.notifyDonation = this.notifyDonation;
+        data.notifyWithdraw = this.notifyWithdraw;
+        data.notifyEmpty = this.notifyEmpty;
+        data.notifyWired = this.notifyWired;
+        data.notifyMode = this.notifyMode;
+        data.log = this.log;
+        return WiredManager.getGson().toJson(data);
+    }
+
+    /** Parse from a wired_data JSON string. Null / blank / malformed → an empty chest (never throws). */
+    public static ChestStorage fromJson(String json) {
+        ChestStorage chest = new ChestStorage();
+        if (json == null || json.isEmpty() || !json.startsWith("{")) {
+            return chest;
+        }
+        try {
+            JsonData data = WiredManager.getGson().fromJson(json, JsonData.class);
+            if (data != null) {
+                if (data.entries != null) {
+                    for (Entry e : data.entries) {
+                        if (e != null && e.quantity > 0) {
+                            chest.add(e.kind, e.type, e.quantity);
+                        }
+                    }
+                }
+                chest.name = (data.name == null) ? "" : data.name;
+                chest.description = (data.description == null) ? "" : data.description;
+                chest.accessOpen = data.accessOpen;
+                chest.accessDonate = data.accessDonate;
+                chest.capacityMax = (data.capacityMax <= 0) ? DEFAULT_CAPACITY : data.capacityMax;
+                chest.appearanceState = data.appearanceState;
+                chest.notifyFull = data.notifyFull;
+                chest.notifyDonation = data.notifyDonation;
+                chest.notifyWithdraw = data.notifyWithdraw;
+                chest.notifyEmpty = data.notifyEmpty;
+                chest.notifyWired = data.notifyWired;
+                chest.notifyMode = data.notifyMode;
+                if (data.log != null) {
+                    for (LogEntry le : data.log) {
+                        if (le != null) chest.log.add(le);
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+            // malformed payload → empty chest
+        }
+        return chest;
+    }
+
+    static class JsonData {
+        List<Entry> entries;
+        String name = "";
+        String description = "";
+        boolean accessOpen = true;
+        boolean accessDonate = false;
+        int capacityMax = DEFAULT_CAPACITY;
+        int appearanceState = 0;
+        boolean notifyFull = false;
+        boolean notifyDonation = false;
+        boolean notifyWithdraw = false;
+        boolean notifyEmpty = false;
+        boolean notifyWired = false;
+        int notifyMode = 0;
+        List<LogEntry> log;
+
+        JsonData() {
+        }
+
+        JsonData(List<Entry> entries) {
+            this.entries = entries;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChest.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChest.java
@@ -1,0 +1,67 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomUnit;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Base for Phase-2 wired storage chests (config-based v1). A chest is a config-holder furni (it opens
+ * a dialog via the {@link InteractionWiredExtra} channel, but is never applied as a stack add-on — the
+ * engine only matches specific add-on classes) whose contents live as JSON in its own
+ * {@code items.wired_data} ({@link ChestStorage}). The give effects + chest conditions read/mutate the
+ * contents through {@link #getContents()} and persist with {@link #persistContents()}.
+ */
+public abstract class InteractionWiredChest extends InteractionWiredExtra {
+    protected ChestStorage contents = new ChestStorage();
+
+    protected InteractionWiredChest(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    protected InteractionWiredChest(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    @Override
+    public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
+        return false;
+    }
+
+    @Override
+    public String getWiredData() {
+        return this.contents.toJson();
+    }
+
+    @Override
+    public void loadWiredData(ResultSet set, Room room) throws SQLException {
+        this.contents = ChestStorage.fromJson(set.getString("wired_data"));
+    }
+
+    @Override
+    public void onPickUp() {
+        this.contents = new ChestStorage();
+    }
+
+    @Override
+    public void onWalk(RoomUnit roomUnit, Room room, Object[] objects) throws Exception {
+
+    }
+
+    @Override
+    public boolean hasConfiguration() {
+        return true;
+    }
+
+    public ChestStorage getContents() {
+        return this.contents;
+    }
+
+    /** Schedule a save of the (mutated) contents to items.wired_data via {@code InteractionWired.run()}. */
+    public void persistContents() {
+        this.needsUpdate(true);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestCurrency.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestCurrency.java
@@ -5,7 +5,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.messages.ServerMessage;
-import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestOpenHelper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -40,7 +40,7 @@ public class InteractionWiredChestCurrency extends InteractionWiredChest {
         if (client == null || room == null) return;
         // "Tutti possono aprire" toggle: anyone if accessOpen, otherwise room rights only.
         if (!this.contents.isAccessOpen() && !room.hasRights(client.getHabbo())) return;
-        client.sendResponse(new ChestDataComposer(this));
+        ChestOpenHelper.open(client, this, room);
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestCurrency.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestCurrency.java
@@ -1,0 +1,86 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Credit Chest (furni classnames {@code wf_storage_coins1} / {@code wf_storage_coins2}). Holds a single
+ * currency pool, configured via its dialog (currency type + amount) and dispensed by
+ * {@code WiredEffectGiveCurrencyFromChest}. Currency type convention: {@code -1} = credits
+ * ({@link com.eu.habbo.habbohotel.users.Habbo#giveCredits}); {@code >= 0} = a points type
+ * ({@code Habbo.givePoints(type, amount)} — e.g. 0 duckets, 5 diamonds).
+ */
+public class InteractionWiredChestCurrency extends InteractionWiredChest {
+    /** Client WiredActionLayoutCode value for the chest dialog. */
+    public static final int CODE = 100;
+    public static final int CURRENCY_CREDITS = -1;
+
+    public InteractionWiredChestCurrency(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionWiredChestCurrency(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    /**
+     * Player-first: clicking the chest opens the player Scrigno UI (balance + deposit/withdraw) instead
+     * of the wired-config dialog. The contents stay a {@link ChestStorage} so contracts / give-from-chest
+     * keep working. Anyone can open; withdraw is gated to room rights server-side (see ChestWithdrawEvent).
+     */
+    @Override
+    public void onClick(GameClient client, Room room, Object[] objects) throws Exception {
+        if (client == null || room == null) return;
+        // "Tutti possono aprire" toggle: anyone if accessOpen, otherwise room rights only.
+        if (!this.contents.isAccessOpen() && !room.hasRights(client.getHabbo())) return;
+        client.sendResponse(new ChestDataComposer(this));
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int[] params = settings.getIntParams();
+        int currencyType = (params.length > 0) ? params[0] : CURRENCY_CREDITS;
+        int amount = (params.length > 1) ? Math.max(0, params[1]) : 0;
+
+        // Re-configuring the chest replaces its pool.
+        this.contents = new ChestStorage();
+        if (amount > 0) {
+            this.contents.add(ChestStorage.KIND_CURRENCY, currencyType, amount);
+        }
+        return true;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        int currencyType = CURRENCY_CREDITS;
+        int amount = 0;
+        for (ChestStorage.Entry e : this.contents.entries()) {
+            if (e.kind == ChestStorage.KIND_CURRENCY) {
+                currencyType = e.type;
+                amount = e.quantity;
+                break;
+            }
+        }
+
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(currencyType);
+        message.appendInt(amount);
+        message.appendInt(0);
+        message.appendInt(CODE);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestFurni.java
@@ -6,8 +6,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.messages.ServerMessage;
-import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniPackets;
-import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestOpenHelper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -39,8 +38,7 @@ public class InteractionWiredChestFurni extends InteractionWiredChest {
     public void onClick(GameClient client, Room room, Object[] objects) throws Exception {
         if (client == null || room == null) return;
         if (!this.contents.isAccessOpen() && !room.hasRights(client.getHabbo())) return;
-        client.sendResponse(new ChestDataComposer(this));
-        ChestFurniPackets.sendFullChunks(client, this.getId(), this.contents);
+        ChestOpenHelper.open(client, this, room);
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestFurni.java
@@ -6,6 +6,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniPackets;
 import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
 
 import java.sql.ResultSet;
@@ -39,6 +40,7 @@ public class InteractionWiredChestFurni extends InteractionWiredChest {
         if (client == null || room == null) return;
         if (!this.contents.isAccessOpen() && !room.hasRights(client.getHabbo())) return;
         client.sendResponse(new ChestDataComposer(this));
+        ChestFurniPackets.sendFullChunks(client, this.getId(), this.contents);
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/InteractionWiredChestFurni.java
@@ -1,0 +1,84 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.chest;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Furni Chest (classnames {@code wf_storage_furni1/2/_starter}). Config-based v1: holds a single furni
+ * base-type pool (base item id + quantity), set via its dialog and dispensed by
+ * {@code WiredEffectGiveFurniFromChest}. (Multi-type chests are a future extension — the
+ * {@link ChestStorage} model already supports many entries.)
+ */
+public class InteractionWiredChestFurni extends InteractionWiredChest {
+    /** Client WiredActionLayoutCode value for the furni-chest dialog. */
+    public static final int CODE = 101;
+
+    public InteractionWiredChestFurni(ResultSet set, Item baseItem) throws SQLException {
+        super(set, baseItem);
+    }
+
+    public InteractionWiredChestFurni(int id, int userId, Item item, String extradata, int limitedStack, int limitedSells) {
+        super(id, userId, item, extradata, limitedStack, limitedSells);
+    }
+
+    /**
+     * Player-first: clicking the furni chest opens the player Scrigno UI (item grid + withdraw) instead of
+     * the wired-config dialog. Anyone can open if accessOpen; withdraw is gated to room rights server-side
+     * (see ChestWithdrawFurniEvent).
+     */
+    @Override
+    public void onClick(GameClient client, Room room, Object[] objects) throws Exception {
+        if (client == null || room == null) return;
+        if (!this.contents.isAccessOpen() && !room.hasRights(client.getHabbo())) return;
+        client.sendResponse(new ChestDataComposer(this));
+    }
+
+    @Override
+    public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        int[] params = settings.getIntParams();
+        int baseItemId = (params.length > 0) ? params[0] : 0;
+        int quantity = (params.length > 1) ? Math.max(0, params[1]) : 0;
+
+        this.contents = new ChestStorage();
+        // Only stock a valid, existing base item.
+        if (baseItemId > 0 && quantity > 0 && Emulator.getGameEnvironment().getItemManager().getItem(baseItemId) != null) {
+            this.contents.add(ChestStorage.KIND_FURNI, baseItemId, quantity);
+        }
+        return true;
+    }
+
+    @Override
+    public void serializeWiredData(ServerMessage message, Room room) {
+        int baseItemId = 0;
+        int quantity = 0;
+        for (ChestStorage.Entry e : this.contents.entries()) {
+            if (e.kind == ChestStorage.KIND_FURNI) {
+                baseItemId = e.type;
+                quantity = e.quantity;
+                break;
+            }
+        }
+
+        message.appendBoolean(false);
+        message.appendInt(0);
+        message.appendInt(0);
+        message.appendInt(this.getBaseItem().getSpriteId());
+        message.appendInt(this.getId());
+        message.appendString("");
+        message.appendInt(2);
+        message.appendInt(baseItemId);
+        message.appendInt(quantity);
+        message.appendInt(0);
+        message.appendInt(CODE);
+        message.appendInt(0);
+        message.appendInt(0);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -390,6 +390,7 @@ public class PacketManager {
         this.registerHandler(Incoming.SearchRoomsMyFavoriteEvent, SearchRoomsMyFavouriteEvent.class);
         this.registerHandler(Incoming.SearchRoomsVisitedEvent, SearchRoomsVisitedEvent.class);
         this.registerHandler(Incoming.RequestNewNavigatorDataEvent, RequestNewNavigatorDataEvent.class);
+        this.registerHandler(Incoming.GetCategoriesWithUserCountEvent, GetCategoriesWithUserCountEvent.class);
         this.registerHandler(Incoming.RequestNewNavigatorRoomsEvent, RequestNewNavigatorRoomsEvent.class);
         this.registerHandler(Incoming.NewNavigatorActionEvent, NewNavigatorActionEvent.class);
         this.registerHandler(Incoming.RequestNavigatorSettingsEvent, RequestNavigatorSettingsEvent.class);
@@ -466,6 +467,7 @@ public class PacketManager {
         this.registerHandler(Incoming.ChestStartDepositEvent, ChestStartDepositEvent.class);
         this.registerHandler(Incoming.ChestDepositInventoryItemEvent, ChestDepositInventoryItemEvent.class);
         this.registerHandler(Incoming.ChestWithdrawAllFurniEvent, ChestWithdrawAllFurniEvent.class);
+        this.registerHandler(Incoming.ChestOpenEvent, ChestOpenEvent.class);
         this.registerHandler(Incoming.ChestSaveSettingsEvent, ChestSaveSettingsEvent.class);
         this.registerHandler(Incoming.ChestSaveNotificationsEvent, ChestSaveNotificationsEvent.class);
         this.registerHandler(Incoming.ChestUpgradeCapacityEvent, ChestUpgradeCapacityEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -459,6 +459,13 @@ public class PacketManager {
         this.registerHandler(Incoming.ClickUserEvent, ClickUserEvent.class);
         this.registerHandler(Incoming.ToggleFloorItemEvent, ToggleFloorItemEvent.class);
         this.registerHandler(Incoming.ToggleWallItemEvent, ToggleWallItemEvent.class);
+        this.registerHandler(Incoming.ChestDepositEvent, ChestDepositEvent.class);
+        this.registerHandler(Incoming.ChestWithdrawEvent, ChestWithdrawEvent.class);
+        this.registerHandler(Incoming.ChestWithdrawFurniEvent, ChestWithdrawFurniEvent.class);
+        this.registerHandler(Incoming.ChestSaveSettingsEvent, ChestSaveSettingsEvent.class);
+        this.registerHandler(Incoming.ChestSaveNotificationsEvent, ChestSaveNotificationsEvent.class);
+        this.registerHandler(Incoming.ChestUpgradeCapacityEvent, ChestUpgradeCapacityEvent.class);
+        this.registerHandler(Incoming.ChestRequestLogEvent, ChestRequestLogEvent.class);
         this.registerHandler(Incoming.RoomBackgroundEvent, RoomBackgroundEvent.class);
         this.registerHandler(Incoming.MannequinSaveNameEvent, MannequinSaveNameEvent.class);
         this.registerHandler(Incoming.MannequinSaveLookEvent, MannequinSaveLookEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -463,6 +463,8 @@ public class PacketManager {
         this.registerHandler(Incoming.ChestWithdrawEvent, ChestWithdrawEvent.class);
         this.registerHandler(Incoming.ChestWithdrawFurniEvent, ChestWithdrawFurniEvent.class);
         this.registerHandler(Incoming.ChestDepositFurniEvent, ChestDepositFurniEvent.class);
+        this.registerHandler(Incoming.ChestStartDepositEvent, ChestStartDepositEvent.class);
+        this.registerHandler(Incoming.ChestDepositInventoryItemEvent, ChestDepositInventoryItemEvent.class);
         this.registerHandler(Incoming.ChestSaveSettingsEvent, ChestSaveSettingsEvent.class);
         this.registerHandler(Incoming.ChestSaveNotificationsEvent, ChestSaveNotificationsEvent.class);
         this.registerHandler(Incoming.ChestUpgradeCapacityEvent, ChestUpgradeCapacityEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -462,6 +462,7 @@ public class PacketManager {
         this.registerHandler(Incoming.ChestDepositEvent, ChestDepositEvent.class);
         this.registerHandler(Incoming.ChestWithdrawEvent, ChestWithdrawEvent.class);
         this.registerHandler(Incoming.ChestWithdrawFurniEvent, ChestWithdrawFurniEvent.class);
+        this.registerHandler(Incoming.ChestDepositFurniEvent, ChestDepositFurniEvent.class);
         this.registerHandler(Incoming.ChestSaveSettingsEvent, ChestSaveSettingsEvent.class);
         this.registerHandler(Incoming.ChestSaveNotificationsEvent, ChestSaveNotificationsEvent.class);
         this.registerHandler(Incoming.ChestUpgradeCapacityEvent, ChestUpgradeCapacityEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -465,6 +465,7 @@ public class PacketManager {
         this.registerHandler(Incoming.ChestDepositFurniEvent, ChestDepositFurniEvent.class);
         this.registerHandler(Incoming.ChestStartDepositEvent, ChestStartDepositEvent.class);
         this.registerHandler(Incoming.ChestDepositInventoryItemEvent, ChestDepositInventoryItemEvent.class);
+        this.registerHandler(Incoming.ChestWithdrawAllFurniEvent, ChestWithdrawAllFurniEvent.class);
         this.registerHandler(Incoming.ChestSaveSettingsEvent, ChestSaveSettingsEvent.class);
         this.registerHandler(Incoming.ChestSaveNotificationsEvent, ChestSaveNotificationsEvent.class);
         this.registerHandler(Incoming.ChestUpgradeCapacityEvent, ChestUpgradeCapacityEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -14,6 +14,7 @@ public class Incoming {
     public static final int ChestStartDepositEvent = 9324; // Enter furni deposit mode (official Kigike)
     public static final int ChestDepositInventoryItemEvent = 9325; // Deposit one inventory row into active chest
     public static final int ChestWithdrawAllFurniEvent = 9326; // Withdraw all furni (official Vefehonuj shape)
+    public static final int ChestOpenEvent = 9327; // Open wired chest (official Nod)
     public static final int ChangeNameCheckUsernameEvent = 3950;
     public static final int ConfirmChangeNameEvent = 2977;
     public static final int ActivateEffectEvent = 2959;
@@ -231,6 +232,7 @@ public class Incoming {
     public static final int UnknownEvent1 = 1371;
     public static final int RequestTalenTrackEvent = 196;
     public static final int RequestNewNavigatorDataEvent = 2110;
+    public static final int GetCategoriesWithUserCountEvent = 3782;
     public static final int RequestNewNavigatorRoomsEvent = 249;
     public static final int RedeemClothingEvent = 3374;
     public static final int NewNavigatorActionEvent = 1703;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -13,6 +13,7 @@ public class Incoming {
     public static final int ChestDepositFurniEvent = 9321; // Player-facing wired furni chest deposit (from inventory)
     public static final int ChestStartDepositEvent = 9324; // Enter furni deposit mode (official Kigike)
     public static final int ChestDepositInventoryItemEvent = 9325; // Deposit one inventory row into active chest
+    public static final int ChestWithdrawAllFurniEvent = 9326; // Withdraw all furni (official Vefehonuj shape)
     public static final int ChangeNameCheckUsernameEvent = 3950;
     public static final int ConfirmChangeNameEvent = 2977;
     public static final int ActivateEffectEvent = 2959;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -2,6 +2,14 @@ package com.eu.habbo.messages.incoming;
 
 public class Incoming {
     public static final int PongEvent = 2596;
+    // Player-facing wired chest (Scrigno)
+    public static final int ChestDepositEvent = 9313;
+    public static final int ChestWithdrawEvent = 9314;
+    public static final int ChestSaveSettingsEvent = 9315;
+    public static final int ChestSaveNotificationsEvent = 9316;
+    public static final int ChestUpgradeCapacityEvent = 9317;
+    public static final int ChestRequestLogEvent = 9318;
+    public static final int ChestWithdrawFurniEvent = 9320;
     public static final int ChangeNameCheckUsernameEvent = 3950;
     public static final int ConfirmChangeNameEvent = 2977;
     public static final int ActivateEffectEvent = 2959;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -11,6 +11,8 @@ public class Incoming {
     public static final int ChestRequestLogEvent = 9318;
     public static final int ChestWithdrawFurniEvent = 9320;
     public static final int ChestDepositFurniEvent = 9321; // Player-facing wired furni chest deposit (from inventory)
+    public static final int ChestStartDepositEvent = 9324; // Enter furni deposit mode (official Kigike)
+    public static final int ChestDepositInventoryItemEvent = 9325; // Deposit one inventory row into active chest
     public static final int ChangeNameCheckUsernameEvent = 3950;
     public static final int ConfirmChangeNameEvent = 2977;
     public static final int ActivateEffectEvent = 2959;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -10,6 +10,7 @@ public class Incoming {
     public static final int ChestUpgradeCapacityEvent = 9317;
     public static final int ChestRequestLogEvent = 9318;
     public static final int ChestWithdrawFurniEvent = 9320;
+    public static final int ChestDepositFurniEvent = 9321; // Player-facing wired furni chest deposit (from inventory)
     public static final int ChangeNameCheckUsernameEvent = 3950;
     public static final int ConfirmChangeNameEvent = 2977;
     public static final int ActivateEffectEvent = 2959;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/navigator/GetCategoriesWithUserCountEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/navigator/GetCategoriesWithUserCountEvent.java
@@ -1,0 +1,19 @@
+package com.eu.habbo.messages.incoming.navigator;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.rooms.RoomCategory;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.navigator.NewNavigatorCategoryUserCountComposer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Client requests per-category visitor counts (header 3782). */
+public class GetCategoriesWithUserCountEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        List<RoomCategory> categories = new ArrayList<>(
+                Emulator.getGameEnvironment().getRoomManager().roomCategoriesForHabbo(this.client.getHabbo()));
+        this.client.sendResponse(new NewNavigatorCategoryUserCountComposer(categories));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/navigator/RequestNewNavigatorDataEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/navigator/RequestNewNavigatorDataEvent.java
@@ -1,7 +1,12 @@
 package com.eu.habbo.messages.incoming.navigator;
 
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.rooms.RoomCategory;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.navigator.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class RequestNewNavigatorDataEvent extends MessageHandler {
     @Override
@@ -12,5 +17,9 @@ public class RequestNewNavigatorDataEvent extends MessageHandler {
         this.client.sendResponse(new NewNavigatorCollapsedCategoriesComposer());
         this.client.sendResponse(new NewNavigatorSavedSearchesComposer(this.client.getHabbo().getHabboInfo().getSavedSearches()));
         this.client.sendResponse(new NewNavigatorEventCategoriesComposer());
+
+        List<RoomCategory> categories = new ArrayList<>(
+                Emulator.getGameEnvironment().getRoomManager().roomCategoriesForHabbo(this.client.getHabbo()));
+        this.client.sendResponse(new NewNavigatorCategoryUserCountComposer(categories));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositEvent.java
@@ -1,0 +1,55 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Player deposits currency into a wired chest (Scrigno). Reads {@code int itemId, int currencyType,
+ * int amount}; allowed if the chest permits donations or the user has room rights. Debits the user
+ * (if affordable), adds to the pool (capped at the chest's capacity), logs it, pushes back the state.
+ */
+public class ChestDepositEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int currencyType = this.packet.readInt();
+        int amount = this.packet.readInt();
+        if (amount <= 0) return;
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        ChestStorage contents = chest.getContents();
+
+        if (!contents.isAccessDonate() && !room.hasRights(habbo)) return;
+
+        int balance = (currencyType < 0)
+                ? habbo.getHabboInfo().getCredits()
+                : habbo.getHabboInfo().getCurrencyAmount(currencyType);
+        if (balance < amount) return;
+
+        int capacityLeft = contents.getCapacityMax() - contents.total(ChestStorage.KIND_CURRENCY);
+        if (capacityLeft <= 0) return;
+        if (amount > capacityLeft) amount = capacityLeft;
+
+        if (currencyType < 0) habbo.giveCredits(-amount);
+        else habbo.givePoints(currencyType, -amount);
+
+        contents.add(ChestStorage.KIND_CURRENCY, currencyType, amount);
+        contents.addLog(new ChestStorage.LogEntry("deposit", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), 0, amount));
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositFurniEvent.java
@@ -3,6 +3,8 @@ package com.eu.habbo.messages.incoming.rooms.items;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.FurnitureType;
 import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniPackets;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniStoredItem;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
 import com.eu.habbo.habbohotel.rooms.Room;
@@ -52,22 +54,25 @@ public class ChestDepositFurniEvent extends MessageHandler {
         int availableInInventory = countInInventory(habbo, baseItemId);
         if (availableInInventory <= 0) return;
 
-        int capacityLeft = contents.getCapacityMax() - contents.total(ChestStorage.KIND_FURNI);
+        int capacityLeft = contents.getCapacityMax() - contents.furniItemCount();
         if (capacityLeft <= 0) return;
 
         amount = Math.min(amount, Math.min(availableInInventory, capacityLeft));
 
         var toRemove = new ArrayList<HabboItem>();
+        var added = new ArrayList<ChestFurniStoredItem>();
         for (int i = 0; i < amount; i++) {
             HabboItem removed = habbo.getInventory().getItemsComponent().getAndRemoveHabboItem(baseItem);
             if (removed == null) break;
             toRemove.add(removed);
+            added.add(ChestFurniStoredItem.fromHabboItem(removed, 0));
         }
-
         int deposited = toRemove.size();
         if (deposited <= 0) return;
 
-        contents.add(ChestStorage.KIND_FURNI, baseItemId, deposited);
+        for (ChestFurniStoredItem stored : added) {
+            contents.addFurniItem(stored);
+        }
         contents.addLog(new ChestStorage.LogEntry("deposit", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), 0, deposited));
         chest.persistContents();
 
@@ -78,6 +83,7 @@ public class ChestDepositFurniEvent extends MessageHandler {
         Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove));
 
         this.client.sendResponse(new ChestDataComposer(chest));
+        ChestFurniPackets.sendDelta(this.client, chest.getId(), List.of(), added);
     }
 
     private static int countInInventory(Habbo habbo, int baseItemId) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositFurniEvent.java
@@ -1,0 +1,92 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.FurnitureType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+import com.eu.habbo.threading.runnables.QueryDeleteHabboItems;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Player deposits floor furni from inventory into a wired furni chest (Scrigno furni).
+ * Reads {@code int itemId, int baseItemId, int amount}. Allowed if the chest permits donations
+ * or the user has room rights. Removes matching inventory rows, adds to the chest pool (capped
+ * at capacity), logs, and pushes back chest state + inventory updates.
+ */
+public class ChestDepositFurniEvent extends MessageHandler {
+    private static final int MAX_DEPOSIT_AMOUNT = 100;
+
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int baseItemId = this.packet.readInt();
+        int amount = this.packet.readInt();
+        if (amount <= 0 || amount > MAX_DEPOSIT_AMOUNT) return;
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        ChestStorage contents = chest.getContents();
+
+        if (!contents.isAccessDonate() && !room.hasRights(habbo)) return;
+
+        Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(baseItemId);
+        if (baseItem == null || baseItem.getType() != FurnitureType.FLOOR) return;
+
+        int availableInInventory = countInInventory(habbo, baseItemId);
+        if (availableInInventory <= 0) return;
+
+        int capacityLeft = contents.getCapacityMax() - contents.total(ChestStorage.KIND_FURNI);
+        if (capacityLeft <= 0) return;
+
+        amount = Math.min(amount, Math.min(availableInInventory, capacityLeft));
+
+        var toRemove = new ArrayList<HabboItem>();
+        for (int i = 0; i < amount; i++) {
+            HabboItem removed = habbo.getInventory().getItemsComponent().getAndRemoveHabboItem(baseItem);
+            if (removed == null) break;
+            toRemove.add(removed);
+        }
+
+        int deposited = toRemove.size();
+        if (deposited <= 0) return;
+
+        contents.add(ChestStorage.KIND_FURNI, baseItemId, deposited);
+        contents.addLog(new ChestStorage.LogEntry("deposit", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), 0, deposited));
+        chest.persistContents();
+
+        for (HabboItem removed : toRemove) {
+            habbo.getClient().sendResponse(new RemoveHabboItemComposer(removed.getGiftAdjustedId()));
+        }
+        habbo.getClient().sendResponse(new InventoryRefreshComposer());
+        Emulator.getThreading().run(new QueryDeleteHabboItems(toRemove));
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+
+    private static int countInInventory(Habbo habbo, int baseItemId) {
+        int count = 0;
+        for (HabboItem habboItem : habbo.getInventory().getItemsComponent().getItemsAsValueCollection()) {
+            if (habboItem != null && habboItem.getBaseItem().getId() == baseItemId) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositInventoryItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestDepositInventoryItemEvent.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestDepositSession;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniDepositHelper;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+
+/** Deposit one inventory furni row into a wired furni chest [chestItemId, inventoryItemId]. Header 9325. */
+public class ChestDepositInventoryItemEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int chestItemId = this.packet.readInt();
+        int inventoryItemId = this.packet.readInt();
+        if (inventoryItemId <= 0) return;
+
+        if (!ChestDepositSession.isDepositingInto(habbo.getHabboInfo().getId(), chestItemId)) return;
+
+        HabboItem item = room.getHabboItem(chestItemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        HabboItem inventoryItem = habbo.getInventory().getItemsComponent().getHabboItem(inventoryItemId);
+        if (inventoryItem == null) return;
+
+        ChestFurniDepositHelper.depositInventoryItem(habbo, chest, inventoryItem);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestOpenEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestOpenEvent.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestOpenHelper;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+
+/**
+ * Player opens a wired chest (official Nod / header 806 wire shape, Nitro header 9327): {@code int chestItemId}.
+ */
+public class ChestOpenEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        ChestOpenHelper.open(this.client, chest, room);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestRequestLogEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestRequestLogEvent.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestLogComposer;
+
+/**
+ * Requests a wired chest's transaction log: {@code int itemId}. Responds with {@link ChestLogComposer}.
+ */
+public class ChestRequestLogEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        this.client.sendResponse(new ChestLogComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestSaveNotificationsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestSaveNotificationsEvent.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Saves a wired chest's notification prefs (room-rights only): {@code int itemId, bool full,
+ * bool donation, bool withdraw, bool empty, bool wired, int mode}.
+ */
+public class ChestSaveNotificationsEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        boolean full = this.packet.readBoolean();
+        boolean donation = this.packet.readBoolean();
+        boolean withdraw = this.packet.readBoolean();
+        boolean empty = this.packet.readBoolean();
+        boolean wired = this.packet.readBoolean();
+        int mode = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+        if (!room.hasRights(habbo)) return;
+
+        chest.getContents().setNotifications(full, donation, withdraw, empty, wired, mode);
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestSaveSettingsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestSaveSettingsEvent.java
@@ -1,0 +1,50 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Saves a wired chest's settings (room-rights only): {@code int itemId, string name, string description,
+ * bool accessOpen, bool accessDonate, int appearanceState}.
+ */
+public class ChestSaveSettingsEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        String name = this.packet.readString();
+        String description = this.packet.readString();
+        boolean accessOpen = this.packet.readBoolean();
+        boolean accessDonate = this.packet.readBoolean();
+        int appearanceState = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+        if (!room.hasRights(habbo)) return;
+
+        ChestStorage c = chest.getContents();
+        c.setName(bound(name, 60));
+        c.setDescription(bound(description, 255));
+        c.setAccessOpen(accessOpen);
+        c.setAccessDonate(accessDonate);
+        c.setAppearanceState(appearanceState);
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+
+    private static String bound(String value, int max) {
+        if (value == null) return "";
+        return value.length() > max ? value.substring(0, max) : value;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestStartDepositEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestStartDepositEvent.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestDepositSession;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+
+/**
+ * Start furni deposit mode (official Kigike / header 3514 wire shape).
+ * We use header {@code ChestStartDepositEvent} (9324) because 3514 is unavailable in Nitro.
+ */
+public class ChestStartDepositEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int chestItemId = this.packet.readInt();
+        HabboItem item = room.getHabboItem(chestItemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+        if (!chest.getContents().isAccessDonate() && !room.hasRights(habbo)) return;
+
+        ChestDepositSession.start(habbo.getHabboInfo().getId(), chestItemId);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestUpgradeCapacityEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestUpgradeCapacityEvent.java
@@ -1,0 +1,56 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Buys extra chest capacity (room-rights only): {@code int itemId, int quantity}. Each step adds
+ * {@link ChestStorage#CAPACITY_STEP} (+5000) and costs {@link #COST_CREDITS} credits +
+ * {@link #COST_DIAMONDS} diamonds (points type {@link #DIAMOND_TYPE}). All-or-nothing.
+ */
+public class ChestUpgradeCapacityEvent extends MessageHandler {
+    public static final int COST_CREDITS = 10;
+    public static final int COST_DIAMONDS = 10;
+    public static final int DIAMOND_TYPE = 5;
+    private static final int MAX_QUANTITY = 10;
+
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int quantity = this.packet.readInt();
+        if (quantity <= 0) return;
+        quantity = Math.min(quantity, MAX_QUANTITY);
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+        if (!room.hasRights(habbo)) return;
+
+        ChestStorage c = chest.getContents();
+        if (c.getCapacityMax() + (ChestStorage.CAPACITY_STEP * quantity) > ChestStorage.MAX_CAPACITY) return;
+
+        int totalCredits = COST_CREDITS * quantity;
+        int totalDiamonds = COST_DIAMONDS * quantity;
+
+        if (habbo.getHabboInfo().getCredits() < totalCredits) return;
+        if (habbo.getHabboInfo().getCurrencyAmount(DIAMOND_TYPE) < totalDiamonds) return;
+
+        habbo.giveCredits(-totalCredits);
+        habbo.givePoints(DIAMOND_TYPE, -totalDiamonds);
+
+        c.setCapacityMax(c.getCapacityMax() + (ChestStorage.CAPACITY_STEP * quantity));
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawAllFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawAllFurniEvent.java
@@ -1,0 +1,68 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniPackets;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniStoredItem;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+import java.util.List;
+
+/**
+ * Withdraw all stored furni from a wired furni chest (official Vefehonuj wire shape):
+ * {@code int chestItemId} only. Header 9326.
+ */
+public class ChestWithdrawAllFurniEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        if (!room.hasRights(habbo)) return;
+
+        ChestStorage contents = chest.getContents();
+        List<ChestFurniStoredItem> removedItems = contents.removeAllFurniItems();
+        if (removedItems.isEmpty()) return;
+
+        int taken = 0;
+        for (ChestFurniStoredItem stored : removedItems) {
+            Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(stored.baseItemId);
+            if (baseItem == null) continue;
+
+            HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
+                    habbo.getHabboInfo().getId(), baseItem, stored.limitedStack, stored.limitedSells, stored.extradata);
+            if (created == null) continue;
+
+            this.client.sendResponse(new AddHabboItemComposer(created));
+            habbo.getInventory().getItemsComponent().addItem(created);
+            taken++;
+        }
+
+        if (taken <= 0) return;
+
+        this.client.sendResponse(new InventoryRefreshComposer());
+
+        contents.addLog(new ChestStorage.LogEntry("withdraw", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), taken, 0));
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+        ChestFurniPackets.sendDelta(this.client, chest.getId(),
+                removedItems.stream().map(i -> i.inventoryId).toList(), List.of());
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawEvent.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Player withdraws currency from a wired chest (Scrigno). Reads {@code int itemId, int currencyType,
+ * int amount} (amount {@code < 0} = withdraw all of that type). Restricted to users with room rights
+ * (anti-theft). Takes from the pool, credits the user, logs it, pushes back the state.
+ */
+public class ChestWithdrawEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int currencyType = this.packet.readInt();
+        int amount = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        if (!room.hasRights(habbo)) return;
+
+        ChestStorage contents = chest.getContents();
+        int available = contents.count(ChestStorage.KIND_CURRENCY, currencyType);
+        if (available <= 0) return;
+
+        int requested = (amount < 0) ? available : Math.min(amount, available);
+        if (requested <= 0) return;
+
+        int taken = contents.take(ChestStorage.KIND_CURRENCY, currencyType, requested);
+        if (taken <= 0) return;
+
+        contents.addLog(new ChestStorage.LogEntry("withdraw", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), taken, 0));
+        chest.persistContents();
+
+        if (currencyType < 0) habbo.giveCredits(taken);
+        else habbo.givePoints(currencyType, taken);
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawFurniEvent.java
@@ -1,0 +1,65 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
+import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
+import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
+
+/**
+ * Player withdraws stored furni from a wired furni chest (Scrigno furni). Reads {@code int itemId,
+ * int baseItemId, int amount} (amount {@code < 0} = withdraw all of that base type). Restricted to users
+ * with room rights (anti-theft). Decrements the chest pool, creates that many items into the player's
+ * inventory, logs it, and pushes back the chest state. Mirrors {@link ChestWithdrawEvent} (currency).
+ */
+public class ChestWithdrawFurniEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        Habbo habbo = this.client.getHabbo();
+        if (habbo == null) return;
+
+        Room room = habbo.getHabboInfo().getCurrentRoom();
+        if (room == null) return;
+
+        int itemId = this.packet.readInt();
+        int baseItemId = this.packet.readInt();
+        int amount = this.packet.readInt();
+
+        HabboItem item = room.getHabboItem(itemId);
+        if (!(item instanceof InteractionWiredChest chest)) return;
+
+        if (!room.hasRights(habbo)) return;
+
+        Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(baseItemId);
+        if (baseItem == null) return;
+
+        ChestStorage contents = chest.getContents();
+        int available = contents.count(ChestStorage.KIND_FURNI, baseItemId);
+        if (available <= 0) return;
+
+        int requested = (amount < 0) ? available : Math.min(amount, available);
+        if (requested <= 0) return;
+
+        int taken = contents.take(ChestStorage.KIND_FURNI, baseItemId, requested);
+        if (taken <= 0) return;
+
+        for (int i = 0; i < taken; i++) {
+            HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getHabboInfo().getId(), baseItem, 0, 0, "");
+            if (created == null) continue;
+            this.client.sendResponse(new AddHabboItemComposer(created));
+            habbo.getInventory().getItemsComponent().addItem(created);
+        }
+        this.client.sendResponse(new InventoryRefreshComposer());
+
+        contents.addLog(new ChestStorage.LogEntry("withdraw", System.currentTimeMillis(), habbo.getHabboInfo().getUsername(), taken, 0));
+        chest.persistContents();
+
+        this.client.sendResponse(new ChestDataComposer(chest));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ChestWithdrawFurniEvent.java
@@ -2,6 +2,8 @@ package com.eu.habbo.messages.incoming.rooms.items;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniPackets;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniStoredItem;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
 import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
 import com.eu.habbo.habbohotel.rooms.Room;
@@ -12,11 +14,12 @@ import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.ChestDataComposer;
 
+import java.util.List;
+
 /**
- * Player withdraws stored furni from a wired furni chest (Scrigno furni). Reads {@code int itemId,
- * int baseItemId, int amount} (amount {@code < 0} = withdraw all of that base type). Restricted to users
- * with room rights (anti-theft). Decrements the chest pool, creates that many items into the player's
- * inventory, logs it, and pushes back the chest state. Mirrors {@link ChestWithdrawEvent} (currency).
+ * Player withdraws stored furni from a wired furni chest (official Dul wire shape):
+ * {@code int chestItemId, bool isWall, int typeId, string legacyPosterId, int amount}.
+ * amount {@code < 0} = withdraw all matching rows.
  */
 public class ChestWithdrawFurniEvent extends MessageHandler {
     @Override
@@ -28,7 +31,9 @@ public class ChestWithdrawFurniEvent extends MessageHandler {
         if (room == null) return;
 
         int itemId = this.packet.readInt();
-        int baseItemId = this.packet.readInt();
+        boolean wallItem = this.packet.readBoolean();
+        int typeId = this.packet.readInt();
+        String legacyPosterId = this.packet.readString();
         int amount = this.packet.readInt();
 
         HabboItem item = room.getHabboItem(itemId);
@@ -36,21 +41,23 @@ public class ChestWithdrawFurniEvent extends MessageHandler {
 
         if (!room.hasRights(habbo)) return;
 
-        Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(baseItemId);
+        Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(typeId);
         if (baseItem == null) return;
 
         ChestStorage contents = chest.getContents();
-        int available = contents.count(ChestStorage.KIND_FURNI, baseItemId);
+        int available = contents.count(ChestStorage.KIND_FURNI, typeId);
         if (available <= 0) return;
 
         int requested = (amount < 0) ? available : Math.min(amount, available);
         if (requested <= 0) return;
 
-        int taken = contents.take(ChestStorage.KIND_FURNI, baseItemId, requested);
+        var removedItems = contents.removeFurniByType(wallItem, typeId, legacyPosterId, requested);
+        int taken = removedItems.size();
         if (taken <= 0) return;
 
-        for (int i = 0; i < taken; i++) {
-            HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(habbo.getHabboInfo().getId(), baseItem, 0, 0, "");
+        for (ChestFurniStoredItem stored : removedItems) {
+            HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
+                    habbo.getHabboInfo().getId(), baseItem, stored.limitedStack, stored.limitedSells, stored.extradata);
             if (created == null) continue;
             this.client.sendResponse(new AddHabboItemComposer(created));
             habbo.getInventory().getItemsComponent().addItem(created);
@@ -61,5 +68,7 @@ public class ChestWithdrawFurniEvent extends MessageHandler {
         chest.persistContents();
 
         this.client.sendResponse(new ChestDataComposer(chest));
+        ChestFurniPackets.sendDelta(this.client, chest.getId(),
+                removedItems.stream().map(i -> i.inventoryId).toList(), List.of());
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -9,6 +9,7 @@ public class Outgoing {
     public final static int ChestLogComposer = 9319;
     public final static int ChestFurniChunkComposer = 9322;
     public final static int ChestFurniDeltaComposer = 9323;
+    public final static int ChestOpenComposer = 9327;
     public final static int FavoriteRoomsCountComposer = 151;
     public final static int UserCurrencyComposer = 2018;
     public final static int RedeemVoucherOKComposer = 3336;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -7,6 +7,8 @@ public class Outgoing {
     // Player-facing wired chest (Scrigno)
     public final static int ChestDataComposer = 9312;
     public final static int ChestLogComposer = 9319;
+    public final static int ChestFurniChunkComposer = 9322;
+    public final static int ChestFurniDeltaComposer = 9323;
     public final static int FavoriteRoomsCountComposer = 151;
     public final static int UserCurrencyComposer = 2018;
     public final static int RedeemVoucherOKComposer = 3336;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -4,6 +4,9 @@ public class Outgoing {
     public static final int PetStatusUpdateComposer = 1907;//error 404
 
     public final static int CfhTopicsMessageComposer = 325;
+    // Player-facing wired chest (Scrigno)
+    public final static int ChestDataComposer = 9312;
+    public final static int ChestLogComposer = 9319;
     public final static int FavoriteRoomsCountComposer = 151;
     public final static int UserCurrencyComposer = 2018;
     public final static int RedeemVoucherOKComposer = 3336;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/navigator/NewNavigatorCategoryUserCountComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/navigator/NewNavigatorCategoryUserCountComposer.java
@@ -1,5 +1,7 @@
 package com.eu.habbo.messages.outgoing.navigator;
 
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomCategory;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
@@ -20,9 +22,14 @@ public class NewNavigatorCategoryUserCountComposer extends MessageComposer {
         this.response.appendInt(this.roomCategories.size());
 
         for (RoomCategory category : this.roomCategories) {
+            int current = 0;
+            for (Room room : Emulator.getGameEnvironment().getRoomManager().getActiveRooms(category.getId())) {
+                current += room.getUserCount();
+            }
+
             this.response.appendInt(category.getId());
-            this.response.appendInt(0);
-            this.response.appendInt(200);
+            this.response.appendInt(current);
+            this.response.appendInt(category.getMaxUserCount());
         }
         return this.response;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestDataComposer.java
@@ -1,0 +1,86 @@
+package com.eu.habbo.messages.outgoing.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChestFurni;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Player-facing wired chest (Scrigno) state push. Sent on open and after every deposit / withdraw /
+ * settings change so the client {@code FurnitureChestView} can render the full window (name, description,
+ * balance, capacity, access flags, appearance, notification prefs). Phase-1 currency-only contents.
+ * Wire layout:
+ * <pre>
+ *   int itemId, string name, string description,
+ *   int capacityMax, int used,
+ *   bool accessOpen, bool accessDonate, int appearanceState,
+ *   bool notifyFull, bool notifyDonation, bool notifyWithdraw, bool notifyEmpty, bool notifyWired, int notifyMode,
+ *   int entryCount, [int currencyType, int amount]*,
+ *   int chestKind (0 = currency, 1 = furni),
+ *   int furniCount, [int baseItemId, int quantity]*
+ * </pre>
+ * For a furni chest, {@code used} is the total stored furni count and the currency entry list is empty;
+ * for a currency chest the furni list is empty.
+ */
+public class ChestDataComposer extends MessageComposer {
+    private final InteractionWiredChest chest;
+
+    public ChestDataComposer(InteractionWiredChest chest) {
+        this.chest = chest;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        ChestStorage c = this.chest.getContents();
+        int chestKind = (this.chest instanceof InteractionWiredChestFurni)
+                ? ChestStorage.KIND_FURNI : ChestStorage.KIND_CURRENCY;
+
+        this.response.init(Outgoing.ChestDataComposer);
+        this.response.appendInt(this.chest.getId());
+        this.response.appendString(c.getName());
+        this.response.appendString(c.getDescription());
+        this.response.appendInt(c.getCapacityMax());
+        this.response.appendInt(c.total(chestKind));
+        this.response.appendBoolean(c.isAccessOpen());
+        this.response.appendBoolean(c.isAccessDonate());
+        this.response.appendInt(c.getAppearanceState());
+        this.response.appendBoolean(c.isNotifyFull());
+        this.response.appendBoolean(c.isNotifyDonation());
+        this.response.appendBoolean(c.isNotifyWithdraw());
+        this.response.appendBoolean(c.isNotifyEmpty());
+        this.response.appendBoolean(c.isNotifyWired());
+        this.response.appendInt(c.getNotifyMode());
+
+        List<ChestStorage.Entry> entries = new ArrayList<>();
+        for (ChestStorage.Entry e : c.entries()) {
+            if (e.kind == ChestStorage.KIND_CURRENCY && e.quantity > 0) entries.add(e);
+        }
+
+        this.response.appendInt(entries.size());
+        for (ChestStorage.Entry e : entries) {
+            this.response.appendInt(e.type);
+            this.response.appendInt(e.quantity);
+        }
+
+        // chest kind + furni contents (base item id + quantity per stored type)
+        this.response.appendInt(chestKind);
+
+        List<ChestStorage.Entry> furni = new ArrayList<>();
+        for (ChestStorage.Entry e : c.entries()) {
+            if (e.kind == ChestStorage.KIND_FURNI && e.quantity > 0) furni.add(e);
+        }
+
+        this.response.appendInt(furni.size());
+        for (ChestStorage.Entry e : furni) {
+            this.response.appendInt(e.type);
+            this.response.appendInt(e.quantity);
+        }
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestDataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestDataComposer.java
@@ -45,7 +45,10 @@ public class ChestDataComposer extends MessageComposer {
         this.response.appendString(c.getName());
         this.response.appendString(c.getDescription());
         this.response.appendInt(c.getCapacityMax());
-        this.response.appendInt(c.total(chestKind));
+        int used = (this.chest instanceof InteractionWiredChestFurni)
+                ? c.furniItemCount()
+                : c.total(chestKind);
+        this.response.appendInt(used);
         this.response.appendBoolean(c.isAccessOpen());
         this.response.appendBoolean(c.isAccessDonate());
         this.response.appendInt(c.getAppearanceState());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestFurniChunkComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestFurniChunkComposer.java
@@ -1,0 +1,41 @@
+package com.eu.habbo.messages.outgoing.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniStoredItem;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+
+/**
+ * Furni-chest storage chunk (official client-6 {@code Sebahew} / header 2323 wire shape).
+ * We use header {@link Outgoing#ChestFurniChunkComposer} (9322) because 2323 is taken in Nitro.
+ */
+public class ChestFurniChunkComposer extends MessageComposer {
+    public static final int CHUNK_SIZE = 100;
+
+    private final int chestId;
+    private final int totalFragments;
+    private final int fragmentNo;
+    private final List<ChestFurniStoredItem> chunk;
+
+    public ChestFurniChunkComposer(int chestId, int totalFragments, int fragmentNo, List<ChestFurniStoredItem> chunk) {
+        this.chestId = chestId;
+        this.totalFragments = totalFragments;
+        this.fragmentNo = fragmentNo;
+        this.chunk = chunk;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.ChestFurniChunkComposer);
+        this.response.appendInt(this.chestId);
+        this.response.appendInt(this.totalFragments);
+        this.response.appendInt(this.fragmentNo);
+        this.response.appendInt(this.chunk.size());
+        for (ChestFurniStoredItem item : this.chunk) {
+            item.appendToMessage(this.response);
+        }
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestFurniDeltaComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestFurniDeltaComposer.java
@@ -1,0 +1,39 @@
+package com.eu.habbo.messages.outgoing.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestFurniStoredItem;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+
+/**
+ * Furni-chest incremental update (official client-6 {@code Sola} / header 2738 wire shape).
+ * We use header {@link Outgoing#ChestFurniDeltaComposer} (9323).
+ */
+public class ChestFurniDeltaComposer extends MessageComposer {
+    private final int chestId;
+    private final List<Integer> removedInventoryIds;
+    private final List<ChestFurniStoredItem> added;
+
+    public ChestFurniDeltaComposer(int chestId, List<Integer> removedInventoryIds, List<ChestFurniStoredItem> added) {
+        this.chestId = chestId;
+        this.removedInventoryIds = removedInventoryIds;
+        this.added = added;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.ChestFurniDeltaComposer);
+        this.response.appendInt(this.chestId);
+        this.response.appendInt(this.removedInventoryIds.size());
+        for (int id : this.removedInventoryIds) {
+            this.response.appendInt(id);
+        }
+        this.response.appendInt(this.added.size());
+        for (ChestFurniStoredItem item : this.added) {
+            item.appendToMessage(this.response);
+        }
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestLogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestLogComposer.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.outgoing.rooms.items;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.ChestStorage;
+import com.eu.habbo.habbohotel.items.interactions.wired.chest.InteractionWiredChest;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+
+/**
+ * Wired chest (Scrigno) transaction log, newest first. Wire layout:
+ * {@code int itemId, int rowCount, [string type, int epochSeconds, string userName, int withdrawn, int deposited]*}.
+ */
+public class ChestLogComposer extends MessageComposer {
+    private final InteractionWiredChest chest;
+
+    public ChestLogComposer(InteractionWiredChest chest) {
+        this.chest = chest;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.ChestLogComposer);
+        this.response.appendInt(this.chest.getId());
+
+        List<ChestStorage.LogEntry> log = this.chest.getContents().getLog();
+        this.response.appendInt(log.size());
+
+        for (ChestStorage.LogEntry e : log) {
+            this.response.appendString(e.type == null ? "" : e.type);
+            this.response.appendInt((int) (e.timestamp / 1000L));
+            this.response.appendString(e.userName == null ? "" : e.userName);
+            this.response.appendInt(e.withdrawn);
+            this.response.appendInt(e.deposited);
+        }
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestOpenComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/items/ChestOpenComposer.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.messages.outgoing.rooms.items;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+/**
+ * Ack that a wired chest open request was accepted (official Syhytarer / 1174 wire shape: chestId).
+ * Nitro uses header 9327 because 806/1174 are taken.
+ */
+public class ChestOpenComposer extends MessageComposer {
+    private final int chestId;
+
+    public ChestOpenComposer(int chestId) {
+        this.chestId = chestId;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.ChestOpenComposer);
+        this.response.appendInt(this.chestId);
+        return this.response;
+    }
+
+    public int getChestId() {
+        return chestId;
+    }
+}


### PR DESCRIPTION
## Summary
- **ChestOpenEvent (9327)**: `ChestOpenHelper` — ack **9327**, **9312**, furni chunks; chest `onClick` delegates here.
- **Navigator**: real category visitor counts (**1455**); handler **3782**; sent on navigator init.

## Stack
**Merge after #303.** Logical delta vs `pr/emu-chest-withdraw-all-furni`: **1 commit** (`55605b7c`).

Fork compare: simoleo89 `pr/emu-chest-withdraw-all-furni` → `pr/emu-chest-open-9327`

## Test plan
- [ ] Open chest via client click
- [ ] Navigator category counts non-zero where rooms have users
