### PR TITLE
Complete room trades atomically

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
@@ -7,13 +7,15 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
+import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
 import com.eu.habbo.messages.outgoing.trading.*;
 import com.eu.habbo.plugin.events.trading.TradeConfirmEvent;
-import com.eu.habbo.threading.runnables.QueryDeleteHabboItem;
+import com.eu.habbo.plugin.events.users.UserCreditsEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.*;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -179,93 +181,8 @@ public class RoomTrade {
             Emulator.getPluginManager().fireEvent(tradeConfirmEvent);
         }
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-
-            int tradeId = 0;
-
-            boolean logTrades = Emulator.getConfig().getBoolean("hotel.log.trades");
-            if (logTrades) {
-                try (PreparedStatement statement = connection.prepareStatement("INSERT INTO room_trade_log (user_one_id, user_two_id, user_one_ip, user_two_ip, timestamp, user_one_item_count, user_two_item_count) VALUES (?, ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
-                    statement.setInt(1, userOne.getHabbo().getHabboInfo().getId());
-                    statement.setInt(2, userTwo.getHabbo().getHabboInfo().getId());
-                    statement.setString(3, userOne.getHabbo().getHabboInfo().getIpLogin());
-                    statement.setString(4, userTwo.getHabbo().getHabboInfo().getIpLogin());
-                    statement.setInt(5, Emulator.getIntUnixTimestamp());
-                    statement.setInt(6, userOne.getItems().size());
-                    statement.setInt(7, userTwo.getItems().size());
-                    statement.executeUpdate();
-                    try (ResultSet generatedKeys = statement.getGeneratedKeys()) {
-                        if (generatedKeys.next()) {
-                            tradeId = generatedKeys.getInt(1);
-                        }
-                    }
-                }
-            }
-
-            int userOneId = userOne.getHabbo().getHabboInfo().getId();
-            int userTwoId = userTwo.getHabbo().getHabboInfo().getId();
-
-            try (PreparedStatement statement = connection.prepareStatement("UPDATE items SET user_id = ? WHERE id = ? AND user_id = ? LIMIT 1")) {
-                try (PreparedStatement stmt = connection.prepareStatement("INSERT INTO room_trade_log_items (id, item_id, user_id) VALUES (?, ?, ?)")) {
-                    for (HabboItem item : userOne.getItems()) {
-                        statement.setInt(1, userTwoId);
-                        statement.setInt(2, item.getId());
-                        statement.setInt(3, userOneId);
-                        statement.addBatch();
-
-                        if (logTrades) {
-                            stmt.setInt(1, tradeId);
-                            stmt.setInt(2, item.getId());
-                            stmt.setInt(3, userOneId);
-                            stmt.addBatch();
-                        }
-                    }
-
-                    for (HabboItem item : userTwo.getItems()) {
-                        statement.setInt(1, userOneId);
-                        statement.setInt(2, item.getId());
-                        statement.setInt(3, userTwoId);
-                        statement.addBatch();
-
-                        if (logTrades) {
-                            stmt.setInt(1, tradeId);
-                            stmt.setInt(2, item.getId());
-                            stmt.setInt(3, userTwoId);
-                            stmt.addBatch();
-                        }
-                    }
-
-                    if (logTrades) {
-                        stmt.executeBatch();
-                    }
-                }
-
-                int expectedUpdates = userOne.getItems().size() + userTwo.getItems().size();
-                int[] updateCounts = statement.executeBatch();
-                if (!RoomTrade.allOwnershipUpdatesSucceeded(updateCounts, expectedUpdates)) {
-                    this.sendMessageToUsers(new TradeClosedComposer(userOne.getHabbo().getRoomUnit().getId(), TradeClosedComposer.ITEMS_NOT_FOUND));
-                    return false;
-                }
-            }
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
-            this.sendMessageToUsers(new TradeClosedComposer(userOne.getHabbo().getRoomUnit().getId(), TradeClosedComposer.ITEMS_NOT_FOUND));
-            return false;
-        }
-
-        for (HabboItem item : userOne.getItems()) {
-            item.setUserId(userTwo.getHabbo().getHabboInfo().getId());
-        }
-
-        for (HabboItem item : userTwo.getItems()) {
-            item.setUserId(userOne.getHabbo().getHabboInfo().getId());
-        }
-
         Set<HabboItem> itemsUserOne = new HashSet<>(userOne.getItems());
         Set<HabboItem> itemsUserTwo = new HashSet<>(userTwo.getItems());
