### PR TITLE
Purchase marketplace offers atomically

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java
@@ -11,9 +11,13 @@ import com.eu.habbo.messages.outgoing.catalog.marketplace.MarketplaceCancelSaleC
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
+import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
+import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
 import com.eu.habbo.plugin.events.marketplace.MarketPlaceItemCancelledEvent;
 import com.eu.habbo.plugin.events.marketplace.MarketPlaceItemOfferedEvent;
 import com.eu.habbo.plugin.events.marketplace.MarketPlaceItemSoldEvent;
+import com.eu.habbo.plugin.events.users.UserCreditsEvent;
+import com.eu.habbo.plugin.events.users.UserPointsEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -297,16 +301,21 @@ public class MarketPlace {
                                         }
 
                                         int soldTimestamp = Emulator.getIntUnixTimestamp();
-                                        try (PreparedStatement updateOffer = connection.prepareStatement("UPDATE marketplace_items SET state = 2, sold_timestamp = ? WHERE id = ? AND state = 1")) {
-                                            updateOffer.setInt(1, soldTimestamp);
-                                            updateOffer.setInt(2, offerId);
-                                            int updated = updateOffer.executeUpdate();
-                                            if (updated == 0) {
-                                                sendErrorMessage(client, set.getInt("item_id"), offerId);
-                                                return;
-                                            }
-                                        }
                                         event.price = calculateCommision(event.price);
+
+                                        PreparedCharge charge = prepareMarketplaceCharge(client.getHabbo(), event.price);
+                                        if (charge == null) return;
+
+                                        if (!MarketPlacePurchaseTransaction.commit(
+                                                offerId,
+                                                item.getId(),
+                                                client.getHabbo().getHabboInfo().getId(),
+                                                charge.currencyType(),
+                                                -charge.delta(),
+                                                soldTimestamp)) {
+                                            sendErrorMessage(client, item.getBaseItem().getId(), offerId);
+                                            return;
+                                        }
 
                                         item.setUserId(client.getHabbo().getHabboInfo().getId());
                                         item.needsUpdate(true);
