### PR TITLE
Claim redeemable furniture before granting currency

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemClaim.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemClaim.java
@@ -1,0 +1,31 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.Emulator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+final class RedeemItemClaim {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedeemItemClaim.class);
+    private static final String DELETE_OWNED_ITEM = "DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1";
+
+    private RedeemItemClaim() {
+    }
+
+    static boolean tryClaim(int itemId, int userId) {
+        if (itemId <= 0 || userId <= 0) return false;
+
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+             PreparedStatement statement = connection.prepareStatement(DELETE_OWNED_ITEM)) {
+            statement.setInt(1, itemId);
+            statement.setInt(2, userId);
+            return statement.executeUpdate() == 1;
+        } catch (SQLException e) {
+            LOGGER.error("Failed to claim redeemable item {} for user {}", itemId, userId, e);
+            return false;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
@@ -8,7 +8,6 @@ import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.rooms.UpdateStackHeightComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
 import com.eu.habbo.plugin.events.furniture.FurnitureRedeemedEvent;
-import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +97,9 @@ public class RedeemItemEvent extends MessageHandler {
                     if (room.getHabboItem(item.getId()) == null) // plugins may cause a lag between which time the item can be removed from the room
                         return;
 
+                    if (!RedeemItemClaim.tryClaim(item.getId(), this.client.getHabbo().getHabboInfo().getId()))
+                        return;
+
                     room.removeHabboItem(item);
                     room.sendComposer(new RemoveFloorItemComposer(item).compose());
                     RoomTile t = room.getLayout().getTile(item.getX(), item.getY());
@@ -107,8 +109,6 @@ public class RedeemItemEvent extends MessageHandler {
                     t.setStackHeight(room.getStackHeight(item.getX(), item.getY(), false));
                     room.updateTile(t);
                     room.sendComposer(new UpdateStackHeightComposer(item.getX(), item.getY(), t.z, t.relativeHeight()).compose());
-                    Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
-
                     switch (furniRedeemEvent.currencyID) {
                         case FurnitureRedeemedEvent.CREDITS:
                             this.client.getHabbo().giveCredits(furniRedeemEvent.amount);

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemClaimContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemClaimContractTest.java
@@ -1,0 +1,39 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedeemItemClaimContractTest {
+    private static String eventSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java"));
+    }
+
+    private static String claimSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemClaim.java"));
+    }
+
+    @Test
+    void databaseClaimPrecedesRoomRemovalAndCurrencyGrant() throws Exception {
+        String source = eventSource();
+        int claim = source.indexOf("RedeemItemClaim.tryClaim(");
+        int roomRemoval = source.indexOf("room.removeHabboItem(item)");
+        int currencyGrant = source.indexOf("switch (furniRedeemEvent.currencyID)");
+
+        assertTrue(claim > -1, "redemption must claim the item in the database");
+        assertTrue(claim < roomRemoval, "database claim must happen before room removal");
+        assertTrue(claim < currencyGrant, "database claim must happen before currency grant");
+    }
+
+    @Test
+    void claimRequiresBothItemAndOwnerAndChecksAffectedRows() throws Exception {
+        String source = claimSource();
+
+        assertTrue(source.contains("DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1"));
+        assertTrue(source.contains("executeUpdate() == 1"),
+                "only the request that deletes the owned item may receive currency");
+    }
+}


### PR DESCRIPTION
## What changed

- atomically claims the owned database item before room removal or currency grant
- rejects repeated, stale or wrong-owner redemption requests through the affected-row check
- stops granting currency when the database claim fails
- removes the previous fire-and-forget item deletion
- adds focused ordering and ownership contract tests

## Validation

- targeted regression tests passed
- mvn clean package — 447 tests passed, build successful