### PR TITLE
perf(catalog): shallow index packet without embedded offer IDs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
@@ -16,7 +16,6 @@ import java.util.List;
 public class CatalogPagesListComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogPagesListComposer.class);
 
-    private static final int MAX_OFFERS = 1000;
     private static final int MAX_CHILDREN = 500;
     private static final int MAX_DEPTH = 20;
 
@@ -74,13 +73,9 @@ public class CatalogPagesListComposer extends MessageComposer {
         this.response.appendString(category.getPageName());
         this.response.appendString(category.getCaption() + (this.hasPermission ? " (" + category.getId() + ")" : ""));
 
-        int[] offers = category.getOfferIds().toIntArray();
-        int offerCount = Math.min(offers.length, MAX_OFFERS);
-        this.response.appendInt(offerCount);
-
-        for (int idx = 0; idx < offerCount; idx++) {
-            this.response.appendInt(offers[idx]);
-        }
+        // Offer IDs are resolved when a page is opened (GetCatalogPage). Embedding ~80k
+        // ids in the index bloats the first catalog open by seconds on large catalogs.
+        this.response.appendInt(0);
 
         if (depth >= MAX_DEPTH) {
             this.response.appendInt(0);


### PR DESCRIPTION
## Summary

Stops embedding offer ID lists in the `CatalogPagesList` index packet. Each node now sends `offerCount = 0` instead of up to 1000 integers.

On our production-scale catalog this removed **~79k integers** from the first-open index, cutting parse time and packet size dramatically. Offer membership is unchanged — it is resolved when the client opens a page via `GetCatalogPageComposer`.

**Pairs with** client PR: session index cache + virtualized grid + lazy icons.

## Measured context (DB `next`)

| Metric | Before (embedded IDs) | After |
|--------|----------------------|-------|
| Offer IDs in index | ~79,448 | 0 |
| Catalog pages | 2,171 | 2,171 |
| Catalog items | 79,611 | 79,611 |

## Tradeoffs

- Client `offersToNodes` reverse map is no longer populated from the index. Deep-link navigation by offer ID (`catalog/open/offerId/...`) depended on this map; catalog search by furni name still works via furnidata.

## Test plan

- [ ] Open catalog — index packet is noticeably smaller; tree navigation works.
- [ ] Open any catalog page — offers still load correctly.
- [ ] Publish catalog page — client invalidates cache and receives fresh index.
- [ ] Staff with `ACC_CATALOG_IDS` — page IDs in captions still shown.