@@ -314,11 +323,7 @@ public class MarketPlace {
 
                                         client.getHabbo().getInventory().getItemsComponent().addItem(item);
 
-                                        if (MARKETPLACE_CURRENCY == 0) {
-                                            client.getHabbo().giveCredits(-event.price);
-                                        } else {
-                                            client.getHabbo().givePoints(MARKETPLACE_CURRENCY, -event.price);
-                                        }
+                                        applyMarketplaceCharge(client, charge);
 
                                         client.sendResponse(new AddHabboItemComposer(item));
                                         client.sendResponse(new InventoryRefreshComposer());
@@ -449,6 +454,35 @@ public class MarketPlace {
     public static int calculateCommision(int price) {
         long commission = price + (long) Math.ceil(price / 100.0);
         return commission > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) commission;
+    }
+
+    private static PreparedCharge prepareMarketplaceCharge(Habbo buyer, int price) {
+        if (MARKETPLACE_CURRENCY == 0) {
+            UserCreditsEvent event = new UserCreditsEvent(buyer, -price);
+            if (Emulator.getPluginManager().fireEvent(event).isCancelled() || event.credits >= 0) return null;
+            return new PreparedCharge(-1, event.credits);
+        }
+
+        UserPointsEvent event = new UserPointsEvent(buyer, -price, MARKETPLACE_CURRENCY);
+        if (Emulator.getPluginManager().fireEvent(event).isCancelled() || event.points >= 0) return null;
+        return new PreparedCharge(event.type, event.points);
+    }
+
+    private static void applyMarketplaceCharge(GameClient client, PreparedCharge charge) {
+        if (charge.currencyType() < 0) {
+            client.getHabbo().getHabboInfo().addCredits(charge.delta());
+            client.sendResponse(new UserCreditsComposer(client.getHabbo()));
+            return;
+        }
+
+        client.getHabbo().getHabboInfo().addCurrencyAmount(charge.currencyType(), charge.delta());
+        client.sendResponse(new UserPointsComposer(
+                client.getHabbo().getHabboInfo().getCurrencyAmount(charge.currencyType()),
+                charge.delta(),
+                charge.currencyType()));
+    }
+
+    private record PreparedCharge(int currencyType, int delta) {
     }
 
     public static boolean isValidListingPrice(int price) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlacePurchaseTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlacePurchaseTransaction.java
@@ -1,0 +1,86 @@
+package com.eu.habbo.habbohotel.catalog.marketplace;
+
+import com.eu.habbo.Emulator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+final class MarketPlacePurchaseTransaction {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MarketPlacePurchaseTransaction.class);
+    private static final String SELL_OFFER = "UPDATE marketplace_items SET state = 2, sold_timestamp = ? WHERE id = ? AND state = 1";
+    private static final String TRANSFER_ITEM = "UPDATE items SET user_id = ? WHERE id = ?";
+    private static final String CHARGE_CREDITS = "UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?";
+    private static final String CHARGE_CURRENCY = "UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?";
+
+    private MarketPlacePurchaseTransaction() {
+    }
+
+    static boolean commit(int offerId, int itemId, int buyerId, int currencyType, int charge, int soldTimestamp) {
+        if (offerId <= 0 || itemId <= 0 || buyerId <= 0 || charge <= 0) return false;
+
+        Connection connection = null;
+        try {
+            connection = Emulator.getDatabase().getDataSource().getConnection();
+            connection.setAutoCommit(false);
+
+            if (!executeOfferSale(connection, offerId, soldTimestamp)
+                    || !executeItemTransfer(connection, itemId, buyerId)
+                    || !executeCharge(connection, buyerId, currencyType, charge)) {
+                connection.rollback();
+                return false;
+            }
+
+            connection.commit();
+            return true;
+        } catch (SQLException e) {
+            if (connection != null) {
+                try { connection.rollback(); } catch (SQLException rollbackError) { e.addSuppressed(rollbackError); }
+            }
+            LOGGER.error("Atomic marketplace purchase failed for offer {}", offerId, e);
+            return false;
+        } finally {
+            if (connection != null) {
+                try { connection.setAutoCommit(true); connection.close(); }
+                catch (SQLException e) { LOGGER.warn("Failed to close marketplace transaction", e); }
+            }
+        }
+    }
+
+    private static boolean executeOfferSale(Connection connection, int offerId, int soldTimestamp) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(SELL_OFFER)) {
+            statement.setInt(1, soldTimestamp);
+            statement.setInt(2, offerId);
+            return statement.executeUpdate() == 1;
+        }
+    }
+
+    private static boolean executeItemTransfer(Connection connection, int itemId, int buyerId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(TRANSFER_ITEM)) {
+            statement.setInt(1, buyerId);
+            statement.setInt(2, itemId);
+            return statement.executeUpdate() == 1;
+        }
+    }
+
+    private static boolean executeCharge(Connection connection, int buyerId, int currencyType, int charge) throws SQLException {
+        if (currencyType < 0) {
+            try (PreparedStatement statement = connection.prepareStatement(CHARGE_CREDITS)) {
+                statement.setInt(1, charge);
+                statement.setInt(2, buyerId);
+                statement.setInt(3, charge);
+                return statement.executeUpdate() == 1;
+            }
+        }
+
+        try (PreparedStatement statement = connection.prepareStatement(CHARGE_CURRENCY)) {
+            statement.setInt(1, charge);
+            statement.setInt(2, buyerId);
+            statement.setInt(3, currencyType);
+            statement.setInt(4, charge);
+            return statement.executeUpdate() == 1;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/marketplace/AtomicMarketPlacePurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/marketplace/AtomicMarketPlacePurchaseContractTest.java
@@ -1,0 +1,39 @@
+package com.eu.habbo.habbohotel.catalog.marketplace;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AtomicMarketPlacePurchaseContractTest {
+    private static String read(String path) throws Exception {
+        return Files.readString(Path.of(path));
+    }
+
+    @Test
+    void purchaseTransactionOwnsOfferItemAndBuyerBalance() throws Exception {
+        String source = read("src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlacePurchaseTransaction.java");
+
+        assertTrue(source.contains("setAutoCommit(false)"));
+        assertTrue(source.contains("UPDATE marketplace_items SET state = 2, sold_timestamp = ? WHERE id = ? AND state = 1"));
+        assertTrue(source.contains("UPDATE items SET user_id = ? WHERE id = ?"));
+        assertTrue(source.contains("UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?"));
+        assertTrue(source.contains("UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?"));
+        assertTrue(source.contains("connection.commit()"));
+        assertTrue(source.contains("connection.rollback()"));
+    }
+
+    @Test
+    void inMemoryTransferOnlyHappensAfterDatabaseCommit() throws Exception {
+        String source = read("src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlace.java");
+        int commit = source.indexOf("MarketPlacePurchaseTransaction.commit(");
+        int setOwner = source.indexOf("item.setUserId(", commit);
+        int inventoryAdd = source.indexOf("addItem(item)", commit);
+
+        assertTrue(commit > -1, "marketplace purchase must use the transaction");
+        assertTrue(commit < setOwner, "item memory owner must change after commit");
+        assertTrue(commit < inventoryAdd, "buyer inventory must change after commit");
+    }
+}


### PR DESCRIPTION
## What changed

- resolves buyer currency plugin events before purchase
- marks the offer sold, transfers item ownership and debits the buyer in one MariaDB transaction
- verifies sufficient balance in the database update
- rolls back all purchase mutations when any step fails
- updates inventory and in-memory balance only after commit
- adds focused marketplace transaction contract tests

## Validation

- targeted marketplace transaction tests passed
- mvn clean package — 447 tests passed, build successful