### PR TITLE
Credit diamond furniture to the diamond balance

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
@@ -115,7 +115,7 @@ public class RedeemItemEvent extends MessageHandler {
                             break;
 
                         case FurnitureRedeemedEvent.DIAMONDS:
-                            this.client.getHabbo().givePoints(furniRedeemEvent.amount);
+                            this.client.getHabbo().givePoints(FurnitureRedeemedEvent.DIAMONDS, furniRedeemEvent.amount);
                             break;
 
                         case FurnitureRedeemedEvent.PIXELS:

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemCurrencyContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemCurrencyContractTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedeemItemCurrencyContractTest {
+    private static String source() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java"));
+    }
+
+    @Test
+    void diamondFurnitureCreditsTheDiamondCurrencyExplicitly() throws Exception {
+        String source = source();
+        int diamondCase = source.indexOf("case FurnitureRedeemedEvent.DIAMONDS:");
+        int nextCase = source.indexOf("case FurnitureRedeemedEvent.PIXELS:", diamondCase);
+        String diamondBranch = source.substring(diamondCase, nextCase);
+
+        assertTrue(diamondCase > -1, "diamond redemption branch must exist");
+        assertTrue(diamondBranch.contains("givePoints(FurnitureRedeemedEvent.DIAMONDS, furniRedeemEvent.amount)"),
+                "diamond furniture must not depend on seasonal.primary.type");
+    }
+}


### PR DESCRIPTION
## What changed

- credits redeemed diamond furniture explicitly to currency type 5
- removes the accidental dependency on seasonal.primary.type
- adds a focused redemption currency contract test

## Validation

- targeted regression test passed
- mvn clean package — 446 tests passed, build successful