### PR TITLE
Audit furniture redemption economy changes

### DIFF
--- a/Database/Database Updates/026_economy_audit.sql
+++ b/Database/Database Updates/026_economy_audit.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS `logs_economy` (
+    `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `operation_id` VARCHAR(96) NOT NULL,
+    `user_id` INT UNSIGNED NOT NULL,
+    `operation` VARCHAR(64) NOT NULL,
+    `currency_type` INT NOT NULL,
+    `amount` INT NOT NULL,
+    `balance_before` INT NOT NULL,
+    `balance_after` INT NOT NULL,
+    `item_id` INT UNSIGNED NULL,
+    `context` VARCHAR(255) NOT NULL DEFAULT '',
+    `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uq_logs_economy_operation_id` (`operation_id`),
+    KEY `idx_logs_economy_user_created` (`user_id`, `created_at`),
+    KEY `idx_logs_economy_operation_created` (`operation`, `created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyAuditEntry.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyAuditEntry.java
@@ -1,0 +1,31 @@
+package com.eu.habbo.habbohotel.economy;
+
+public record EconomyAuditEntry(
+        String operationId,
+        int userId,
+        String operation,
+        int currencyType,
+        int amount,
+        int balanceBefore,
+        int balanceAfter,
+        Integer itemId,
+        String context) {
+
+    public static EconomyAuditEntry redemption(int userId, int itemId, int currencyType, int amount,
+                                                int balanceBefore, int balanceAfter, String itemName) {
+        if (userId <= 0 || itemId <= 0 || amount <= 0) {
+            throw new IllegalArgumentException("redemption audit values must be positive");
+        }
+
+        return new EconomyAuditEntry(
+                "furniture-redeem:" + itemId,
+                userId,
+                "furniture_redeem",
+                currencyType,
+                amount,
+                balanceBefore,
+                balanceAfter,
+                itemId,
+                itemName == null ? "" : itemName);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyAuditLogger.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyAuditLogger.java
@@ -1,0 +1,46 @@
+package com.eu.habbo.habbohotel.economy;
+
+import com.eu.habbo.Emulator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public final class EconomyAuditLogger {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EconomyAuditLogger.class);
+    private static final String INSERT = """
+            INSERT IGNORE INTO logs_economy
+                (operation_id, user_id, operation, currency_type, amount, balance_before, balance_after, item_id, context)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+
+    private EconomyAuditLogger() {
+    }
+
+    public static boolean record(EconomyAuditEntry entry) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement statement = connection.prepareStatement(INSERT)) {
+            statement.setString(1, entry.operationId());
+            statement.setInt(2, entry.userId());
+            statement.setString(3, entry.operation());
+            statement.setInt(4, entry.currencyType());
+            statement.setInt(5, entry.amount());
+            statement.setInt(6, entry.balanceBefore());
+            statement.setInt(7, entry.balanceAfter());
+            if (entry.itemId() == null) statement.setNull(8, java.sql.Types.INTEGER);
+            else statement.setInt(8, entry.itemId());
+            statement.setString(9, truncate(entry.context(), 255));
+            return statement.executeUpdate() == 1;
+        } catch (SQLException e) {
+            LOGGER.error("Failed to write economy audit operation {}", entry.operationId(), e);
+            return false;
+        }
+    }
+
+    private static String truncate(String value, int maxLength) {
+        if (value == null || value.isEmpty()) return "";
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
@@ -1,6 +1,8 @@
 package com.eu.habbo.messages.incoming.rooms.items;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyAuditEntry;
+import com.eu.habbo.habbohotel.economy.EconomyAuditLogger;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.HabboItem;
@@ -109,6 +111,8 @@ public class RedeemItemEvent extends MessageHandler {
                     room.sendComposer(new UpdateStackHeightComposer(item.getX(), item.getY(), t.z, t.relativeHeight()).compose());
                     Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
 
+                    int balanceBefore = getCurrencyBalance(furniRedeemEvent.currencyID);
+
                     switch (furniRedeemEvent.currencyID) {
                         case FurnitureRedeemedEvent.CREDITS:
                             this.client.getHabbo().giveCredits(furniRedeemEvent.amount);
@@ -126,8 +130,26 @@ public class RedeemItemEvent extends MessageHandler {
                             this.client.getHabbo().givePoints(furniRedeemEvent.currencyID, furniRedeemEvent.amount);
                             break;
                     }
+
+                    int balanceAfter = getCurrencyBalance(furniRedeemEvent.currencyID);
+                    EconomyAuditLogger.record(EconomyAuditEntry.redemption(
+                            this.client.getHabbo().getHabboInfo().getId(),
+                            item.getId(),
+                            furniRedeemEvent.currencyID,
+                            furniRedeemEvent.amount,
+                            balanceBefore,
+                            balanceAfter,
+                            item.getBaseItem().getName()));
                 }
             }
         }
+    }
+
+    private int getCurrencyBalance(int currencyType) {
+        return switch (currencyType) {
+            case FurnitureRedeemedEvent.CREDITS -> this.client.getHabbo().getHabboInfo().getCredits();
+            case FurnitureRedeemedEvent.PIXELS -> this.client.getHabbo().getHabboInfo().getPixels();
+            default -> this.client.getHabbo().getHabboInfo().getCurrencyAmount(currencyType);
+        };
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditEntryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditEntryTest.java
@@ -1,0 +1,32 @@
+package com.eu.habbo.habbohotel.economy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EconomyAuditEntryTest {
+
+    @Test
+    void redemptionBuildsStableOperationIdentityAndBalances() {
+        EconomyAuditEntry entry = EconomyAuditEntry.redemption(42, 9001, -1, 50, 100, 150, "CF_50_goldbar");
+
+        assertEquals("furniture-redeem:9001", entry.operationId());
+        assertEquals(42, entry.userId());
+        assertEquals("furniture_redeem", entry.operation());
+        assertEquals(-1, entry.currencyType());
+        assertEquals(50, entry.amount());
+        assertEquals(100, entry.balanceBefore());
+        assertEquals(150, entry.balanceAfter());
+        assertEquals(9001, entry.itemId());
+        assertEquals("CF_50_goldbar", entry.context());
+    }
+
+    @Test
+    void redemptionRejectsInvalidEconomicValues() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EconomyAuditEntry.redemption(42, 9001, -1, 0, 100, 100, "CF_0_invalid"));
+        assertThrows(IllegalArgumentException.class,
+                () -> EconomyAuditEntry.redemption(0, 9001, -1, 50, 100, 150, "CF_50_goldbar"));
+    }
+}


### PR DESCRIPTION
## What changed

- adds a versioned logs_economy migration with stable operation identifiers
- records furniture redemption currency, requested amount, balances, user, item and classname
- keeps audit failures isolated from the gameplay path while logging the database error
- adds focused audit entry validation tests

## Validation

- mvn clean package — 447 tests passed, build successful
- migration applied to the development MariaDB — logs_economy verified with 11 columns