### PR TITLE
Redeem furniture in one database transaction

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
@@ -9,8 +9,12 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.rooms.UpdateStackHeightComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RemoveFloorItemComposer;
+import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
+import com.eu.habbo.messages.outgoing.users.UserCurrencyComposer;
+import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
 import com.eu.habbo.plugin.events.furniture.FurnitureRedeemedEvent;
-import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
+import com.eu.habbo.plugin.events.users.UserCreditsEvent;
+import com.eu.habbo.plugin.events.users.UserPointsEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +101,19 @@ public class RedeemItemEvent extends MessageHandler {
                     if (furniRedeemEvent.amount < 1)
                         return;
 
+                    PreparedCurrencyGrant currencyGrant = prepareCurrencyGrant(
+                            furniRedeemEvent.currencyID, furniRedeemEvent.amount);
+                    if (currencyGrant == null || currencyGrant.amount() <= 0)
+                        return;
+
                     if (room.getHabboItem(item.getId()) == null) // plugins may cause a lag between which time the item can be removed from the room
+                        return;
+
+                    if (!RedeemItemTransaction.commit(
+                            item.getId(),
+                            this.client.getHabbo().getHabboInfo().getId(),
+                            currencyGrant.currencyType(),
+                            currencyGrant.amount()))
                         return;
 
                     room.removeHabboItem(item);
@@ -109,34 +125,14 @@ public class RedeemItemEvent extends MessageHandler {
                     t.setStackHeight(room.getStackHeight(item.getX(), item.getY(), false));
                     room.updateTile(t);
                     room.sendComposer(new UpdateStackHeightComposer(item.getX(), item.getY(), t.z, t.relativeHeight()).compose());
-                    Emulator.getThreading().run(new QueryDeleteHabboItem(item.getId()));
-
-                    int balanceBefore = getCurrencyBalance(furniRedeemEvent.currencyID);
-
-                    switch (furniRedeemEvent.currencyID) {
-                        case FurnitureRedeemedEvent.CREDITS:
-                            this.client.getHabbo().giveCredits(furniRedeemEvent.amount);
-                            break;
-
-                        case FurnitureRedeemedEvent.DIAMONDS:
-                            this.client.getHabbo().givePoints(FurnitureRedeemedEvent.DIAMONDS, furniRedeemEvent.amount);
-                            break;
-
-                        case FurnitureRedeemedEvent.PIXELS:
-                            this.client.getHabbo().givePixels(furniRedeemEvent.amount);
-                            break;
-
-                        default:
-                            this.client.getHabbo().givePoints(furniRedeemEvent.currencyID, furniRedeemEvent.amount);
-                            break;
-                    }
-
-                    int balanceAfter = getCurrencyBalance(furniRedeemEvent.currencyID);
+                    int balanceBefore = getCurrencyBalance(currencyGrant.currencyType());
+                    applyCurrencyGrant(currencyGrant);
+                    int balanceAfter = getCurrencyBalance(currencyGrant.currencyType());
                     EconomyAuditLogger.record(EconomyAuditEntry.redemption(
                             this.client.getHabbo().getHabboInfo().getId(),
                             item.getId(),
-                            furniRedeemEvent.currencyID,
-                            furniRedeemEvent.amount,
+                            currencyGrant.currencyType(),
+                            currencyGrant.amount(),
                             balanceBefore,
                             balanceAfter,
                             item.getBaseItem().getName()));
@@ -151,5 +147,38 @@ public class RedeemItemEvent extends MessageHandler {
             case FurnitureRedeemedEvent.PIXELS -> this.client.getHabbo().getHabboInfo().getPixels();
             default -> this.client.getHabbo().getHabboInfo().getCurrencyAmount(currencyType);
         };
+    }
+
+    private PreparedCurrencyGrant prepareCurrencyGrant(int currencyType, int amount) {
+        if (currencyType == FurnitureRedeemedEvent.CREDITS) {
+            UserCreditsEvent event = new UserCreditsEvent(this.client.getHabbo(), amount);
+            if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return null;
+            return new PreparedCurrencyGrant(FurnitureRedeemedEvent.CREDITS, event.credits);
+        }
+
+        UserPointsEvent event = new UserPointsEvent(this.client.getHabbo(), amount, currencyType);
+        if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return null;
+        return new PreparedCurrencyGrant(event.type, event.points);
+    }
+
+    private void applyCurrencyGrant(PreparedCurrencyGrant grant) {
+        if (grant.currencyType() == FurnitureRedeemedEvent.CREDITS) {
+            this.client.getHabbo().getHabboInfo().addCredits(grant.amount());
+            this.client.sendResponse(new UserCreditsComposer(this.client.getHabbo()));
+            return;
+        }
+
+        this.client.getHabbo().getHabboInfo().addCurrencyAmount(grant.currencyType(), grant.amount());
+        if (grant.currencyType() == FurnitureRedeemedEvent.PIXELS) {
+            this.client.sendResponse(new UserCurrencyComposer(this.client.getHabbo()));
+        } else {
+            this.client.sendResponse(new UserPointsComposer(
+                    this.client.getHabbo().getHabboInfo().getCurrencyAmount(grant.currencyType()),
+                    grant.amount(),
+                    grant.currencyType()));
+        }
+    }
+
+    private record PreparedCurrencyGrant(int currencyType, int amount) {
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemTransaction.java
@@ -1,0 +1,83 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.plugin.events.furniture.FurnitureRedeemedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+final class RedeemItemTransaction {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedeemItemTransaction.class);
+    private static final String DELETE_ITEM = "DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1";
+    private static final String ADD_CREDITS = "UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1";
+    private static final String ADD_CURRENCY = """
+            INSERT INTO users_currency (user_id, type, amount) VALUES (?, ?, ?)
+            ON DUPLICATE KEY UPDATE amount = amount + ?
+            """;
+
+    private RedeemItemTransaction() {
+    }
+
+    static boolean commit(int itemId, int userId, int currencyType, int amount) {
+        if (itemId <= 0 || userId <= 0 || amount <= 0) return false;
+
+        Connection connection = null;
+        try {
+            connection = Emulator.getDatabase().getDataSource().getConnection();
+            connection.setAutoCommit(false);
+
+            try (PreparedStatement delete = connection.prepareStatement(DELETE_ITEM)) {
+                delete.setInt(1, itemId);
+                delete.setInt(2, userId);
+                if (delete.executeUpdate() != 1) {
+                    connection.rollback();
+                    return false;
+                }
+            }
+
+            if (currencyType == FurnitureRedeemedEvent.CREDITS) {
+                try (PreparedStatement update = connection.prepareStatement(ADD_CREDITS)) {
+                    update.setInt(1, amount);
+                    update.setInt(2, userId);
+                    if (update.executeUpdate() != 1) {
+                        connection.rollback();
+                        return false;
+                    }
+                }
+            } else {
+                try (PreparedStatement update = connection.prepareStatement(ADD_CURRENCY)) {
+                    update.setInt(1, userId);
+                    update.setInt(2, currencyType);
+                    update.setInt(3, amount);
+                    update.setInt(4, amount);
+                    update.executeUpdate();
+                }
+            }
+
+            connection.commit();
+            return true;
+        } catch (SQLException e) {
+            if (connection != null) {
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackError) {
+                    e.addSuppressed(rollbackError);
+                }
+            }
+            LOGGER.error("Atomic redemption failed for item {} and user {}", itemId, userId, e);
+            return false;
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.setAutoCommit(true);
+                    connection.close();
+                } catch (SQLException e) {
+                    LOGGER.warn("Failed to close redemption transaction connection", e);
+                }
+            }
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/AtomicRedeemItemContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/AtomicRedeemItemContractTest.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AtomicRedeemItemContractTest {
+    private static String read(String relativePath) throws Exception {
+        return Files.readString(Path.of(relativePath));
+    }
+
+    @Test
+    void pluginResolutionPrecedesTransactionAndMemoryApplyFollowsCommit() throws Exception {
+        String source = read("src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java");
+        int prepare = source.indexOf("prepareCurrencyGrant(");
+        int commit = source.indexOf("RedeemItemTransaction.commit(");
+        int roomRemoval = source.indexOf("room.removeHabboItem(item)");
+        int apply = source.indexOf("applyCurrencyGrant(");
+        int audit = source.indexOf("EconomyAuditLogger.record(");
+
+        assertTrue(prepare > -1 && prepare < commit, "plugin currency events must resolve before the transaction");
+        assertTrue(commit < roomRemoval, "database commit must precede room removal");
+        assertTrue(roomRemoval < apply, "memory balance must be synchronized only after commit");
+        assertTrue(apply < audit, "economy audit must record the committed and synchronized balance");
+        assertTrue(source.contains("currencyGrant.currencyType()"),
+                "audit and balance updates must use the plugin-resolved currency type");
+    }
+
+    @Test
+    void itemDeleteAndBalanceUpdateShareOneDatabaseTransaction() throws Exception {
+        String source = read("src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemTransaction.java");
+
+        assertTrue(source.contains("setAutoCommit(false)"));
+        assertTrue(source.contains("DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1"));
+        assertTrue(source.contains("UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1"));
+        assertTrue(source.contains("ON DUPLICATE KEY UPDATE amount = amount + ?"));
+        assertTrue(source.contains("connection.commit()"));
+        assertTrue(source.contains("connection.rollback()"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemCurrencyContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemCurrencyContractTest.java
@@ -15,12 +15,17 @@ class RedeemItemCurrencyContractTest {
     @Test
     void diamondFurnitureCreditsTheDiamondCurrencyExplicitly() throws Exception {
         String source = source();
-        int diamondCase = source.indexOf("case FurnitureRedeemedEvent.DIAMONDS:");
-        int nextCase = source.indexOf("case FurnitureRedeemedEvent.PIXELS:", diamondCase);
-        String diamondBranch = source.substring(diamondCase, nextCase);
+        int diamondFurniture = source.indexOf("startsWith(\"CF_diamond_\")");
+        int diamondType = source.indexOf("FurnitureRedeemedEvent.DIAMONDS", diamondFurniture);
+        int transaction = source.indexOf("RedeemItemTransaction.commit(", diamondType);
+        int transactionType = source.indexOf("currencyGrant.currencyType()", transaction);
+        int apply = source.indexOf("applyCurrencyGrant(currencyGrant)", transactionType);
 
-        assertTrue(diamondCase > -1, "diamond redemption branch must exist");
-        assertTrue(diamondBranch.contains("givePoints(FurnitureRedeemedEvent.DIAMONDS, furniRedeemEvent.amount)"),
-                "diamond furniture must not depend on seasonal.primary.type");
+        assertTrue(diamondFurniture > -1 && diamondType > diamondFurniture,
+                "diamond furniture must resolve explicitly to the diamond currency type");
+        assertTrue(transactionType > transaction,
+                "the resolved diamond type must be persisted by the atomic transaction");
+        assertTrue(apply > transactionType,
+                "the client balance must use the same committed currency grant");
     }
 }


### PR DESCRIPTION
## What changed

- resolves currency plugin events before consuming the item
- deletes the owned furniture and increments the resolved balance in one MariaDB transaction
- rolls back both changes when either database operation fails
- updates room state and in-memory balance only after commit
- prevents plugin cancellation from consuming the furniture
- adds focused transaction ordering and SQL contract tests

## Validation

- targeted atomic redemption tests passed
- mvn clean package — 447 tests passed, build successful