-
-        userOne.clearItems();
-        userTwo.clearItems();
 
         int creditsForUserTwo = 0;
         Set<HabboItem> creditFurniUserOne = new HashSet<>();
@@ -274,7 +191,6 @@ public class RoomTrade {
             if (worth > 0) {
                 creditsForUserTwo += worth;
                 creditFurniUserOne.add(item);
-                new QueryDeleteHabboItem(item).run();
             }
         }
         itemsUserOne.removeAll(creditFurniUserOne);
@@ -286,13 +202,33 @@ public class RoomTrade {
             if (worth > 0) {
                 creditsForUserOne += worth;
                 creditFurniUserTwo.add(item);
-                new QueryDeleteHabboItem(item).run();
             }
         }
         itemsUserTwo.removeAll(creditFurniUserTwo);
 
-        userOne.getHabbo().giveCredits(creditsForUserOne);
-        userTwo.getHabbo().giveCredits(creditsForUserTwo);
+        creditsForUserOne = resolveCredits(userOne.getHabbo(), creditsForUserOne);
+        creditsForUserTwo = resolveCredits(userTwo.getHabbo(), creditsForUserTwo);
+
+        try {
+            if (!RoomTradeTransaction.execute(userOne.getHabbo(), userTwo.getHabbo(),
+                    userOne.getItems(), userTwo.getItems(), creditsForUserOne, creditsForUserTwo,
+                    Emulator.getConfig().getBoolean("hotel.log.trades"))) {
+                return false;
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+            this.sendMessageToUsers(new TradeClosedComposer(userOne.getHabbo().getRoomUnit().getId(), TradeClosedComposer.ITEMS_NOT_FOUND));
+            return false;
+        }
+
+        for (HabboItem item : itemsUserOne) item.setUserId(userTwo.getHabbo().getHabboInfo().getId());
+        for (HabboItem item : itemsUserTwo) item.setUserId(userOne.getHabbo().getHabboInfo().getId());
+
+        userOne.clearItems();
+        userTwo.clearItems();
+
+        applyCommittedCredits(userOne.getHabbo(), creditsForUserOne);
+        applyCommittedCredits(userTwo.getHabbo(), creditsForUserTwo);
 
         userOne.getHabbo().getInventory().getItemsComponent().addItems(itemsUserTwo);
         userTwo.getHabbo().getInventory().getItemsComponent().addItems(itemsUserOne);
@@ -303,6 +239,18 @@ public class RoomTrade {
         userOne.getHabbo().getClient().sendResponse(new InventoryRefreshComposer());
         userTwo.getHabbo().getClient().sendResponse(new InventoryRefreshComposer());
         return true;
+    }
+
+    private static int resolveCredits(Habbo habbo, int credits) {
+        if (credits <= 0) return 0;
+        UserCreditsEvent event = new UserCreditsEvent(habbo, credits);
+        return Emulator.getPluginManager().fireEvent(event).isCancelled() ? 0 : Math.max(0, event.credits);
+    }
+
+    private static void applyCommittedCredits(Habbo habbo, int credits) {
+        if (credits <= 0) return;
+        habbo.getHabboInfo().addCredits(credits);
+        if (habbo.getClient() != null) habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
     }
 
     protected void clearAccepted() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java
@@ -1,0 +1,110 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboItem;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+
+final class RoomTradeTransaction {
+    private static final String TRANSFER_ITEM = "UPDATE items SET user_id = ? WHERE id = ? AND user_id = ? LIMIT 1";
+    private static final String REDEEM_ITEM = "DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1";
+    private static final String CREDIT_USER = "UPDATE users SET credits = credits + ? WHERE id = ?";
+
+    private RoomTradeTransaction() {
+    }
+
+    static boolean execute(Habbo userOne, Habbo userTwo,
+                           Collection<HabboItem> userOneItems, Collection<HabboItem> userTwoItems,
+                           int creditsForUserOne, int creditsForUserTwo, boolean logTrades) throws SQLException {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                int tradeId = logTrades
+                        ? insertTradeLog(connection, userOne, userTwo, userOneItems.size(), userTwoItems.size())
+                        : 0;
+
+                persistItems(connection, tradeId, userOne.getHabboInfo().getId(), userTwo.getHabboInfo().getId(),
+                        userOneItems, logTrades);
+                persistItems(connection, tradeId, userTwo.getHabboInfo().getId(), userOne.getHabboInfo().getId(),
+                        userTwoItems, logTrades);
+                creditUser(connection, userOne.getHabboInfo().getId(), creditsForUserOne);
+                creditUser(connection, userTwo.getHabboInfo().getId(), creditsForUserTwo);
+
+                connection.commit();
+                return true;
+            } catch (SQLException | RuntimeException exception) {
+                connection.rollback();
+                throw exception;
+            }
+        }
+    }
+
+    private static int insertTradeLog(Connection connection, Habbo userOne, Habbo userTwo,
+                                      int userOneItemCount, int userTwoItemCount) throws SQLException {
+        String sql = "INSERT INTO room_trade_log (user_one_id, user_two_id, user_one_ip, user_two_ip, timestamp, user_one_item_count, user_two_item_count) VALUES (?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setInt(1, userOne.getHabboInfo().getId());
+            statement.setInt(2, userTwo.getHabboInfo().getId());
+            statement.setString(3, userOne.getHabboInfo().getIpLogin());
+            statement.setString(4, userTwo.getHabboInfo().getIpLogin());
+            statement.setInt(5, Emulator.getIntUnixTimestamp());
+            statement.setInt(6, userOneItemCount);
+            statement.setInt(7, userTwoItemCount);
+            statement.executeUpdate();
+            try (ResultSet keys = statement.getGeneratedKeys()) {
+                if (keys.next()) return keys.getInt(1);
+            }
+        }
+        throw new SQLException("Unable to create trade log");
+    }
+
+    private static void persistItems(Connection connection, int tradeId, int sourceUserId, int targetUserId,
+                                     Collection<HabboItem> items, boolean logTrades) throws SQLException {
+        for (HabboItem item : items) {
+            if (logTrades) insertTradeItemLog(connection, tradeId, item.getId(), sourceUserId);
+
+            int redeemCredits = RoomTrade.getCreditsByItem(item);
+            String sql = redeemCredits > 0 ? REDEEM_ITEM : TRANSFER_ITEM;
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                if (redeemCredits > 0) {
+                    statement.setInt(1, item.getId());
+                    statement.setInt(2, sourceUserId);
+                } else {
+                    statement.setInt(1, targetUserId);
+                    statement.setInt(2, item.getId());
+                    statement.setInt(3, sourceUserId);
+                }
+                if (statement.executeUpdate() != 1) {
+                    throw new SQLException("Trade item ownership changed before commit: " + item.getId());
+                }
+            }
+
+        }
+    }
+
+    private static void insertTradeItemLog(Connection connection, int tradeId, int itemId, int sourceUserId)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO room_trade_log_items (id, item_id, user_id) VALUES (?, ?, ?)")) {
+            statement.setInt(1, tradeId);
+            statement.setInt(2, itemId);
+            statement.setInt(3, sourceUserId);
+            statement.executeUpdate();
+        }
+    }
+
+    private static void creditUser(Connection connection, int userId, int credits) throws SQLException {
+        if (credits <= 0) return;
+        try (PreparedStatement statement = connection.prepareStatement(CREDIT_USER)) {
+            statement.setInt(1, credits);
+            statement.setInt(2, userId);
+            if (statement.executeUpdate() != 1) throw new SQLException("Unable to credit trade recipient " + userId);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/AtomicRoomTradeContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/AtomicRoomTradeContractTest.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AtomicRoomTradeContractTest {
+    @Test
+    void tradePersistenceUsesOneTransaction() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java"));
+
+        int begin = source.indexOf("connection.setAutoCommit(false)");
+        int persist = source.indexOf("persistItems(connection", begin);
+        int credit = source.indexOf("creditUser(connection", persist);
+        int commit = source.indexOf("connection.commit()");
+        int rollback = source.indexOf("connection.rollback()");
+
+        assertTrue(begin > -1, "trade persistence must disable autocommit");
+        assertTrue(source.contains("UPDATE items SET user_id = ? WHERE id = ? AND user_id = ? LIMIT 1"));
+        assertTrue(source.contains("DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1"));
+        assertTrue(source.contains("UPDATE users SET credits = credits + ? WHERE id = ?"));
+        assertTrue(persist > begin, "furni must be persisted inside the transaction");
+        assertTrue(credit > persist, "trade credits must be granted after item persistence");
+        assertTrue(commit > credit, "the transaction must commit only after every economy mutation");
+        assertTrue(rollback > begin, "failed trades must roll back");
+    }
+
+    @Test
+    void roomTradeDoesNotPersistRedeemsOrCreditsAfterTransaction() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java"));
+
+        assertTrue(source.contains("RoomTradeTransaction.execute("));
+        assertFalse(source.contains("new QueryDeleteHabboItem(item).run()"));
+        assertFalse(source.contains("giveCredits(creditsForUserOne)"));
+        assertFalse(source.contains("giveCredits(creditsForUserTwo)"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomTradeSafetyContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomTradeSafetyContractTest.java
@@ -13,42 +13,49 @@ class RoomTradeSafetyContractTest {
         return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java"));
     }
 
+    private static String transactionSource() throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java"));
+    }
+
     @Test
     void sqlFailureStopsBeforeInventoryTransfer() throws Exception {
         String source = roomTradeSource();
-        int catchIndex = source.indexOf("catch (SQLException e)");
+        int transaction = source.indexOf("RoomTradeTransaction.execute(");
+        int catchIndex = source.indexOf("catch (SQLException e)", transaction);
         int inventoryTransferIndex = source.indexOf("Set<HabboItem> itemsUserOne");
 
+        assertTrue(transaction > -1, "RoomTrade must delegate persistence to its transaction boundary");
         assertTrue(catchIndex > -1, "RoomTrade must handle SQL failures explicitly");
-        assertTrue(inventoryTransferIndex > catchIndex, "Inventory transfer should happen after SQL ownership updates");
-        assertTrue(source.substring(catchIndex, inventoryTransferIndex).contains("return false"),
+        assertTrue(inventoryTransferIndex < transaction, "Inventory snapshots may be prepared before persistence");
+        int firstInventoryMutation = source.indexOf("userOne.clearItems()", transaction);
+        assertTrue(firstInventoryMutation > catchIndex, "Inventory mutation should happen after SQL ownership updates");
+        assertTrue(source.substring(catchIndex, firstInventoryMutation).contains("return false"),
                 "SQL failures must abort the trade before in-memory inventory/credit transfer");
     }
 
     @Test
     void itemOwnersChangeOnlyAfterDatabaseBatchSucceeds() throws Exception {
         String source = roomTradeSource();
+        String transaction = transactionSource();
         int firstOwnerMutation = source.indexOf("item.setUserId(");
-        int batchExecution = source.indexOf("int[] updateCounts = statement.executeBatch();");
-        int batchGuard = source.indexOf("allOwnershipUpdatesSucceeded(updateCounts, expectedUpdates)", batchExecution);
+        int transactionExecution = source.indexOf("RoomTradeTransaction.execute(");
+        int commit = transaction.indexOf("connection.commit()");
 
         assertTrue(firstOwnerMutation > -1, "RoomTrade should update in-memory item owners after commit");
-        assertTrue(batchExecution > -1, "RoomTrade should persist item owner changes with a batch update");
-        assertTrue(batchGuard > batchExecution, "RoomTrade must validate every ownership update before mutating memory");
-        assertTrue(firstOwnerMutation > batchGuard,
-                "In-memory item owners must not change until the database batch has succeeded");
+        assertTrue(transactionExecution > -1, "RoomTrade should persist changes through RoomTradeTransaction");
+        assertTrue(commit > -1, "RoomTradeTransaction must commit its database mutations");
+        assertTrue(firstOwnerMutation > transactionExecution,
+                "In-memory item owners must not change until the transaction has succeeded");
     }
 
     @Test
     void ownershipUpdatesRequireExpectedDatabaseOwner() throws Exception {
-        String source = roomTradeSource();
+        String source = transactionSource();
 
         assertTrue(source.contains("UPDATE items SET user_id = ? WHERE id = ? AND user_id = ? LIMIT 1"),
                 "RoomTrade ownership transfer should only update items still owned by the offering user");
-        assertTrue(source.contains("statement.setInt(3, userOneId)"),
-                "User one offered items must require user one as the current database owner");
-        assertTrue(source.contains("statement.setInt(3, userTwoId)"),
-                "User two offered items must require user two as the current database owner");
+        assertTrue(source.contains("statement.setInt(3, sourceUserId)"),
+                "Every offered item must require its source user as current database owner");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- persist trade logs, furni transfers, credit-furni consumption and credit grants in one transaction
- roll back the entire trade when ownership or any economy mutation fails
- update in-memory ownership, balances and inventories only after commit
- preserve UserCreditsEvent plugin behavior before persistence

## Verification
- mvn clean package
- 447 tests, 0 failures, 0 errors