### PR TITLE
fix(netty): graceful GamePacketHandler pool shutdown on server stop

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/Server.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/Server.java
@@ -95,10 +95,11 @@ public abstract class Server {
     public void stop() {
         LOGGER.info("Stopping {}", this.name);
         try {
-            this.workerGroup.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).sync();
-            this.bossGroup.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).sync();
+            this.workerGroup.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).sync();
+            this.bossGroup.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).sync();
         } catch(InterruptedException e) {
             LOGGER.error("Exception during {} shutdown... HARD STOP", this.name, e);
+            Thread.currentThread().interrupt();
         }
         LOGGER.info("Stopped {}", this.name);
     }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.networking.gameserver;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.gameclients.GameClientManager;
 import com.eu.habbo.messages.PacketManager;
 import com.eu.habbo.networking.Server;
@@ -19,6 +20,8 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
 
 public class GameServer extends Server {
     private static final Logger LOGGER = LoggerFactory.getLogger(GameServer.class);
@@ -115,5 +118,18 @@ public class GameServer extends Server {
 
     public GameClientManager getGameClientManager() {
         return this.gameClientManager;
+    }
+
+    @Override
+    public void stop() {
+        for (GameClient client : new ArrayList<>(this.gameClientManager.getSessions().values())) {
+            this.gameClientManager.forceDisposeClient(client);
+        }
+
+        if (Emulator.getConfig().getBoolean("ws.enabled", false)) {
+            WebSocketChannelInitializer.shutdownPacketHandlers();
+        }
+
+        super.stop();
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -29,10 +29,14 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.EventExecutorGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
+import java.util.concurrent.TimeUnit;
 
 public class WebSocketChannelInitializer extends ChannelInitializer<SocketChannel> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketChannelInitializer.class);
     private static final int MAX_FRAME_SIZE = 500000;
 
     // Runs the game packet handler OFF the Netty I/O event loop, so a blocking
@@ -117,5 +121,14 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
 
     public boolean isSslEnabled() {
         return this.sslEnabled;
+    }
+
+    /** Gracefully stop the off-I/O packet handler pool (call before worker/boss shutdown). */
+    public static void shutdownPacketHandlers() {
+        try {
+            PACKET_HANDLER_GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).syncUninterruptibly();
+        } catch (Exception e) {
+            LOGGER.warn("Packet handler group shutdown interrupted", e);
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/GameMessageHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/decoders/GameMessageHandler.java
@@ -35,7 +35,7 @@ public class GameMessageHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelUnregistered(ChannelHandlerContext ctx) {
-        ctx.channel().close();
+        ctx.fireChannelUnregistered();
     }
 
     @Override
@@ -70,7 +70,7 @@ public class GameMessageHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        ctx.channel().close();
+        super.channelInactive(ctx);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes `RejectedExecutionException: event executor terminated` on `GamePacketHandler-*` threads during emulator stop/restart.

The WebSocket stack runs `GameMessageHandler` on a dedicated `DefaultEventExecutorGroup` (`PACKET_HANDLER_GROUP`). On shutdown, boss/worker groups were terminated immediately (`shutdownGracefully(0, 0)`) while channels were still tearing down pipeline handlers on the packet pool — causing harmless but noisy WARNs.

## Changes

1. **`GameServer.stop()`** — disconnect all clients, then `WebSocketChannelInitializer.shutdownPacketHandlers()` before boss/worker shutdown.
2. **`WebSocketChannelInitializer.shutdownPacketHandlers()`** — graceful shutdown of `PACKET_HANDLER_GROUP` (100ms quiet / 3s timeout).
3. **`Server.stop()`** — non-zero graceful shutdown for boss/worker (100ms / 3s); restore interrupt flag on `InterruptedException`.
4. **`GameMessageHandler`** — remove redundant `channel.close()` from `channelInactive` / `channelUnregistered` that could double-trigger pipeline destroy.

## Context

Observed when restarting the emulator (e.g. after JAR rebuild):

```
WARN GamePacketHandler-7-3 | Unexpected exception from an event executor:
java.util.concurrent.RejectedExecutionException: event executor terminated
    at io.netty.channel.DefaultChannelPipeline.destroyUp(...)
```

Not related to catalog or game logic — shutdown ordering only.

## Test plan

- [ ] Start emulator with `ws.enabled=true`, connect a client, stop emulator — no `RejectedExecutionException` in logs.
- [ ] Normal client disconnect still disposes sessions correctly.
- [ ] Login + catalog + room entry still work after restart.
