### PR TITLE
fix(catalog-admin): sync in-memory catalog cache after admin mutations

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogAdminCacheSync.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogAdminCacheSync.java
@@ -1,0 +1,257 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import com.eu.habbo.Emulator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Keeps the in-memory catalog cache aligned with catalog admin DB mutations
+ * (draft edits before publish reload).
+ */
+public final class CatalogAdminCacheSync {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CatalogAdminCacheSync.class);
+
+    private static final String BC_ITEM_SELECT =
+            "SELECT id, item_ids, page_id, catalog_name, 0 AS cost_credits, 0 AS cost_points, 0 AS points_type, 1 AS amount, "
+                    + "0 AS limited_stack, 0 AS limited_sells, extradata, '0' AS club_only, '1' AS have_offer, id AS offer_id, order_number "
+                    + "FROM catalog_items_bc WHERE id = ? LIMIT 1";
+
+    private CatalogAdminCacheSync() {
+    }
+
+    public static void attachCreatedPage(CatalogPage page, int parentId, int orderNum, CatalogPageType pageType) {
+        if (page == null) return;
+        reparentPage(page, parentId, orderNum, pageType);
+    }
+
+    public static void reparentPage(CatalogPage page, int newParentId, int newOrderNum, CatalogPageType pageType) {
+        if (page == null) return;
+
+        CatalogManager catalogManager = Emulator.getGameEnvironment().getCatalogManager();
+        int oldParentId = page.getParentId();
+
+        if (oldParentId != newParentId) {
+            CatalogPage oldParent = catalogManager.getCatalogPage(oldParentId, pageType);
+            if (oldParent != null) {
+                oldParent.getChildPages().remove(page.getId());
+            }
+
+            CatalogPage newParent = catalogManager.getCatalogPage(newParentId, pageType);
+            if (newParent != null) {
+                newParent.addChildPage(page);
+            }
+
+            page.setParentId(newParentId);
+        }
+
+        page.setOrderNum(newOrderNum);
+    }
+
+    public static void refreshPageFlagsFromDb(int pageId, CatalogPageType pageType) {
+        CatalogManager catalogManager = Emulator.getGameEnvironment().getCatalogManager();
+        CatalogPage page = catalogManager.getCatalogPage(pageId, pageType);
+        if (page == null) return;
+
+        String tableName = (pageType == CatalogPageType.BUILDER) ? "catalog_pages_bc" : "catalog_pages";
+        String sql = "SELECT visible, enabled FROM " + tableName + " WHERE id = ? LIMIT 1";
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, pageId);
+
+            try (ResultSet set = statement.executeQuery()) {
+                if (!set.next()) return;
+
+                page.setVisible("1".equals(set.getString("visible")) || set.getBoolean("visible"));
+                page.setEnabled("1".equals(set.getString("enabled")) || set.getBoolean("enabled"));
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Failed to refresh catalog page flags for page {}", pageId, e);
+        }
+    }
+
+    public static void applyPageSave(
+            CatalogPage page,
+            String caption,
+            String captionSave,
+            String layout,
+            int iconImage,
+            int minRank,
+            boolean visible,
+            boolean enabled,
+            int orderNum,
+            int parentId,
+            String headline,
+            String teaser,
+            String textDetails,
+            String textOne,
+            CatalogPageType catalogMode,
+            CatalogPageType pageType
+    ) {
+        if (page == null) return;
+
+        if (page.getParentId() != parentId) {
+            reparentPage(page, parentId, orderNum, pageType);
+        } else {
+            page.setOrderNum(orderNum);
+        }
+
+        page.setCaption(caption);
+        page.setPageName(captionSave);
+        page.setLayout(layout);
+        page.setIconImage(iconImage);
+        page.setRank(minRank);
+        page.setVisible(visible);
+        page.setEnabled(enabled);
+        page.setHeaderImage(headline);
+        page.setTeaserImage(teaser);
+        page.setTextDetails(textDetails);
+        page.setTextOne(textOne);
+
+        if (pageType != CatalogPageType.BUILDER) {
+            page.setCatalogPageType(catalogMode);
+        }
+    }
+
+    public static void detachDeletedPage(CatalogPage page, CatalogPageType pageType) {
+        if (page == null) return;
+
+        CatalogManager catalogManager = Emulator.getGameEnvironment().getCatalogManager();
+        CatalogPage parent = catalogManager.getCatalogPage(page.getParentId(), pageType);
+
+        if (parent != null) {
+            parent.getChildPages().remove(page.getId());
+        }
+
+        catalogManager.getCatalogPagesMap(pageType).remove(page.getId());
+    }
+
+    public static boolean reloadCatalogItem(int offerId, CatalogPageType pageType) {
+        CatalogManager catalogManager = Emulator.getGameEnvironment().getCatalogManager();
+        CatalogItem existing = catalogManager.getCatalogItem(offerId, pageType);
+        int previousPageId = existing != null ? existing.getPageId() : -1;
+
+        String sql = (pageType == CatalogPageType.BUILDER)
+                ? BC_ITEM_SELECT
+                : "SELECT * FROM catalog_items WHERE id = ? LIMIT 1";
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, offerId);
+
+            try (ResultSet set = statement.executeQuery()) {
+                if (!set.next()) {
+                    removeCatalogItem(offerId, pageType, previousPageId);
+                    return false;
+                }
+
+                if (existing != null) {
+                    unregisterOfferSearchIndex(existing, pageType);
+
+                    if (previousPageId != set.getInt("page_id")) {
+                        CatalogPage oldPage = catalogManager.getCatalogPage(previousPageId, pageType);
+                        if (oldPage != null) {
+                            oldPage.getCatalogItems().remove(offerId);
+                        }
+                    }
+
+                    existing.update(set);
+                    attachItemToPage(existing, pageType);
+                    registerOfferSearchIndex(existing, pageType);
+                    return true;
+                }
+
+                if ("0".equals(set.getString("item_ids"))) {
+                    return false;
+                }
+
+                CatalogItem created = new CatalogItem(set);
+                attachItemToPage(created, pageType);
+                registerOfferSearchIndex(created, pageType);
+                return true;
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Failed to reload catalog item {}", offerId, e);
+            return false;
+        }
+    }
+
+    public static void removeCatalogItem(int offerId, CatalogPageType pageType, int pageIdHint) {
+        CatalogManager catalogManager = Emulator.getGameEnvironment().getCatalogManager();
+        CatalogItem item = catalogManager.getCatalogItem(offerId, pageType);
+
+        if (item != null) {
+            unregisterOfferSearchIndex(item, pageType);
+        }
+
+        int pageId = item != null ? item.getPageId() : pageIdHint;
+
+        if (pageId > -1) {
+            CatalogPage page = catalogManager.getCatalogPage(pageId, pageType);
+            if (page != null) {
+                page.getCatalogItems().remove(offerId);
+            }
+        }
+    }
+
+    private static void unregisterOfferSearchIndex(CatalogItem item, CatalogPageType pageType) {
+        if (item == null) return;
+
+        CatalogManager catalogManager = Emulator.getGameEnvironment().getCatalogManager();
+        int searchOfferId = item.getSearchOfferId();
+
+        if (searchOfferId != -1) {
+            if (pageType == CatalogPageType.BUILDER) {
+                catalogManager.buildersClubOfferDefs.remove(searchOfferId);
+            } else {
+                catalogManager.offerDefs.remove(searchOfferId);
+            }
+
+            CatalogPage page = catalogManager.getCatalogPage(item.getPageId(), pageType);
+            removeOfferIdFromPage(page, searchOfferId);
+        }
+    }
+
+    private static void removeOfferIdFromPage(CatalogPage page, int offerId) {
+        if (page == null || offerId < 0) return;
+
+        for (int i = 0; i < page.getOfferIds().size(); i++) {
+            if (page.getOfferIds().getInt(i) == offerId) {
+                page.getOfferIds().removeInt(i);
+                return;
+            }
+        }
+    }
+
+    private static void attachItemToPage(CatalogItem item, CatalogPageType pageType) {
+        CatalogManager catalogManager = Emulator.getGameEnvironment().getCatalogManager();
+        CatalogPage page = catalogManager.getCatalogPage(item.getPageId(), pageType);
+
+        if (page == null) return;
+
+        page.getCatalogItems().put(item.getId(), item);
+    }
+
+    private static void registerOfferSearchIndex(CatalogItem item, CatalogPageType pageType) {
+        CatalogManager catalogManager = Emulator.getGameEnvironment().getCatalogManager();
+        CatalogPage page = catalogManager.getCatalogPage(item.getPageId(), pageType);
+
+        if (page == null) return;
+
+        int searchOfferId = item.getSearchOfferId();
+        if (searchOfferId != -1) {
+            page.addOfferId(searchOfferId);
+
+            if (pageType == CatalogPageType.BUILDER) {
+                catalogManager.buildersClubOfferDefs.put(searchOfferId, item.getId());
+            } else {
+                catalogManager.offerDefs.put(searchOfferId, item.getId());
+            }
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogItem.java
@@ -192,6 +192,10 @@ public class CatalogItem implements ISerialize, Runnable, Comparable<CatalogItem
         return this.orderNumber;
     }
 
+    public void setOrderNumber(int orderNumber) {
+        this.orderNumber = orderNumber;
+    }
+
     public void setNeedsUpdate(boolean needsUpdate) {
         this.needsUpdate = needsUpdate;
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -462,6 +462,7 @@ public class CatalogManager {
     }
 
     private synchronized void loadCatalogItems() {
+        this.offerDefs.clear();
         this.clubItems.clear();
         catalogItemAmount = 0;
 
@@ -895,11 +896,15 @@ public class CatalogManager {
 
 
     public CatalogPage createCatalogPage(String caption, String captionSave, int roomId, int icon, CatalogPageLayouts layout, int minRank, int parentId, CatalogPageType pageType, CatalogPageType catalogMode) {
+        return createCatalogPage(caption, captionSave, roomId, icon, layout, minRank, parentId, pageType, catalogMode, true, true, 1);
+    }
+
+    public CatalogPage createCatalogPage(String caption, String captionSave, int roomId, int icon, CatalogPageLayouts layout, int minRank, int parentId, CatalogPageType pageType, CatalogPageType catalogMode, boolean visible, boolean enabled, int orderNum) {
         CatalogPage catalogPage = null;
         boolean buildersClubPage = (pageType == CatalogPageType.BUILDER);
         String insertQuery = buildersClubPage
                 ? "INSERT INTO catalog_pages_bc (parent_id, caption, page_layout, icon_color, icon_image, order_num, visible, enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-                : "INSERT INTO catalog_pages (parent_id, caption, caption_save, icon_image, visible, enabled, min_rank, page_layout, room_id, catalog_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                : "INSERT INTO catalog_pages (parent_id, caption, caption_save, icon_image, visible, enabled, min_rank, page_layout, room_id, catalog_mode, order_num) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         String selectQuery = buildersClubPage
                 ? "SELECT id, parent_id, caption, caption AS caption_save, page_layout, icon_color, icon_image, 1 AS min_rank, order_num, visible, enabled, '0' AS club_only, 'BUILDERS_CLUB' AS catalog_mode, page_headline, page_teaser, page_special, page_text1, page_text2, page_text_details, page_text_teaser, '' AS includes FROM catalog_pages_bc WHERE id = ?"
                 : "SELECT * FROM catalog_pages WHERE id = ?";
@@ -913,18 +918,19 @@ public class CatalogManager {
                 statement.setString(3, layout.name());
                 statement.setInt(4, 1);
                 statement.setInt(5, icon);
-                statement.setInt(6, 1);
-                statement.setString(7, "1");
-                statement.setString(8, "1");
+                statement.setInt(6, orderNum < 0 ? 0 : orderNum);
+                statement.setString(7, visible ? "1" : "0");
+                statement.setString(8, enabled ? "1" : "0");
             } else {
                 statement.setString(3, captionSave);
                 statement.setInt(4, icon);
-                statement.setString(5, "1");
-                statement.setString(6, "1");
+                statement.setString(5, visible ? "1" : "0");
+                statement.setString(6, enabled ? "1" : "0");
                 statement.setInt(7, minRank);
                 statement.setString(8, layout.name());
                 statement.setInt(9, roomId);
                 statement.setString(10, catalogMode.name());
+                statement.setInt(11, orderNum < 0 ? 0 : orderNum);
             }
             statement.execute();
             try (ResultSet set = statement.getGeneratedKeys()) {
@@ -955,6 +961,7 @@ public class CatalogManager {
 
         if (catalogPage != null) {
             this.getCatalogPagesMap(pageType).put(catalogPage.getId(), catalogPage);
+            CatalogAdminCacheSync.attachCreatedPage(catalogPage, parentId, orderNum < 0 ? 0 : orderNum, pageType);
         }
 
         return catalogPage;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPage.java
@@ -105,6 +105,58 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
         this.rank = rank;
     }
 
+    public void setParentId(int parentId) {
+        this.parentId = parentId;
+    }
+
+    public void setCaption(String caption) {
+        this.caption = caption;
+    }
+
+    public void setPageName(String pageName) {
+        this.pageName = pageName;
+    }
+
+    public void setIconImage(int iconImage) {
+        this.iconImage = iconImage;
+    }
+
+    public void setOrderNum(int orderNum) {
+        this.orderNum = orderNum;
+    }
+
+    public void setVisible(boolean visible) {
+        this.visible = visible;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setLayout(String layout) {
+        this.layout = layout;
+    }
+
+    public void setCatalogPageType(CatalogPageType catalogPageType) {
+        this.catalogPageType = catalogPageType;
+    }
+
+    public void setHeaderImage(String headerImage) {
+        this.headerImage = headerImage;
+    }
+
+    public void setTeaserImage(String teaserImage) {
+        this.teaserImage = teaserImage;
+    }
+
+    public void setTextOne(String textOne) {
+        this.textOne = textOne;
+    }
+
+    public void setTextDetails(String textDetails) {
+        this.textDetails = textDetails;
+    }
+
     public String getCaption() {
         return this.caption;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminCreateOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminCreateOfferEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogAdminCacheSync;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.incoming.MessageHandler;
@@ -85,6 +86,7 @@ public class CatalogAdminCreateOfferEvent extends MessageHandler {
         }
 
         if (newId > 0) {
+            CatalogAdminCacheSync.reloadCatalogItem(newId, pageType);
             this.client.sendResponse(new CatalogAdminResultComposer(true, "Offer created: " + newId));
         } else {
             this.client.sendResponse(new CatalogAdminResultComposer(false, "Failed to create offer"));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminCreatePageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminCreatePageEvent.java
@@ -1,7 +1,6 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin;
 
 import com.eu.habbo.Emulator;
-import com.eu.habbo.habbohotel.catalog.CatalogPage;
 import com.eu.habbo.habbohotel.catalog.CatalogPageLayouts;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import com.eu.habbo.habbohotel.permissions.Permission;
@@ -49,8 +48,8 @@ public class CatalogAdminCreatePageEvent extends MessageHandler {
         if (caption.length() > 128) caption = caption.substring(0, 128);
         if (caption2.length() > 25) caption2 = caption2.substring(0, 25);
 
-        CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().createCatalogPage(
-                caption, caption2, 0, iconType, pageLayout, minRank, parentId, pageType, catalogMode
+        var page = Emulator.getGameEnvironment().getCatalogManager().createCatalogPage(
+                caption, caption2, 0, iconType, pageLayout, minRank, parentId, pageType, catalogMode, visible, enabled, orderNum
         );
 
         if (page == null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminDeleteOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminDeleteOfferEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogAdminCacheSync;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.incoming.MessageHandler;
@@ -35,6 +36,7 @@ public class CatalogAdminDeleteOfferEvent extends MessageHandler {
             }
         }
 
+        CatalogAdminCacheSync.removeCatalogItem(offerId, pageType, -1);
         this.client.sendResponse(new CatalogAdminResultComposer(true, "Offer deleted"));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminDeletePageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminDeletePageEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogAdminCacheSync;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import com.eu.habbo.habbohotel.permissions.Permission;
@@ -42,8 +43,7 @@ public class CatalogAdminDeletePageEvent extends MessageHandler {
             }
         }
 
-        Emulator.getGameEnvironment().getCatalogManager().getCatalogPagesMap(pageType).remove(pageId);
-
+        CatalogAdminCacheSync.detachDeletedPage(page, pageType);
         this.client.sendResponse(new CatalogAdminResultComposer(true, "Page deleted"));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminLoadOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminLoadOfferEvent.java
@@ -32,7 +32,10 @@ public class CatalogAdminLoadOfferEvent extends MessageHandler {
             statement.setInt(1, offerId);
 
             try (ResultSet set = statement.executeQuery()) {
-                if (!set.next()) return;
+                if (!set.next()) {
+                    this.client.sendResponse(new CatalogAdminResultComposer(false, "Offer not found: " + offerId));
+                    return;
+                }
 
                 if (pageType == CatalogPageType.BUILDER) {
                     this.client.sendResponse(new CatalogAdminOfferDetailsComposer(

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminLoadPageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminLoadPageEvent.java
@@ -21,7 +21,10 @@ public class CatalogAdminLoadPageEvent extends MessageHandler {
         CatalogPageType pageType = CatalogPageType.fromString(this.packet.readString());
 
         CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(pageId, pageType);
-        if (page == null) return;
+        if (page == null) {
+            this.client.sendResponse(new CatalogAdminResultComposer(false, "Page not found: " + pageId));
+            return;
+        }
 
         this.client.sendResponse(new CatalogAdminPageDetailsComposer(page));
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminMoveOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminMoveOfferEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogItem;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.incoming.MessageHandler;
@@ -37,6 +38,11 @@ public class CatalogAdminMoveOfferEvent extends MessageHandler {
                 this.client.sendResponse(new CatalogAdminResultComposer(false, "Offer not found: " + offerId));
                 return;
             }
+        }
+
+        CatalogItem item = Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(offerId, pageType);
+        if (item != null) {
+            item.setOrderNumber(orderNumber);
         }
 
         this.client.sendResponse(new CatalogAdminResultComposer(true, "Offer reordered"));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminMovePageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminMovePageEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogAdminCacheSync;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import com.eu.habbo.habbohotel.permissions.Permission;
@@ -44,6 +45,7 @@ public class CatalogAdminMovePageEvent extends MessageHandler {
                     return;
                 }
             }
+            CatalogAdminCacheSync.refreshPageFlagsFromDb(pageId, pageType);
             this.client.sendResponse(new CatalogAdminResultComposer(true, "Page toggled"));
             return;
         }
@@ -58,6 +60,7 @@ public class CatalogAdminMovePageEvent extends MessageHandler {
                     return;
                 }
             }
+            CatalogAdminCacheSync.refreshPageFlagsFromDb(pageId, pageType);
             this.client.sendResponse(new CatalogAdminResultComposer(true, "Visibility toggled"));
             return;
         }
@@ -92,6 +95,7 @@ public class CatalogAdminMovePageEvent extends MessageHandler {
             }
         }
 
+        CatalogAdminCacheSync.reparentPage(page, newParentId, newIndex, pageType);
         this.client.sendResponse(new CatalogAdminResultComposer(true, "Page moved"));
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminOfferPayload.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminOfferPayload.java
@@ -84,15 +84,17 @@ final class CatalogAdminOfferPayload {
             return "0";
         }
 
-        String clean = value.trim();
+        String clean = value.trim().replaceAll("\\s+", "");
+        String[] parts = clean.split("[;,]");
         if (clean.length() > MAX_ITEM_IDS_LENGTH) {
             return null;
         }
 
-        String[] parts = clean.split(",");
         if (parts.length == 0 || parts.length > MAX_ITEM_IDS) {
             return null;
         }
+
+        StringBuilder normalized = new StringBuilder();
 
         for (String part : parts) {
             if (part.isBlank()) {
@@ -100,15 +102,18 @@ final class CatalogAdminOfferPayload {
             }
 
             try {
-                if (Integer.parseInt(part.trim()) < 0) {
+                if (Integer.parseInt(part) < 0) {
                     return null;
                 }
             } catch (NumberFormatException e) {
                 return null;
             }
+
+            if (normalized.length() > 0) normalized.append(';');
+            normalized.append(part);
         }
 
-        return clean.replaceAll("\\s+", "");
+        return normalized.toString();
     }
 
     private static boolean isInRange(int value, int min, int max) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSaveOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSaveOfferEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogAdminCacheSync;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.incoming.MessageHandler;
@@ -97,6 +98,7 @@ public class CatalogAdminSaveOfferEvent extends MessageHandler {
             }
         }
 
+        CatalogAdminCacheSync.reloadCatalogItem(offerId, pageType);
         this.client.sendResponse(new CatalogAdminResultComposer(true, "Offer saved"));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSavePageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSavePageEvent.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogAdminCacheSync;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
 import com.eu.habbo.habbohotel.catalog.CatalogPageLayouts;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
@@ -150,6 +151,8 @@ public class CatalogAdminSavePageEvent extends MessageHandler {
             }
         }
 
+        CatalogAdminCacheSync.applyPageSave(page, caption, caption2, layout, iconType, minRank, visible, enabled,
+                orderNum, parentId, headline, teaser, textDetails, text1, catalogMode, pageType);
         this.client.sendResponse(new CatalogAdminResultComposer(true, "Page saved"));
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminOfferPayloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminOfferPayloadTest.java
@@ -15,7 +15,7 @@ class CatalogAdminOfferPayloadTest {
                 "extra", true, 0, 0, 10, CatalogPageType.NORMAL);
 
         assertNotNull(payload);
-        assertEquals("1,2,3", payload.itemIds);
+        assertEquals("1;2;3", payload.itemIds);
         assertEquals("Rare Chair", payload.catalogName);
     }
 
@@ -37,5 +37,15 @@ class CatalogAdminOfferPayloadTest {
                 "", false, 0, 0, 0, CatalogPageType.BUILDER));
         assertNull(CatalogAdminOfferPayload.validate(42, "1", "", 0, 0, 0, 1, 0,
                 "", false, 0, 0, 0, CatalogPageType.BUILDER));
+    }
+
+    @Test
+    void acceptsSemicolonSeparatedItemIds() {
+        CatalogAdminOfferPayload payload = CatalogAdminOfferPayload.validate(
+                42, "100;200", "Bundle", 10, 0, 0, 1, 0,
+                "", false, 0, 0, 0, CatalogPageType.NORMAL);
+
+        assertNotNull(payload);
+        assertEquals("100;200", payload.itemIds);
     }
 }


### PR DESCRIPTION
## Summary

- Add `CatalogAdminCacheSync` so admin DB writes immediately update `CatalogManager` RAM (page tree, visibility/enabled flags, offers) without waiting for Publish
- **CreatePage**: honor `visible` / `enabled` / `orderNum` from client and attach new page to parent tree in RAM
- Keep offer `order_number` in memory after drag-and-drop reorder (`MoveOffer`)
- Return `CatalogAdminResultComposer` errors when LoadPage/LoadOffer targets are missing
- Accept `;` or `,` in offer `item_ids` (normalized to `;` for storage)
- Reindex `offerDefs` / `page.offerIds` on offer save/update/delete; clear `offerDefs` on publish reload

## Why

The Nitro catalog admin console edits `catalog_pages` / `catalog_items` directly. Clients read the in-memory catalog until a full publish. Without cache sync, saves/moves/deletes appeared in the DB but not in the live tree or offer grid.

## Test plan

- [ ] Create sub-page — appears in admin tree immediately
- [ ] Reorder offers — order persists in UI without reload
- [ ] Save/edit page — tree caption, parent, visibility update immediately
- [ ] Create/delete offer — grid updates without publish
- [ ] Offer with `item_ids` `100;200` saves successfully
- [ ] Publish propagates to all connected clients
- [ ] `mvn test -Dtest=CatalogAdminOfferPayloadTest,CatalogAdminOfferMutationContractTest,CatalogAdminPageMutationContractTest`
