### PR TITLE
Add persistent messenger history and delivery

### DIFF
--- a/Database/Database Updates/025_messenger_history.sql
+++ b/Database/Database Updates/025_messenger_history.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS `messenger_conversations` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `type` ENUM('direct','group') NOT NULL,
+  `direct_key` VARCHAR(64) NULL,
+  `name` VARCHAR(100) NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_messenger_direct_key` (`direct_key`),
+  KEY `idx_messenger_updated` (`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `messenger_members` (
+  `conversation_id` BIGINT UNSIGNED NOT NULL,
+  `user_id` INT NOT NULL,
+  `role` ENUM('member','admin') NOT NULL DEFAULT 'member',
+  `joined_message_id` BIGINT UNSIGNED NULL,
+  `left_message_id` BIGINT UNSIGNED NULL,
+  `last_read_message_id` BIGINT UNSIGNED NULL,
+  `joined_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `left_at` TIMESTAMP NULL,
+  PRIMARY KEY (`conversation_id`, `user_id`),
+  KEY `idx_messenger_member_user` (`user_id`, `left_at`),
+  CONSTRAINT `fk_messenger_member_conversation`
+    FOREIGN KEY (`conversation_id`) REFERENCES `messenger_conversations` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `messenger_messages` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `conversation_id` BIGINT UNSIGNED NOT NULL,
+  `sender_id` INT NOT NULL,
+  `type` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `message` VARCHAR(255) NOT NULL,
+  `metadata` VARCHAR(1024) NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_messenger_page` (`conversation_id`, `id`),
+  KEY `idx_messenger_retention` (`created_at`, `conversation_id`),
+  CONSTRAINT `fk_messenger_message_conversation`
+    FOREIGN KEY (`conversation_id`) REFERENCES `messenger_conversations` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/Database/Default Database/FullDatabase.sql
+++ b/Database/Default Database/FullDatabase.sql
@@ -31209,3 +31209,45 @@ DELETE FROM `youtube_playlists`;
 /*!40014 SET FOREIGN_KEY_CHECKS=IFNULL(@OLD_FOREIGN_KEY_CHECKS, 1) */;
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40111 SET SQL_NOTES=IFNULL(@OLD_SQL_NOTES, 1) */;
+-- Persistent messenger conversations and history.
+CREATE TABLE IF NOT EXISTS `messenger_conversations` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `type` ENUM('direct','group') NOT NULL,
+  `direct_key` VARCHAR(64) NULL,
+  `name` VARCHAR(100) NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_messenger_direct_key` (`direct_key`),
+  KEY `idx_messenger_updated` (`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `messenger_members` (
+  `conversation_id` BIGINT UNSIGNED NOT NULL,
+  `user_id` INT NOT NULL,
+  `role` ENUM('member','admin') NOT NULL DEFAULT 'member',
+  `joined_message_id` BIGINT UNSIGNED NULL,
+  `left_message_id` BIGINT UNSIGNED NULL,
+  `last_read_message_id` BIGINT UNSIGNED NULL,
+  `joined_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `left_at` TIMESTAMP NULL,
+  PRIMARY KEY (`conversation_id`, `user_id`),
+  KEY `idx_messenger_member_user` (`user_id`, `left_at`),
+  CONSTRAINT `fk_messenger_member_conversation`
+    FOREIGN KEY (`conversation_id`) REFERENCES `messenger_conversations` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `messenger_messages` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `conversation_id` BIGINT UNSIGNED NOT NULL,
+  `sender_id` INT NOT NULL,
+  `type` TINYINT UNSIGNED NOT NULL DEFAULT 0,
+  `message` VARCHAR(255) NOT NULL,
+  `metadata` VARCHAR(1024) NULL,
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_messenger_page` (`conversation_id`, `id`),
+  KEY `idx_messenger_retention` (`created_at`, `conversation_id`),
+  CONSTRAINT `fk_messenger_message_conversation`
+    FOREIGN KEY (`conversation_id`) REFERENCES `messenger_conversations` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/Emulator/src/main/java/com/eu/habbo/core/CleanerThread.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/CleanerThread.java
@@ -2,6 +2,7 @@ package com.eu.habbo.core;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.guilds.forums.ForumThread;
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryServices;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.friends.SearchUserEvent;
 import com.eu.habbo.messages.outgoing.users.UserDataComposer;
@@ -27,6 +28,7 @@ public class CleanerThread implements Runnable {
     private static final int REMOVE_INACTIVE_TOURS = 600;
     private static final int SAVE_ERROR_LOGS = 30;
     private static final int CLEAR_CACHED_VALUES = 60 * 60;
+    private static final int CLEAN_MESSENGER_HISTORY = 60 * 60;
     private static final int CALLBACK_TIME = 60 * 15;
 
     private static int LAST_HOF_RELOAD = Emulator.getIntUnixTimestamp();
@@ -38,6 +40,7 @@ public class CleanerThread implements Runnable {
     private static int LAST_DAILY_REFILL = Emulator.getIntUnixTimestamp();
     private static int LAST_CALLBACK = Emulator.getIntUnixTimestamp();
     private static int LAST_HABBO_CACHE_CLEARED = Emulator.getIntUnixTimestamp();
+    private static int LAST_MESSENGER_HISTORY_CLEANED = Emulator.getIntUnixTimestamp();
 
     public CleanerThread() {
         this.databaseCleanup();
@@ -98,6 +101,15 @@ public class CleanerThread implements Runnable {
         if (time - LAST_HABBO_CACHE_CLEARED > CLEAR_CACHED_VALUES) {
             this.clearCachedValues();
             LAST_HABBO_CACHE_CLEARED = time;
+        }
+
+        if (time - LAST_MESSENGER_HISTORY_CLEANED > CLEAN_MESSENGER_HISTORY) {
+            try {
+                MessengerHistoryServices.create().cleanupRetention();
+            } catch (RuntimeException exception) {
+                LOGGER.error("Unable to clean messenger history", exception);
+            }
+            LAST_MESSENGER_HISTORY_CLEANED = time;
         }
 
         SearchUserEvent.cleanExpiredCache();

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/MessengerBuddy.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/MessengerBuddy.java
@@ -140,6 +140,8 @@ public class MessengerBuddy implements Runnable, ISerialize {
 
     public int getCategoryId() { return this.categoryId; }
 
+    public void setCategoryId(int categoryId) { this.categoryId = categoryId; }
+
     public boolean inRoom() {
         return this.inRoom;
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/ConversationType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/ConversationType.java
@@ -1,0 +1,6 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+public enum ConversationType {
+    DIRECT,
+    GROUP
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
@@ -217,11 +217,26 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
 
     @Override
     public boolean markRead(long conversationId, int userId, long messageId) {
-        String sql = "UPDATE messenger_members SET last_read_message_id = GREATEST(COALESCE(last_read_message_id, 0), ?) WHERE conversation_id = ? AND user_id = ? AND left_at IS NULL";
+        String sql = """
+                UPDATE messenger_members member
+                SET member.last_read_message_id = GREATEST(COALESCE(member.last_read_message_id, 0), ?)
+                WHERE member.conversation_id = ?
+                  AND member.user_id = ?
+                  AND member.left_at IS NULL
+                  AND EXISTS (
+                      SELECT 1
+                      FROM messenger_messages message
+                      WHERE message.id = ?
+                        AND message.conversation_id = member.conversation_id
+                        AND (member.joined_message_id IS NULL OR message.id >= member.joined_message_id)
+                        AND (member.left_message_id IS NULL OR message.id <= member.left_message_id)
+                  )
+                """;
         try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setLong(1, messageId);
             statement.setLong(2, conversationId);
             statement.setInt(3, userId);
+            statement.setLong(4, messageId);
             return statement.executeUpdate() == 1;
         } catch (SQLException exception) {
             throw new IllegalStateException("failed to update messenger read cursor", exception);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
@@ -232,15 +232,20 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
     public void cleanupRetention(int days, int maxMessagesPerConversation) {
         String deleteExpired = "DELETE FROM messenger_messages WHERE created_at < UTC_TIMESTAMP() - INTERVAL ? DAY LIMIT ?";
         String deleteOverflow = """
-                DELETE FROM messenger_messages
-                WHERE id IN (
-                    SELECT id FROM (
-                        SELECT id, ROW_NUMBER() OVER (PARTITION BY conversation_id ORDER BY id DESC) AS row_number
-                        FROM messenger_messages
-                    ) ranked
-                    WHERE ranked.row_number > ?
-                    LIMIT ?
-                )
+                DELETE messages FROM messenger_messages messages
+                JOIN (
+                    SELECT overflow_rows.id
+                    FROM (
+                        SELECT older.id
+                        FROM messenger_messages older
+                        JOIN messenger_messages newer
+                          ON newer.conversation_id = older.conversation_id
+                         AND newer.id > older.id
+                        GROUP BY older.id
+                        HAVING COUNT(newer.id) >= ?
+                        LIMIT ?
+                    ) overflow_rows
+                ) doomed ON doomed.id = messages.id
                 """;
         try (Connection connection = dataSource.getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(deleteExpired)) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,6 +17,41 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
     public JdbcMessengerHistoryRepository(DataSource dataSource) {
         if (dataSource == null) throw new IllegalArgumentException("dataSource is required");
         this.dataSource = dataSource;
+    }
+
+    @Override
+    public List<MessengerConversationSummary> listConversations(int userId) {
+        String sql = """
+                SELECT c.id, c.type, c.name, COALESCE(MAX(m.id), 0) AS last_message_id,
+                       SUM(CASE WHEN m.id > COALESCE(member.last_read_message_id, 0) AND m.sender_id <> ? THEN 1 ELSE 0 END) AS unread_count,
+                       UNIX_TIMESTAMP(c.updated_at) AS updated_at
+                FROM messenger_members member
+                JOIN messenger_conversations c ON c.id = member.conversation_id
+                LEFT JOIN messenger_messages m ON m.conversation_id = c.id
+                WHERE member.user_id = ? AND member.left_at IS NULL
+                GROUP BY c.id, c.type, c.name, member.last_read_message_id, c.updated_at
+                ORDER BY c.updated_at DESC
+                """;
+        List<MessengerConversationSummary> summaries = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, userId);
+            statement.setInt(2, userId);
+            try (ResultSet result = statement.executeQuery()) {
+                while (result.next()) {
+                    summaries.add(new MessengerConversationSummary(
+                            result.getLong("id"),
+                            ConversationType.valueOf(result.getString("type").toUpperCase()),
+                            result.getString("name"),
+                            result.getLong("last_message_id"),
+                            result.getInt("unread_count"),
+                            result.getLong("updated_at")
+                    ));
+                }
+            }
+            return summaries;
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to list messenger conversations", exception);
+        }
     }
 
     @Override
@@ -72,6 +108,99 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
             return messages;
         } catch (SQLException exception) {
             throw new IllegalStateException("failed to load messenger history", exception);
+        }
+    }
+
+    @Override
+    public MessengerStoredMessage storeDirectMessage(int senderId, int recipientId, int type, String message, String metadata) {
+        String conversationSql = "INSERT INTO messenger_conversations (type, direct_key) VALUES ('direct', ?) ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id), updated_at = CURRENT_TIMESTAMP";
+        String memberSql = "INSERT INTO messenger_members (conversation_id, user_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE left_at = NULL, left_message_id = NULL";
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                long conversationId;
+                try (PreparedStatement statement = connection.prepareStatement(conversationSql, Statement.RETURN_GENERATED_KEYS)) {
+                    statement.setString(1, MessengerHistoryService.directKey(senderId, recipientId));
+                    statement.executeUpdate();
+                    try (ResultSet keys = statement.getGeneratedKeys()) {
+                        if (!keys.next()) throw new SQLException("missing conversation id");
+                        conversationId = keys.getLong(1);
+                    }
+                }
+                try (PreparedStatement statement = connection.prepareStatement(memberSql)) {
+                    statement.setLong(1, conversationId);
+                    statement.setInt(2, senderId);
+                    statement.addBatch();
+                    statement.setLong(1, conversationId);
+                    statement.setInt(2, recipientId);
+                    statement.addBatch();
+                    statement.executeBatch();
+                }
+                MessengerStoredMessage stored = insertMessage(connection, conversationId, senderId, type, message, metadata);
+                connection.commit();
+                return stored;
+            } catch (SQLException exception) {
+                connection.rollback();
+                throw exception;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to store direct messenger message", exception);
+        }
+    }
+
+    @Override
+    public MessengerStoredMessage storeConversationMessage(long conversationId, int senderId, int type, String message, String metadata) {
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                MessengerStoredMessage stored = insertMessage(connection, conversationId, senderId, type, message, metadata);
+                connection.commit();
+                return stored;
+            } catch (SQLException exception) {
+                connection.rollback();
+                throw exception;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to store messenger message", exception);
+        }
+    }
+
+    private MessengerStoredMessage insertMessage(Connection connection, long conversationId, int senderId, int type, String message, String metadata) throws SQLException {
+        String sql = "INSERT INTO messenger_messages (conversation_id, sender_id, type, message, metadata) VALUES (?, ?, ?, ?, ?)";
+        long messageId;
+        try (PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setLong(1, conversationId);
+            statement.setInt(2, senderId);
+            statement.setInt(3, type);
+            statement.setString(4, message);
+            statement.setString(5, metadata);
+            statement.executeUpdate();
+            try (ResultSet keys = statement.getGeneratedKeys()) {
+                if (!keys.next()) throw new SQLException("missing message id");
+                messageId = keys.getLong(1);
+            }
+        }
+        try (PreparedStatement statement = connection.prepareStatement("UPDATE messenger_conversations SET updated_at = CURRENT_TIMESTAMP WHERE id = ?")) {
+            statement.setLong(1, conversationId);
+            statement.executeUpdate();
+        }
+        return new MessengerStoredMessage(messageId, conversationId, senderId, type, message, metadata, System.currentTimeMillis() / 1000L);
+    }
+
+    @Override
+    public boolean markRead(long conversationId, int userId, long messageId) {
+        String sql = "UPDATE messenger_members SET last_read_message_id = GREATEST(COALESCE(last_read_message_id, 0), ?) WHERE conversation_id = ? AND user_id = ? AND left_at IS NULL";
+        try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, messageId);
+            statement.setLong(2, conversationId);
+            statement.setInt(3, userId);
+            return statement.executeUpdate() == 1;
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to update messenger read cursor", exception);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
@@ -22,11 +22,16 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
     @Override
     public List<MessengerConversationSummary> listConversations(int userId) {
         String sql = """
-                SELECT c.id, c.type, c.name, COALESCE(MAX(m.id), 0) AS last_message_id,
-                       SUM(CASE WHEN m.id > COALESCE(member.last_read_message_id, 0) AND m.sender_id <> ? THEN 1 ELSE 0 END) AS unread_count,
+                SELECT c.id, c.type,
+                       CASE WHEN c.type = 'direct' THEN COALESCE(MAX(CASE WHEN peer.user_id <> ? THEN peer.user_id END), 0) ELSE 0 END AS participant_id,
+                       COALESCE(c.name, MAX(CASE WHEN peer.user_id <> ? THEN users.username END), '') AS display_name,
+                       COALESCE(MAX(m.id), 0) AS last_message_id,
+                       COUNT(DISTINCT CASE WHEN m.id > COALESCE(member.last_read_message_id, 0) AND m.sender_id <> ? THEN m.id END) AS unread_count,
                        UNIX_TIMESTAMP(c.updated_at) AS updated_at
                 FROM messenger_members member
                 JOIN messenger_conversations c ON c.id = member.conversation_id
+                JOIN messenger_members peer ON peer.conversation_id = c.id AND peer.left_at IS NULL
+                LEFT JOIN users ON users.id = peer.user_id
                 LEFT JOIN messenger_messages m ON m.conversation_id = c.id
                 WHERE member.user_id = ? AND member.left_at IS NULL
                 GROUP BY c.id, c.type, c.name, member.last_read_message_id, c.updated_at
@@ -36,12 +41,15 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
         try (Connection connection = dataSource.getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setInt(1, userId);
             statement.setInt(2, userId);
+            statement.setInt(3, userId);
+            statement.setInt(4, userId);
             try (ResultSet result = statement.executeQuery()) {
                 while (result.next()) {
                     summaries.add(new MessengerConversationSummary(
                             result.getLong("id"),
                             ConversationType.valueOf(result.getString("type").toUpperCase()),
-                            result.getString("name"),
+                            result.getInt("participant_id"),
+                            result.getString("display_name"),
                             result.getLong("last_message_id"),
                             result.getInt("unread_count"),
                             result.getLong("updated_at")
@@ -66,6 +74,22 @@ public final class JdbcMessengerHistoryRepository implements MessengerHistoryRep
             }
         } catch (SQLException exception) {
             throw new IllegalStateException("failed to validate messenger membership", exception);
+        }
+    }
+
+    @Override
+    public List<Integer> listActiveMemberIds(long conversationId) {
+        String sql = "SELECT user_id FROM messenger_members WHERE conversation_id = ? AND left_at IS NULL";
+        List<Integer> userIds = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, conversationId);
+            try (ResultSet result = statement.executeQuery()) {
+                while (result.next()) userIds.add(result.getInt("user_id"));
+            }
+            return userIds;
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to list messenger members", exception);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java
@@ -1,0 +1,107 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class JdbcMessengerHistoryRepository implements MessengerHistoryRepository {
+    private static final int CLEANUP_BATCH_SIZE = 1000;
+
+    private final DataSource dataSource;
+
+    public JdbcMessengerHistoryRepository(DataSource dataSource) {
+        if (dataSource == null) throw new IllegalArgumentException("dataSource is required");
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public boolean isActiveMember(long conversationId, int userId) {
+        String sql = "SELECT 1 FROM messenger_members WHERE conversation_id = ? AND user_id = ? AND left_at IS NULL LIMIT 1";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setLong(1, conversationId);
+            statement.setInt(2, userId);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next();
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to validate messenger membership", exception);
+        }
+    }
+
+    @Override
+    public List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit) {
+        String sql = """
+                SELECT m.id, m.conversation_id, m.sender_id, m.type, m.message, m.metadata,
+                       UNIX_TIMESTAMP(m.created_at) AS created_at
+                FROM messenger_messages m
+                JOIN messenger_members member
+                  ON member.conversation_id = m.conversation_id AND member.user_id = ?
+                WHERE m.conversation_id = ?
+                  AND (? = 0 OR m.id < ?)
+                  AND (member.joined_message_id IS NULL OR m.id >= member.joined_message_id)
+                  AND (member.left_message_id IS NULL OR m.id <= member.left_message_id)
+                ORDER BY m.id DESC
+                LIMIT ?
+                """;
+        List<MessengerStoredMessage> messages = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, userId);
+            statement.setLong(2, conversationId);
+            statement.setLong(3, beforeMessageId);
+            statement.setLong(4, beforeMessageId);
+            statement.setInt(5, limit + 1);
+            try (ResultSet result = statement.executeQuery()) {
+                while (result.next()) {
+                    messages.add(new MessengerStoredMessage(
+                            result.getLong("id"),
+                            result.getLong("conversation_id"),
+                            result.getInt("sender_id"),
+                            result.getInt("type"),
+                            result.getString("message"),
+                            result.getString("metadata"),
+                            result.getLong("created_at")
+                    ));
+                }
+            }
+            return messages;
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to load messenger history", exception);
+        }
+    }
+
+    @Override
+    public void cleanupRetention(int days, int maxMessagesPerConversation) {
+        String deleteExpired = "DELETE FROM messenger_messages WHERE created_at < UTC_TIMESTAMP() - INTERVAL ? DAY LIMIT ?";
+        String deleteOverflow = """
+                DELETE FROM messenger_messages
+                WHERE id IN (
+                    SELECT id FROM (
+                        SELECT id, ROW_NUMBER() OVER (PARTITION BY conversation_id ORDER BY id DESC) AS row_number
+                        FROM messenger_messages
+                    ) ranked
+                    WHERE ranked.row_number > ?
+                    LIMIT ?
+                )
+                """;
+        try (Connection connection = dataSource.getConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement(deleteExpired)) {
+                statement.setInt(1, days);
+                statement.setInt(2, CLEANUP_BATCH_SIZE);
+                statement.executeUpdate();
+            }
+            try (PreparedStatement statement = connection.prepareStatement(deleteOverflow)) {
+                statement.setInt(1, maxMessagesPerConversation);
+                statement.setInt(2, CLEANUP_BATCH_SIZE);
+                statement.executeUpdate();
+            }
+        } catch (SQLException exception) {
+            throw new IllegalStateException("failed to clean messenger history", exception);
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerConversationSummary.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerConversationSummary.java
@@ -1,0 +1,11 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+public record MessengerConversationSummary(
+        long id,
+        ConversationType type,
+        String name,
+        long lastMessageId,
+        int unreadCount,
+        long updatedAt
+) {
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerConversationSummary.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerConversationSummary.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.messenger.history;
 public record MessengerConversationSummary(
         long id,
         ConversationType type,
+        int participantId,
         String name,
         long lastMessageId,
         int unreadCount,

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryPage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryPage.java
@@ -1,0 +1,9 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+import java.util.List;
+
+public record MessengerHistoryPage(List<MessengerStoredMessage> messages, boolean hasMore) {
+    public MessengerHistoryPage {
+        messages = List.copyOf(messages);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryRepository.java
@@ -3,9 +3,17 @@ package com.eu.habbo.habbohotel.messenger.history;
 import java.util.List;
 
 public interface MessengerHistoryRepository {
+    List<MessengerConversationSummary> listConversations(int userId);
+
     boolean isActiveMember(long conversationId, int userId);
 
     List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit);
+
+    MessengerStoredMessage storeDirectMessage(int senderId, int recipientId, int type, String message, String metadata);
+
+    MessengerStoredMessage storeConversationMessage(long conversationId, int senderId, int type, String message, String metadata);
+
+    boolean markRead(long conversationId, int userId, long messageId);
 
     void cleanupRetention(int days, int maxMessagesPerConversation);
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryRepository.java
@@ -7,6 +7,8 @@ public interface MessengerHistoryRepository {
 
     boolean isActiveMember(long conversationId, int userId);
 
+    List<Integer> listActiveMemberIds(long conversationId);
+
     List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit);
 
     MessengerStoredMessage storeDirectMessage(int senderId, int recipientId, int type, String message, String metadata);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+import java.util.List;
+
+public interface MessengerHistoryRepository {
+    boolean isActiveMember(long conversationId, int userId);
+
+    List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit);
+
+    void cleanupRetention(int days, int maxMessagesPerConversation);
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
@@ -39,6 +39,31 @@ public final class MessengerHistoryService {
         return new MessengerHistoryPage(page, hasMore);
     }
 
+    public List<MessengerConversationSummary> listConversations(int userId) {
+        if (userId <= 0) throw new IllegalArgumentException("userId must be positive");
+        return List.copyOf(repository.listConversations(userId));
+    }
+
+    public MessengerStoredMessage sendMessage(long conversationId, int senderId, int recipientId, int type, String message, String metadata) {
+        if (senderId <= 0) throw new IllegalArgumentException("senderId must be positive");
+        if (type < 0 || type > 3) throw new IllegalArgumentException("unsupported message type");
+        String normalized = message == null ? "" : message.strip();
+        if (normalized.isEmpty() || normalized.length() > 255) throw new IllegalArgumentException("message length must be 1..255");
+        if (metadata != null && metadata.length() > 1024) throw new IllegalArgumentException("metadata is too long");
+        if (conversationId > 0) {
+            if (!repository.isActiveMember(conversationId, senderId)) throw new SecurityException("conversation access denied");
+            return repository.storeConversationMessage(conversationId, senderId, type, normalized, metadata);
+        }
+        if (recipientId <= 0 || recipientId == senderId) throw new IllegalArgumentException("invalid direct recipient");
+        return repository.storeDirectMessage(senderId, recipientId, type, normalized, metadata);
+    }
+
+    public boolean markRead(long conversationId, int userId, long messageId) {
+        if (conversationId <= 0 || userId <= 0 || messageId <= 0) throw new IllegalArgumentException("invalid read cursor");
+        if (!repository.isActiveMember(conversationId, userId)) throw new SecurityException("conversation access denied");
+        return repository.markRead(conversationId, userId, messageId);
+    }
+
     public void cleanupRetention() {
         repository.cleanupRetention(retentionDays, maxMessagesPerConversation);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
@@ -64,6 +64,12 @@ public final class MessengerHistoryService {
         return repository.markRead(conversationId, userId, messageId);
     }
 
+    public List<Integer> listActiveMemberIds(long conversationId, int requestingUserId) {
+        if (conversationId <= 0 || requestingUserId <= 0) throw new IllegalArgumentException("invalid conversation");
+        if (!repository.isActiveMember(conversationId, requestingUserId)) throw new SecurityException("conversation access denied");
+        return List.copyOf(repository.listActiveMemberIds(conversationId));
+    }
+
     public void cleanupRetention() {
         repository.cleanupRetention(retentionDays, maxMessagesPerConversation);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryService.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class MessengerHistoryService {
+    public static final int DEFAULT_RETENTION_DAYS = 30;
+    public static final int DEFAULT_MAX_MESSAGES = 500;
+    public static final int DEFAULT_PAGE_SIZE = 30;
+    public static final int MAX_PAGE_SIZE = 50;
+
+    private final MessengerHistoryRepository repository;
+    private final int retentionDays;
+    private final int maxMessagesPerConversation;
+
+    public MessengerHistoryService(MessengerHistoryRepository repository) {
+        this(repository, DEFAULT_RETENTION_DAYS, DEFAULT_MAX_MESSAGES);
+    }
+
+    public MessengerHistoryService(MessengerHistoryRepository repository, int retentionDays, int maxMessagesPerConversation) {
+        if (repository == null) throw new IllegalArgumentException("repository is required");
+        if (retentionDays <= 0) throw new IllegalArgumentException("retentionDays must be positive");
+        if (maxMessagesPerConversation <= 0) throw new IllegalArgumentException("maxMessagesPerConversation must be positive");
+        this.repository = repository;
+        this.retentionDays = retentionDays;
+        this.maxMessagesPerConversation = maxMessagesPerConversation;
+    }
+
+    public MessengerHistoryPage loadHistory(long conversationId, int userId, long beforeMessageId, int requestedLimit) {
+        if (conversationId <= 0 || userId <= 0) throw new IllegalArgumentException("conversationId and userId must be positive");
+        if (!repository.isActiveMember(conversationId, userId)) throw new SecurityException("conversation access denied");
+
+        int limit = Math.max(1, Math.min(MAX_PAGE_SIZE, requestedLimit));
+        List<MessengerStoredMessage> loaded = repository.loadHistory(conversationId, userId, Math.max(0, beforeMessageId), limit);
+        boolean hasMore = loaded.size() > limit;
+        List<MessengerStoredMessage> page = new ArrayList<>(hasMore ? loaded.subList(0, limit) : loaded);
+        Collections.reverse(page);
+        return new MessengerHistoryPage(page, hasMore);
+    }
+
+    public void cleanupRetention() {
+        repository.cleanupRetention(retentionDays, maxMessagesPerConversation);
+    }
+
+    public static String directKey(int firstUserId, int secondUserId) {
+        if (firstUserId <= 0 || secondUserId <= 0 || firstUserId == secondUserId) {
+            throw new IllegalArgumentException("direct conversation requires two distinct positive user ids");
+        }
+        return Math.min(firstUserId, secondUserId) + ":" + Math.max(firstUserId, secondUserId);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServices.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServices.java
@@ -1,0 +1,12 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+import com.eu.habbo.Emulator;
+
+public final class MessengerHistoryServices {
+    private MessengerHistoryServices() {
+    }
+
+    public static MessengerHistoryService create() {
+        return new MessengerHistoryService(new JdbcMessengerHistoryRepository(Emulator.getDatabase().getDataSource()));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerStoredMessage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/messenger/history/MessengerStoredMessage.java
@@ -1,0 +1,12 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+public record MessengerStoredMessage(
+        long id,
+        long conversationId,
+        int senderId,
+        int type,
+        String message,
+        String metadata,
+        long createdAt
+) {
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
@@ -238,12 +238,37 @@ public class HabboInfo implements Runnable {
     }
 
     public void deleteMessengerCategory(MessengerCategory category) {
-        this.messengerCategories.remove(category);
-
         try {
-            SqlQueries.update("DELETE FROM messenger_categories WHERE id = ?", category.getId());
+            SqlQueries.update("UPDATE messenger_friendships SET category = 0 WHERE user_one_id = ? AND category = ?", this.id, category.getId());
+            if (SqlQueries.update("DELETE FROM messenger_categories WHERE id = ? AND user_id = ?", category.getId(), this.id) > 0) {
+                this.messengerCategories.remove(category);
+            }
         } catch (SqlQueries.DataAccessException e) {
             LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    public MessengerCategory getMessengerCategory(int categoryId) {
+        return this.messengerCategories.stream().filter(category -> category.getId() == categoryId).findFirst().orElse(null);
+    }
+
+    public boolean renameMessengerCategory(MessengerCategory category, String name) {
+        try {
+            if (SqlQueries.update("UPDATE messenger_categories SET name = ? WHERE id = ? AND user_id = ?", name, category.getId(), this.id) <= 0) return false;
+            category.setName(name);
+            return true;
+        } catch (SqlQueries.DataAccessException e) {
+            LOGGER.error("Caught SQL exception", e);
+            return false;
+        }
+    }
+
+    public boolean moveMessengerFriendToCategory(int friendId, int categoryId) {
+        try {
+            return SqlQueries.update("UPDATE messenger_friendships SET category = ? WHERE user_one_id = ? AND user_two_id = ?", categoryId, this.id, friendId) > 0;
+        } catch (SqlQueries.DataAccessException e) {
+            LOGGER.error("Caught SQL exception", e);
+            return false;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -344,6 +344,10 @@ public class PacketManager {
         this.registerHandler(Incoming.RequestMessengerHistoryEvent, RequestMessengerHistoryEvent.class);
         this.registerHandler(Incoming.SendMessengerMessageEvent, SendMessengerMessageEvent.class);
         this.registerHandler(Incoming.MarkMessengerReadEvent, MarkMessengerReadEvent.class);
+        this.registerHandler(Incoming.AddFriendCategoryEvent, AddFriendCategoryEvent.class);
+        this.registerHandler(Incoming.RenameFriendCategoryEvent, RenameFriendCategoryEvent.class);
+        this.registerHandler(Incoming.RemoveFriendCategoryEvent, RemoveFriendCategoryEvent.class);
+        this.registerHandler(Incoming.MoveFriendToCategoryEvent, MoveFriendToCategoryEvent.class);
     }
 
     private void registerUsers() throws Exception {

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -340,6 +340,10 @@ public class PacketManager {
         this.registerHandler(Incoming.RequestInitFriendsEvent, RequestInitFriendsEvent.class);
         this.registerHandler(Incoming.FindNewFriendsEvent, FindNewFriendsEvent.class);
         this.registerHandler(Incoming.InviteFriendsEvent, InviteFriendsEvent.class);
+        this.registerHandler(Incoming.RequestMessengerConversationsEvent, RequestMessengerConversationsEvent.class);
+        this.registerHandler(Incoming.RequestMessengerHistoryEvent, RequestMessengerHistoryEvent.class);
+        this.registerHandler(Incoming.SendMessengerMessageV2Event, SendMessengerMessageV2Event.class);
+        this.registerHandler(Incoming.MarkMessengerReadV2Event, MarkMessengerReadV2Event.class);
     }
 
     private void registerUsers() throws Exception {

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -342,8 +342,8 @@ public class PacketManager {
         this.registerHandler(Incoming.InviteFriendsEvent, InviteFriendsEvent.class);
         this.registerHandler(Incoming.RequestMessengerConversationsEvent, RequestMessengerConversationsEvent.class);
         this.registerHandler(Incoming.RequestMessengerHistoryEvent, RequestMessengerHistoryEvent.class);
-        this.registerHandler(Incoming.SendMessengerMessageV2Event, SendMessengerMessageV2Event.class);
-        this.registerHandler(Incoming.MarkMessengerReadV2Event, MarkMessengerReadV2Event.class);
+        this.registerHandler(Incoming.SendMessengerMessageEvent, SendMessengerMessageEvent.class);
+        this.registerHandler(Incoming.MarkMessengerReadEvent, MarkMessengerReadEvent.class);
     }
 
     private void registerUsers() throws Exception {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -526,4 +526,8 @@ public class Incoming {
     public static final int RequestMessengerHistoryEvent = 4901;
     public static final int SendMessengerMessageEvent = 4902;
     public static final int MarkMessengerReadEvent = 4903;
+    public static final int AddFriendCategoryEvent = 4081;
+    public static final int RenameFriendCategoryEvent = 4082;
+    public static final int RemoveFriendCategoryEvent = 4083;
+    public static final int MoveFriendToCategoryEvent = 4084;
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -522,4 +522,8 @@ public class Incoming {
     public static final int RequestMentionsEvent = 4803;
     public static final int MarkMentionsReadEvent = 4804;
     public static final int DeleteMentionEvent = 4805;
+    public static final int RequestMessengerConversationsEvent = 4900;
+    public static final int RequestMessengerHistoryEvent = 4901;
+    public static final int SendMessengerMessageV2Event = 4902;
+    public static final int MarkMessengerReadV2Event = 4903;
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -524,6 +524,6 @@ public class Incoming {
     public static final int DeleteMentionEvent = 4805;
     public static final int RequestMessengerConversationsEvent = 4900;
     public static final int RequestMessengerHistoryEvent = 4901;
-    public static final int SendMessengerMessageV2Event = 4902;
-    public static final int MarkMessengerReadV2Event = 4903;
+    public static final int SendMessengerMessageEvent = 4902;
+    public static final int MarkMessengerReadEvent = 4903;
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/AddFriendCategoryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/AddFriendCategoryEvent.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import com.eu.habbo.habbohotel.messenger.MessengerCategory;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.friends.UpdateFriendComposer;
+
+import java.util.Collections;
+
+public class AddFriendCategoryEvent extends MessageHandler {
+    @Override
+    public void handle() {
+        HabboInfo info = this.client.getHabbo().getHabboInfo();
+        String name = FriendCategoryInputGuard.normalizeName(this.packet.readString());
+        if (!FriendCategoryInputGuard.isValidName(name) || info.getMessengerCategories().size() >= FriendCategoryInputGuard.MAX_CATEGORIES) return;
+        if (info.getMessengerCategories().stream().anyMatch(category -> category.getName().equalsIgnoreCase(name))) return;
+
+        info.addMessengerCategory(new MessengerCategory(name, info.getId(), 0));
+        this.client.sendResponse(new UpdateFriendComposer(this.client.getHabbo(), Collections.emptyList(), 0));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/ChangeRelationEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/ChangeRelationEvent.java
@@ -12,6 +12,10 @@ public class ChangeRelationEvent extends MessageHandler {
         int userId = this.packet.readInt();
         int relationId = this.packet.readInt();
 
+        if (!FriendInputGuard.isPositiveId(userId)) {
+            return;
+        }
+
         MessengerBuddy buddy = this.client.getHabbo().getMessenger().getFriends().get(userId);
         if (buddy != null && FriendInputGuard.isValidRelation(relationId)) {
             UserRelationShipEvent event = new UserRelationShipEvent(this.client.getHabbo(), buddy, relationId);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/DeclineFriendRequestEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/DeclineFriendRequestEvent.java
@@ -16,7 +16,9 @@ public class DeclineFriendRequestEvent extends MessageHandler {
             if (count <= 0 || count > MAX_BATCH_SIZE) return;
 
             for (int i = 0; i < count; i++) {
-                this.client.getHabbo().getMessenger().deleteFriendRequests(this.packet.readInt(), this.client.getHabbo().getHabboInfo().getId());
+                int userId = this.packet.readInt();
+                if (!FriendInputGuard.isPositiveId(userId)) continue;
+                this.client.getHabbo().getMessenger().deleteFriendRequests(userId, this.client.getHabbo().getHabboInfo().getId());
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/FriendCategoryInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/FriendCategoryInputGuard.java
@@ -1,0 +1,16 @@
+package com.eu.habbo.messages.incoming.friends;
+
+final class FriendCategoryInputGuard {
+    static final int MAX_NAME_LENGTH = 25;
+    static final int MAX_CATEGORIES = 10;
+
+    private FriendCategoryInputGuard() {}
+
+    static String normalizeName(String name) {
+        return name == null ? "" : name.trim();
+    }
+
+    static boolean isValidName(String name) {
+        return !name.isEmpty() && name.length() <= MAX_NAME_LENGTH;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/FriendInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/FriendInputGuard.java
@@ -28,4 +28,21 @@ final class FriendInputGuard {
     static boolean isValidRelation(int relationId) {
         return relationId >= 0 && relationId <= MAX_RELATION_ID;
     }
+
+    static boolean isPositiveId(int id) {
+        return id > 0;
+    }
+
+    static boolean arePositiveIds(int... ids) {
+        for (int id : ids) {
+            if (!isPositiveId(id)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static boolean isValidMessageTarget(int conversationId, int recipientId) {
+        return isPositiveId(conversationId) || (conversationId == 0 && isPositiveId(recipientId));
+    }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/FriendPrivateMessageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/FriendPrivateMessageEvent.java
@@ -11,7 +11,7 @@ public class FriendPrivateMessageEvent extends MessageHandler {
         int userId = this.packet.readInt();
         String message = FriendInputGuard.normalizeMessage(this.packet.readString());
 
-        if (message.isEmpty()) {
+        if (!FriendInputGuard.isPositiveId(userId) || message.isEmpty()) {
             return;
         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/InviteFriendsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/InviteFriendsEvent.java
@@ -33,7 +33,7 @@ public class InviteFriendsEvent extends MessageHandler {
             message = FriendInputGuard.normalizeMessage(message);
 
             for (int i : userIds) {
-                if (i == 0)
+                if (!FriendInputGuard.isPositiveId(i))
                     continue;
 
                 if (!this.client.getHabbo().getMessenger().getFriends().containsKey(i))

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MarkMessengerReadEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MarkMessengerReadEvent.java
@@ -13,7 +13,7 @@ public final class MarkMessengerReadEvent extends MessageHandler {
         int conversationId = packet.readInt();
         int messageId = packet.readInt();
         int userId = client.getHabbo().getHabboInfo().getId();
-        if (conversationId <= 0 || messageId <= 0) return;
+        if (!FriendInputGuard.arePositiveIds(conversationId, messageId)) return;
         MessengerHistoryService history = MessengerHistoryServices.create();
         if (history.markRead(conversationId, userId, messageId)) {
             for (int memberId : history.listActiveMemberIds(conversationId, userId)) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MarkMessengerReadEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MarkMessengerReadEvent.java
@@ -4,7 +4,7 @@ import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryServices;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.friends.MessengerReadCursorComposer;
 
-public final class MarkMessengerReadV2Event extends MessageHandler {
+public final class MarkMessengerReadEvent extends MessageHandler {
     @Override
     public void handle() {
         int conversationId = packet.readInt();

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MarkMessengerReadEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MarkMessengerReadEvent.java
@@ -1,6 +1,9 @@
 package com.eu.habbo.messages.incoming.friends;
 
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryService;
 import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryServices;
+import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.friends.MessengerReadCursorComposer;
 
@@ -11,8 +14,12 @@ public final class MarkMessengerReadEvent extends MessageHandler {
         int messageId = packet.readInt();
         int userId = client.getHabbo().getHabboInfo().getId();
         if (conversationId <= 0 || messageId <= 0) return;
-        if (MessengerHistoryServices.create().markRead(conversationId, userId, messageId)) {
-            client.sendResponse(new MessengerReadCursorComposer(conversationId, userId, messageId));
+        MessengerHistoryService history = MessengerHistoryServices.create();
+        if (history.markRead(conversationId, userId, messageId)) {
+            for (int memberId : history.listActiveMemberIds(conversationId, userId)) {
+                Habbo member = Emulator.getGameEnvironment().getHabboManager().getHabbo(memberId);
+                if (member != null && member.getClient() != null) member.getClient().sendResponse(new MessengerReadCursorComposer(conversationId, userId, messageId));
+            }
         }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MarkMessengerReadV2Event.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MarkMessengerReadV2Event.java
@@ -1,0 +1,18 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryServices;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.friends.MessengerReadCursorComposer;
+
+public final class MarkMessengerReadV2Event extends MessageHandler {
+    @Override
+    public void handle() {
+        int conversationId = packet.readInt();
+        int messageId = packet.readInt();
+        int userId = client.getHabbo().getHabboInfo().getId();
+        if (conversationId <= 0 || messageId <= 0) return;
+        if (MessengerHistoryServices.create().markRead(conversationId, userId, messageId)) {
+            client.sendResponse(new MessengerReadCursorComposer(conversationId, userId, messageId));
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MoveFriendToCategoryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/MoveFriendToCategoryEvent.java
@@ -1,0 +1,20 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import com.eu.habbo.habbohotel.messenger.MessengerBuddy;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.friends.UpdateFriendComposer;
+
+public class MoveFriendToCategoryEvent extends MessageHandler {
+    @Override
+    public void handle() {
+        int friendId = this.packet.readInt();
+        int categoryId = this.packet.readInt();
+        if (friendId <= 0 || categoryId < 0) return;
+        if (categoryId > 0 && this.client.getHabbo().getHabboInfo().getMessengerCategory(categoryId) == null) return;
+
+        MessengerBuddy buddy = this.client.getHabbo().getMessenger().getFriend(friendId);
+        if (buddy == null || !this.client.getHabbo().getHabboInfo().moveMessengerFriendToCategory(friendId, categoryId)) return;
+        buddy.setCategoryId(categoryId);
+        this.client.sendResponse(new UpdateFriendComposer(this.client.getHabbo(), buddy, 0));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RemoveFriendCategoryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RemoveFriendCategoryEvent.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import com.eu.habbo.habbohotel.messenger.MessengerBuddy;
+import com.eu.habbo.habbohotel.messenger.MessengerCategory;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.friends.UpdateFriendComposer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RemoveFriendCategoryEvent extends MessageHandler {
+    @Override
+    public void handle() {
+        HabboInfo info = this.client.getHabbo().getHabboInfo();
+        int categoryId = this.packet.readInt();
+        MessengerCategory category = info.getMessengerCategory(categoryId);
+        if (category == null) return;
+
+        List<MessengerBuddy> changed = new ArrayList<>();
+        for (MessengerBuddy buddy : this.client.getHabbo().getMessenger().getFriends().values()) {
+            if (buddy.getCategoryId() != categoryId) continue;
+            buddy.setCategoryId(0);
+            changed.add(buddy);
+        }
+        info.deleteMessengerCategory(category);
+        this.client.sendResponse(new UpdateFriendComposer(this.client.getHabbo(), changed, 0));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RemoveFriendCategoryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RemoveFriendCategoryEvent.java
@@ -14,6 +14,7 @@ public class RemoveFriendCategoryEvent extends MessageHandler {
     public void handle() {
         HabboInfo info = this.client.getHabbo().getHabboInfo();
         int categoryId = this.packet.readInt();
+        if (!FriendInputGuard.isPositiveId(categoryId)) return;
         MessengerCategory category = info.getMessengerCategory(categoryId);
         if (category == null) return;
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RenameFriendCategoryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RenameFriendCategoryEvent.java
@@ -1,0 +1,23 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import com.eu.habbo.habbohotel.messenger.MessengerCategory;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.friends.UpdateFriendComposer;
+
+import java.util.Collections;
+
+public class RenameFriendCategoryEvent extends MessageHandler {
+    @Override
+    public void handle() {
+        HabboInfo info = this.client.getHabbo().getHabboInfo();
+        int categoryId = this.packet.readInt();
+        String name = FriendCategoryInputGuard.normalizeName(this.packet.readString());
+        MessengerCategory category = info.getMessengerCategory(categoryId);
+        if (category == null || !FriendCategoryInputGuard.isValidName(name)) return;
+        if (info.getMessengerCategories().stream().anyMatch(item -> item.getId() != categoryId && item.getName().equalsIgnoreCase(name))) return;
+        if (!info.renameMessengerCategory(category, name)) return;
+
+        this.client.sendResponse(new UpdateFriendComposer(this.client.getHabbo(), Collections.emptyList(), 0));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RenameFriendCategoryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RenameFriendCategoryEvent.java
@@ -13,6 +13,7 @@ public class RenameFriendCategoryEvent extends MessageHandler {
         HabboInfo info = this.client.getHabbo().getHabboInfo();
         int categoryId = this.packet.readInt();
         String name = FriendCategoryInputGuard.normalizeName(this.packet.readString());
+        if (!FriendInputGuard.isPositiveId(categoryId)) return;
         MessengerCategory category = info.getMessengerCategory(categoryId);
         if (category == null || !FriendCategoryInputGuard.isValidName(name)) return;
         if (info.getMessengerCategories().stream().anyMatch(item -> item.getId() != categoryId && item.getName().equalsIgnoreCase(name))) return;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RequestMessengerConversationsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RequestMessengerConversationsEvent.java
@@ -1,0 +1,13 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryServices;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.friends.MessengerConversationsComposer;
+
+public final class RequestMessengerConversationsEvent extends MessageHandler {
+    @Override
+    public void handle() {
+        int userId = client.getHabbo().getHabboInfo().getId();
+        client.sendResponse(new MessengerConversationsComposer(MessengerHistoryServices.create().listConversations(userId)));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RequestMessengerHistoryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RequestMessengerHistoryEvent.java
@@ -11,7 +11,7 @@ public final class RequestMessengerHistoryEvent extends MessageHandler {
         int conversationId = packet.readInt();
         int beforeMessageId = packet.readInt();
         int limit = packet.readInt();
-        if (conversationId <= 0 || beforeMessageId < 0) return;
+        if (!FriendInputGuard.isPositiveId(conversationId) || beforeMessageId < 0) return;
         int userId = client.getHabbo().getHabboInfo().getId();
         MessengerHistoryPage page = MessengerHistoryServices.create().loadHistory(conversationId, userId, beforeMessageId, limit);
         client.sendResponse(new MessengerHistoryComposer(conversationId, page));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RequestMessengerHistoryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/RequestMessengerHistoryEvent.java
@@ -1,0 +1,19 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryPage;
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryServices;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.friends.MessengerHistoryComposer;
+
+public final class RequestMessengerHistoryEvent extends MessageHandler {
+    @Override
+    public void handle() {
+        int conversationId = packet.readInt();
+        int beforeMessageId = packet.readInt();
+        int limit = packet.readInt();
+        if (conversationId <= 0 || beforeMessageId < 0) return;
+        int userId = client.getHabbo().getHabboInfo().getId();
+        MessengerHistoryPage page = MessengerHistoryServices.create().loadHistory(conversationId, userId, beforeMessageId, limit);
+        client.sendResponse(new MessengerHistoryComposer(conversationId, page));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SendMessengerMessageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SendMessengerMessageEvent.java
@@ -25,6 +25,7 @@ public final class SendMessengerMessageEvent extends MessageHandler {
 
         try {
             if (!client.getHabbo().getHabboStats().allowTalk()) throw new IllegalStateException("muted");
+            if (!FriendInputGuard.isValidMessageTarget(conversationId, recipientId)) throw new IllegalArgumentException("invalid message target");
             if (conversationId <= 0) {
                 MessengerBuddy buddy = client.getHabbo().getMessenger().getFriend(recipientId);
                 if (buddy == null) throw new SecurityException("not friends");

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SendMessengerMessageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SendMessengerMessageEvent.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.messenger.Message;
 import com.eu.habbo.habbohotel.messenger.MessengerBuddy;
 import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryServices;
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryService;
 import com.eu.habbo.habbohotel.messenger.history.MessengerStoredMessage;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
@@ -28,13 +29,20 @@ public final class SendMessengerMessageEvent extends MessageHandler {
                 MessengerBuddy buddy = client.getHabbo().getMessenger().getFriend(recipientId);
                 if (buddy == null) throw new SecurityException("not friends");
             }
-            MessengerStoredMessage stored = MessengerHistoryServices.create().sendMessage(conversationId, senderId, recipientId, type, message, metadata);
+            MessengerHistoryService history = MessengerHistoryServices.create();
+            MessengerStoredMessage stored = history.sendMessage(conversationId, senderId, recipientId, type, message, metadata);
             client.sendResponse(new MessengerMessageAckComposer(confirmationId, stored));
 
             if (conversationId <= 0) {
                 new Message(senderId, recipientId, message).run();
                 Habbo recipient = Emulator.getGameEnvironment().getHabboManager().getHabbo(recipientId);
                 if (recipient != null && recipient.getClient() != null) recipient.getClient().sendResponse(new MessengerMessageComposer(stored));
+            } else {
+                for (int memberId : history.listActiveMemberIds(conversationId, senderId)) {
+                    if (memberId == senderId) continue;
+                    Habbo member = Emulator.getGameEnvironment().getHabboManager().getHabbo(memberId);
+                    if (member != null && member.getClient() != null) member.getClient().sendResponse(new MessengerMessageComposer(stored));
+                }
             }
         } catch (SecurityException exception) {
             client.sendResponse(new MessengerMessageFailedComposer(confirmationId, 6));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SendMessengerMessageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SendMessengerMessageEvent.java
@@ -9,9 +9,9 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.friends.MessengerMessageAckComposer;
 import com.eu.habbo.messages.outgoing.friends.MessengerMessageFailedComposer;
-import com.eu.habbo.messages.outgoing.friends.MessengerMessageV2Composer;
+import com.eu.habbo.messages.outgoing.friends.MessengerMessageComposer;
 
-public final class SendMessengerMessageV2Event extends MessageHandler {
+public final class SendMessengerMessageEvent extends MessageHandler {
     @Override
     public void handle() {
         int conversationId = packet.readInt();
@@ -34,7 +34,7 @@ public final class SendMessengerMessageV2Event extends MessageHandler {
             if (conversationId <= 0) {
                 new Message(senderId, recipientId, message).run();
                 Habbo recipient = Emulator.getGameEnvironment().getHabboManager().getHabbo(recipientId);
-                if (recipient != null && recipient.getClient() != null) recipient.getClient().sendResponse(new MessengerMessageV2Composer(stored));
+                if (recipient != null && recipient.getClient() != null) recipient.getClient().sendResponse(new MessengerMessageComposer(stored));
             }
         } catch (SecurityException exception) {
             client.sendResponse(new MessengerMessageFailedComposer(confirmationId, 6));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SendMessengerMessageV2Event.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/SendMessengerMessageV2Event.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.messenger.Message;
+import com.eu.habbo.habbohotel.messenger.MessengerBuddy;
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryServices;
+import com.eu.habbo.habbohotel.messenger.history.MessengerStoredMessage;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.friends.MessengerMessageAckComposer;
+import com.eu.habbo.messages.outgoing.friends.MessengerMessageFailedComposer;
+import com.eu.habbo.messages.outgoing.friends.MessengerMessageV2Composer;
+
+public final class SendMessengerMessageV2Event extends MessageHandler {
+    @Override
+    public void handle() {
+        int conversationId = packet.readInt();
+        int recipientId = packet.readInt();
+        int confirmationId = packet.readInt();
+        int type = packet.readInt();
+        String message = FriendInputGuard.normalizeMessage(packet.readString());
+        String metadata = packet.readString();
+        int senderId = client.getHabbo().getHabboInfo().getId();
+
+        try {
+            if (!client.getHabbo().getHabboStats().allowTalk()) throw new IllegalStateException("muted");
+            if (conversationId <= 0) {
+                MessengerBuddy buddy = client.getHabbo().getMessenger().getFriend(recipientId);
+                if (buddy == null) throw new SecurityException("not friends");
+            }
+            MessengerStoredMessage stored = MessengerHistoryServices.create().sendMessage(conversationId, senderId, recipientId, type, message, metadata);
+            client.sendResponse(new MessengerMessageAckComposer(confirmationId, stored));
+
+            if (conversationId <= 0) {
+                new Message(senderId, recipientId, message).run();
+                Habbo recipient = Emulator.getGameEnvironment().getHabboManager().getHabbo(recipientId);
+                if (recipient != null && recipient.getClient() != null) recipient.getClient().sendResponse(new MessengerMessageV2Composer(stored));
+            }
+        } catch (SecurityException exception) {
+            client.sendResponse(new MessengerMessageFailedComposer(confirmationId, 6));
+        } catch (IllegalArgumentException exception) {
+            client.sendResponse(new MessengerMessageFailedComposer(confirmationId, 1));
+        } catch (RuntimeException exception) {
+            client.sendResponse(new MessengerMessageFailedComposer(confirmationId, 7));
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/StalkFriendEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/friends/StalkFriendEvent.java
@@ -15,6 +15,11 @@ public class StalkFriendEvent extends MessageHandler {
     public void handle() throws Exception {
         int friendId = this.packet.readInt();
 
+        if (!FriendInputGuard.isPositiveId(friendId)) {
+            this.client.sendResponse(new StalkErrorComposer(StalkErrorComposer.NOT_IN_FRIEND_LIST));
+            return;
+        }
+
         MessengerBuddy buddy = this.client.getHabbo().getMessenger().getFriend(friendId);
 
         if (buddy == null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -617,5 +617,11 @@ public class Outgoing {
     public static final int EarningsClaimResultComposer = 9408;
     public static final int MentionReceivedComposer = 4801;
     public static final int MentionsListComposer = 4802;
+    public static final int MessengerConversationsComposer = 4900;
+    public static final int MessengerHistoryComposer = 4901;
+    public static final int MessengerMessageAckComposer = 4902;
+    public static final int MessengerMessageFailedComposer = 4903;
+    public static final int MessengerMessageV2Composer = 4904;
+    public static final int MessengerReadCursorComposer = 4905;
 
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -621,7 +621,7 @@ public class Outgoing {
     public static final int MessengerHistoryComposer = 4901;
     public static final int MessengerMessageAckComposer = 4902;
     public static final int MessengerMessageFailedComposer = 4903;
-    public static final int MessengerMessageV2Composer = 4904;
+    public static final int MessengerMessageComposer = 4904;
     public static final int MessengerReadCursorComposer = 4905;
 
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerConversationsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerConversationsComposer.java
@@ -1,0 +1,31 @@
+package com.eu.habbo.messages.outgoing.friends;
+
+import com.eu.habbo.habbohotel.messenger.history.MessengerConversationSummary;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+import java.util.List;
+
+public final class MessengerConversationsComposer extends MessageComposer {
+    private final List<MessengerConversationSummary> conversations;
+
+    public MessengerConversationsComposer(List<MessengerConversationSummary> conversations) {
+        this.conversations = List.copyOf(conversations);
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        response.init(Outgoing.MessengerConversationsComposer);
+        response.appendInt(conversations.size());
+        for (MessengerConversationSummary conversation : conversations) {
+            response.appendInt(Math.toIntExact(conversation.id()));
+            response.appendInt(conversation.type().ordinal());
+            response.appendString(conversation.name());
+            response.appendInt(Math.toIntExact(conversation.lastMessageId()));
+            response.appendInt(conversation.unreadCount());
+            response.appendInt(Math.toIntExact(conversation.updatedAt()));
+        }
+        return response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerConversationsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerConversationsComposer.java
@@ -21,6 +21,7 @@ public final class MessengerConversationsComposer extends MessageComposer {
         for (MessengerConversationSummary conversation : conversations) {
             response.appendInt(Math.toIntExact(conversation.id()));
             response.appendInt(conversation.type().ordinal());
+            response.appendInt(conversation.participantId());
             response.appendString(conversation.name());
             response.appendInt(Math.toIntExact(conversation.lastMessageId()));
             response.appendInt(conversation.unreadCount());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerHistoryComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerHistoryComposer.java
@@ -1,0 +1,36 @@
+package com.eu.habbo.messages.outgoing.friends;
+
+import com.eu.habbo.habbohotel.messenger.history.MessengerHistoryPage;
+import com.eu.habbo.habbohotel.messenger.history.MessengerStoredMessage;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public final class MessengerHistoryComposer extends MessageComposer {
+    private final long conversationId;
+    private final MessengerHistoryPage page;
+
+    public MessengerHistoryComposer(long conversationId, MessengerHistoryPage page) {
+        this.conversationId = conversationId;
+        this.page = page;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        response.init(Outgoing.MessengerHistoryComposer);
+        response.appendInt(Math.toIntExact(conversationId));
+        response.appendBoolean(page.hasMore());
+        response.appendInt(page.messages().size());
+        for (MessengerStoredMessage message : page.messages()) appendMessage(response, message);
+        return response;
+    }
+
+    static void appendMessage(ServerMessage response, MessengerStoredMessage message) {
+        response.appendInt(Math.toIntExact(message.id()));
+        response.appendInt(message.senderId());
+        response.appendInt(message.type());
+        response.appendString(message.message());
+        response.appendString(message.metadata());
+        response.appendInt(Math.toIntExact(message.createdAt()));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerMessageAckComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerMessageAckComposer.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.messages.outgoing.friends;
+
+import com.eu.habbo.habbohotel.messenger.history.MessengerStoredMessage;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public final class MessengerMessageAckComposer extends MessageComposer {
+    private final int confirmationId;
+    private final MessengerStoredMessage message;
+
+    public MessengerMessageAckComposer(int confirmationId, MessengerStoredMessage message) {
+        this.confirmationId = confirmationId;
+        this.message = message;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        response.init(Outgoing.MessengerMessageAckComposer);
+        response.appendInt(confirmationId);
+        response.appendInt(Math.toIntExact(message.conversationId()));
+        response.appendInt(Math.toIntExact(message.id()));
+        response.appendInt(Math.toIntExact(message.createdAt()));
+        return response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerMessageComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerMessageComposer.java
@@ -5,16 +5,16 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
-public final class MessengerMessageV2Composer extends MessageComposer {
+public final class MessengerMessageComposer extends MessageComposer {
     private final MessengerStoredMessage message;
 
-    public MessengerMessageV2Composer(MessengerStoredMessage message) {
+    public MessengerMessageComposer(MessengerStoredMessage message) {
         this.message = message;
     }
 
     @Override
     protected ServerMessage composeInternal() {
-        response.init(Outgoing.MessengerMessageV2Composer);
+        response.init(Outgoing.MessengerMessageComposer);
         response.appendInt(Math.toIntExact(message.conversationId()));
         MessengerHistoryComposer.appendMessage(response, message);
         return response;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerMessageFailedComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerMessageFailedComposer.java
@@ -1,0 +1,23 @@
+package com.eu.habbo.messages.outgoing.friends;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public final class MessengerMessageFailedComposer extends MessageComposer {
+    private final int confirmationId;
+    private final int errorCode;
+
+    public MessengerMessageFailedComposer(int confirmationId, int errorCode) {
+        this.confirmationId = confirmationId;
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        response.init(Outgoing.MessengerMessageFailedComposer);
+        response.appendInt(confirmationId);
+        response.appendInt(errorCode);
+        return response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerMessageV2Composer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerMessageV2Composer.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.messages.outgoing.friends;
+
+import com.eu.habbo.habbohotel.messenger.history.MessengerStoredMessage;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public final class MessengerMessageV2Composer extends MessageComposer {
+    private final MessengerStoredMessage message;
+
+    public MessengerMessageV2Composer(MessengerStoredMessage message) {
+        this.message = message;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        response.init(Outgoing.MessengerMessageV2Composer);
+        response.appendInt(Math.toIntExact(message.conversationId()));
+        MessengerHistoryComposer.appendMessage(response, message);
+        return response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerReadCursorComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/friends/MessengerReadCursorComposer.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.messages.outgoing.friends;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public final class MessengerReadCursorComposer extends MessageComposer {
+    private final long conversationId;
+    private final int readerId;
+    private final long messageId;
+
+    public MessengerReadCursorComposer(long conversationId, int readerId, long messageId) {
+        this.conversationId = conversationId;
+        this.readerId = readerId;
+        this.messageId = messageId;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        response.init(Outgoing.MessengerReadCursorComposer);
+        response.appendInt(Math.toIntExact(conversationId));
+        response.appendInt(readerId);
+        response.appendInt(Math.toIntExact(messageId));
+        return response;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/MessengerHistorySchemaContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/MessengerHistorySchemaContractTest.java
@@ -1,0 +1,39 @@
+package com.eu.habbo.database;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessengerHistorySchemaContractTest {
+    private static final Path MIGRATION = Path.of("../Database/Database Updates/025_messenger_history.sql");
+    private static final Path FULL_DATABASE = Path.of("../Database/Default Database/FullDatabase.sql");
+
+    @Test
+    void migrationDefinesUtf8InnoDbMessengerTablesAndIndexes() throws Exception {
+        String sql = Files.readString(MIGRATION);
+
+        assertAll(
+                () -> assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS `messenger_conversations`")),
+                () -> assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS `messenger_members`")),
+                () -> assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS `messenger_messages`")),
+                () -> assertTrue(sql.contains("UNIQUE KEY `uq_messenger_direct_key` (`direct_key`)")),
+                () -> assertTrue(sql.contains("KEY `idx_messenger_page` (`conversation_id`, `id`)")),
+                () -> assertTrue(sql.contains("ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"))
+        );
+    }
+
+    @Test
+    void cleanInstallSchemaMirrorsMessengerTables() throws Exception {
+        String sql = Files.readString(FULL_DATABASE);
+
+        assertAll(
+                () -> assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS `messenger_conversations`")),
+                () -> assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS `messenger_members`")),
+                () -> assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS `messenger_messages`"))
+        );
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryRetentionSqlContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryRetentionSqlContractTest.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessengerHistoryRetentionSqlContractTest {
+    @Test
+    void overflowCleanupAvoidsVersionSensitiveWindowAndInLimitSyntax() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java"));
+
+        assertTrue(source.contains("DELETE messages FROM messenger_messages messages"));
+        assertTrue(source.contains("JOIN messenger_messages newer"));
+        assertTrue(source.contains("HAVING COUNT(newer.id) >= ?"));
+        assertFalse(source.contains("ROW_NUMBER()"));
+        assertFalse(source.contains("WHERE id IN"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
@@ -57,6 +57,11 @@ class MessengerHistoryServiceTest {
         private final List<MessengerStoredMessage> rows = new ArrayList<>();
 
         @Override
+        public List<MessengerConversationSummary> listConversations(int userId) {
+            return List.of();
+        }
+
+        @Override
         public boolean isActiveMember(long conversationId, int userId) {
             return member;
         }
@@ -65,6 +70,21 @@ class MessengerHistoryServiceTest {
         public List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit) {
             requestedLimit = limit;
             return new ArrayList<>(rows);
+        }
+
+        @Override
+        public MessengerStoredMessage storeDirectMessage(int senderId, int recipientId, int type, String message, String metadata) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MessengerStoredMessage storeConversationMessage(long conversationId, int senderId, int type, String message, String metadata) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean markRead(long conversationId, int userId, long messageId) {
+            return true;
         }
 
         @Override

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
@@ -49,12 +49,22 @@ class MessengerHistoryServiceTest {
         assertEquals(500, repository.cleanupCap);
     }
 
+    @Test
+    void exposesOnlyMembersForAnAuthorizedConversation() {
+        FakeRepository repository = new FakeRepository();
+        repository.memberIds = List.of(7, 8, 9);
+        MessengerHistoryService service = new MessengerHistoryService(repository, 30, 500);
+
+        assertEquals(List.of(7, 8, 9), service.listActiveMemberIds(12, 7));
+    }
+
     private static final class FakeRepository implements MessengerHistoryRepository {
         private boolean member = true;
         private int requestedLimit;
         private int cleanupDays;
         private int cleanupCap;
         private final List<MessengerStoredMessage> rows = new ArrayList<>();
+        private List<Integer> memberIds = List.of();
 
         @Override
         public List<MessengerConversationSummary> listConversations(int userId) {
@@ -64,6 +74,11 @@ class MessengerHistoryServiceTest {
         @Override
         public boolean isActiveMember(long conversationId, int userId) {
             return member;
+        }
+
+        @Override
+        public List<Integer> listActiveMemberIds(long conversationId) {
+            return memberIds;
         }
 
         @Override

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/messenger/history/MessengerHistoryServiceTest.java
@@ -1,0 +1,76 @@
+package com.eu.habbo.habbohotel.messenger.history;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MessengerHistoryServiceTest {
+    @Test
+    void directKeyIsStableRegardlessOfSenderOrder() {
+        assertEquals("7:19", MessengerHistoryService.directKey(7, 19));
+        assertEquals("7:19", MessengerHistoryService.directKey(19, 7));
+    }
+
+    @Test
+    void rejectsHistoryForNonMembers() {
+        FakeRepository repository = new FakeRepository();
+        repository.member = false;
+        MessengerHistoryService service = new MessengerHistoryService(repository, 30, 500);
+
+        assertThrows(SecurityException.class, () -> service.loadHistory(9, 7, 0, 30));
+    }
+
+    @Test
+    void clampsHistoryLimitAndReturnsChronologicalMessages() {
+        FakeRepository repository = new FakeRepository();
+        repository.rows.add(new MessengerStoredMessage(3, 9, 7, 0, "third", null, 300));
+        repository.rows.add(new MessengerStoredMessage(2, 9, 8, 0, "second", null, 200));
+        repository.rows.add(new MessengerStoredMessage(1, 9, 7, 0, "first", null, 100));
+        MessengerHistoryService service = new MessengerHistoryService(repository, 30, 500);
+
+        MessengerHistoryPage page = service.loadHistory(9, 7, 0, 500);
+
+        assertEquals(50, repository.requestedLimit);
+        assertEquals(List.of(1L, 2L, 3L), page.messages().stream().map(MessengerStoredMessage::id).toList());
+    }
+
+    @Test
+    void cleanupUsesConfiguredAgeAndConversationCap() {
+        FakeRepository repository = new FakeRepository();
+        MessengerHistoryService service = new MessengerHistoryService(repository, 30, 500);
+
+        service.cleanupRetention();
+
+        assertEquals(30, repository.cleanupDays);
+        assertEquals(500, repository.cleanupCap);
+    }
+
+    private static final class FakeRepository implements MessengerHistoryRepository {
+        private boolean member = true;
+        private int requestedLimit;
+        private int cleanupDays;
+        private int cleanupCap;
+        private final List<MessengerStoredMessage> rows = new ArrayList<>();
+
+        @Override
+        public boolean isActiveMember(long conversationId, int userId) {
+            return member;
+        }
+
+        @Override
+        public List<MessengerStoredMessage> loadHistory(long conversationId, int userId, long beforeMessageId, int limit) {
+            requestedLimit = limit;
+            return new ArrayList<>(rows);
+        }
+
+        @Override
+        public void cleanupRetention(int days, int maxMessagesPerConversation) {
+            cleanupDays = days;
+            cleanupCap = maxMessagesPerConversation;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/MessengerPacketContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/MessengerPacketContractTest.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.messages;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessengerPacketContractTest {
+    @Test
+    void messengerV2HeadersUseReservedDirectionalIds() throws Exception {
+        String incoming = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/Incoming.java"));
+        String outgoing = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java"));
+
+        assertTrue(incoming.contains("RequestMessengerConversationsEvent = 4900"));
+        assertTrue(incoming.contains("RequestMessengerHistoryEvent = 4901"));
+        assertTrue(incoming.contains("SendMessengerMessageV2Event = 4902"));
+        assertTrue(incoming.contains("MarkMessengerReadV2Event = 4903"));
+        assertTrue(outgoing.contains("MessengerConversationsComposer = 4900"));
+        assertTrue(outgoing.contains("MessengerHistoryComposer = 4901"));
+        assertTrue(outgoing.contains("MessengerMessageAckComposer = 4902"));
+        assertTrue(outgoing.contains("MessengerMessageFailedComposer = 4903"));
+        assertTrue(outgoing.contains("MessengerMessageV2Composer = 4904"));
+        assertTrue(outgoing.contains("MessengerReadCursorComposer = 4905"));
+    }
+
+    @Test
+    void packetManagerRegistersMessengerV2Handlers() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/PacketManager.java"));
+
+        assertTrue(source.contains("Incoming.RequestMessengerConversationsEvent, RequestMessengerConversationsEvent.class"));
+        assertTrue(source.contains("Incoming.RequestMessengerHistoryEvent, RequestMessengerHistoryEvent.class"));
+        assertTrue(source.contains("Incoming.SendMessengerMessageV2Event, SendMessengerMessageV2Event.class"));
+        assertTrue(source.contains("Incoming.MarkMessengerReadV2Event, MarkMessengerReadV2Event.class"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/MessengerPacketContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/MessengerPacketContractTest.java
@@ -9,29 +9,29 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MessengerPacketContractTest {
     @Test
-    void messengerV2HeadersUseReservedDirectionalIds() throws Exception {
+    void messengerHeadersUseReservedDirectionalIds() throws Exception {
         String incoming = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/Incoming.java"));
         String outgoing = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java"));
 
         assertTrue(incoming.contains("RequestMessengerConversationsEvent = 4900"));
         assertTrue(incoming.contains("RequestMessengerHistoryEvent = 4901"));
-        assertTrue(incoming.contains("SendMessengerMessageV2Event = 4902"));
-        assertTrue(incoming.contains("MarkMessengerReadV2Event = 4903"));
+        assertTrue(incoming.contains("SendMessengerMessageEvent = 4902"));
+        assertTrue(incoming.contains("MarkMessengerReadEvent = 4903"));
         assertTrue(outgoing.contains("MessengerConversationsComposer = 4900"));
         assertTrue(outgoing.contains("MessengerHistoryComposer = 4901"));
         assertTrue(outgoing.contains("MessengerMessageAckComposer = 4902"));
         assertTrue(outgoing.contains("MessengerMessageFailedComposer = 4903"));
-        assertTrue(outgoing.contains("MessengerMessageV2Composer = 4904"));
+        assertTrue(outgoing.contains("MessengerMessageComposer = 4904"));
         assertTrue(outgoing.contains("MessengerReadCursorComposer = 4905"));
     }
 
     @Test
-    void packetManagerRegistersMessengerV2Handlers() throws Exception {
+    void packetManagerRegistersMessengerHandlers() throws Exception {
         String source = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/PacketManager.java"));
 
         assertTrue(source.contains("Incoming.RequestMessengerConversationsEvent, RequestMessengerConversationsEvent.class"));
         assertTrue(source.contains("Incoming.RequestMessengerHistoryEvent, RequestMessengerHistoryEvent.class"));
-        assertTrue(source.contains("Incoming.SendMessengerMessageV2Event, SendMessengerMessageV2Event.class"));
-        assertTrue(source.contains("Incoming.MarkMessengerReadV2Event, MarkMessengerReadV2Event.class"));
+        assertTrue(source.contains("Incoming.SendMessengerMessageEvent, SendMessengerMessageEvent.class"));
+        assertTrue(source.contains("Incoming.MarkMessengerReadEvent, MarkMessengerReadEvent.class"));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/friends/FriendCategoryPacketContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/friends/FriendCategoryPacketContractTest.java
@@ -1,0 +1,46 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FriendCategoryPacketContractTest {
+    private static String source(String path) throws Exception {
+        return Files.readString(Path.of("src/main/java/" + path));
+    }
+
+    @Test
+    void categoryPacketHeadersMatchRendererContract() throws Exception {
+        String incoming = source("com/eu/habbo/messages/incoming/Incoming.java");
+
+        assertTrue(incoming.contains("AddFriendCategoryEvent = 4081"));
+        assertTrue(incoming.contains("RenameFriendCategoryEvent = 4082"));
+        assertTrue(incoming.contains("RemoveFriendCategoryEvent = 4083"));
+        assertTrue(incoming.contains("MoveFriendToCategoryEvent = 4084"));
+    }
+
+    @Test
+    void packetManagerRegistersAllCategoryHandlers() throws Exception {
+        String registry = source("com/eu/habbo/messages/PacketManager.java");
+
+        assertTrue(registry.contains("Incoming.AddFriendCategoryEvent, AddFriendCategoryEvent.class"));
+        assertTrue(registry.contains("Incoming.RenameFriendCategoryEvent, RenameFriendCategoryEvent.class"));
+        assertTrue(registry.contains("Incoming.RemoveFriendCategoryEvent, RemoveFriendCategoryEvent.class"));
+        assertTrue(registry.contains("Incoming.MoveFriendToCategoryEvent, MoveFriendToCategoryEvent.class"));
+    }
+
+    @Test
+    void categoryMutationsValidateOwnedCategoriesAndFriends() throws Exception {
+        String rename = source("com/eu/habbo/messages/incoming/friends/RenameFriendCategoryEvent.java");
+        String remove = source("com/eu/habbo/messages/incoming/friends/RemoveFriendCategoryEvent.java");
+        String move = source("com/eu/habbo/messages/incoming/friends/MoveFriendToCategoryEvent.java");
+
+        assertTrue(rename.contains("getMessengerCategory(categoryId)"));
+        assertTrue(remove.contains("getMessengerCategory(categoryId)"));
+        assertTrue(move.contains("getMessengerCategory(categoryId)"));
+        assertTrue(move.contains("getMessenger().getFriend(friendId)"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/friends/MessengerIdInputGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/friends/MessengerIdInputGuardContractTest.java
@@ -1,0 +1,50 @@
+package com.eu.habbo.messages.incoming.friends;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessengerIdInputGuardContractTest {
+    private static final Path FRIEND_SOURCE = Path.of("src/main/java/com/eu/habbo/messages/incoming/friends");
+
+    private static String friendSource(String file) throws Exception {
+        return Files.readString(FRIEND_SOURCE.resolve(file));
+    }
+
+    @Test
+    void messengerPacketIdsUseTheSharedPositiveIdGuard() throws Exception {
+        Map<String, String> expectedGuards = Map.ofEntries(
+                Map.entry("ChangeRelationEvent.java", "FriendInputGuard.isPositiveId(userId)"),
+                Map.entry("DeclineFriendRequestEvent.java", "FriendInputGuard.isPositiveId(userId)"),
+                Map.entry("FriendPrivateMessageEvent.java", "FriendInputGuard.isPositiveId(userId)"),
+                Map.entry("InviteFriendsEvent.java", "FriendInputGuard.isPositiveId(i)"),
+                Map.entry("MarkMessengerReadEvent.java", "FriendInputGuard.arePositiveIds(conversationId, messageId)"),
+                Map.entry("RemoveFriendCategoryEvent.java", "FriendInputGuard.isPositiveId(categoryId)"),
+                Map.entry("RenameFriendCategoryEvent.java", "FriendInputGuard.isPositiveId(categoryId)"),
+                Map.entry("RequestMessengerHistoryEvent.java", "FriendInputGuard.isPositiveId(conversationId)"),
+                Map.entry("SendMessengerMessageEvent.java", "FriendInputGuard.isValidMessageTarget(conversationId, recipientId)"),
+                Map.entry("StalkFriendEvent.java", "FriendInputGuard.isPositiveId(friendId)"));
+
+        for (Map.Entry<String, String> entry : expectedGuards.entrySet()) {
+            assertTrue(friendSource(entry.getKey()).contains(entry.getValue()),
+                    entry.getKey() + " must reject invalid packet IDs before lookup or persistence");
+        }
+    }
+
+    @Test
+    void readCursorMustReferenceAMessageInTheSameConversation() throws Exception {
+        String repository = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/messenger/history/JdbcMessengerHistoryRepository.java"));
+        int markRead = repository.indexOf("public boolean markRead");
+        String method = repository.substring(markRead, repository.indexOf("@Override", markRead + 10));
+
+        assertTrue(method.contains("EXISTS"), "cursor update must atomically verify the message");
+        assertTrue(method.contains("message.id = ?"), "cursor update must validate the supplied message id");
+        assertTrue(method.contains("message.conversation_id = member.conversation_id"),
+                "cursor message must belong to the member conversation");
+    }
+}


### PR DESCRIPTION
## Summary
- add persistent direct and group messenger history and delivery
- add friend category creation, rename, removal and assignment
- support MariaDB-compatible retention cleanup
- validate messenger, friend and category IDs at packet boundaries
- only advance read cursors to messages in the same visible conversation

## Verification
- `mvn '-Dtest=MessengerIdInputGuardContractTest,MessengerHistoryServiceTest,MessengerHistoryRetentionSqlContractTest' test`
- `mvn clean package`
- 460 tests, 0 failures, 0 errors