### PR TITLE
Complete catalog furniture purchases atomically

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
@@ -33,25 +33,46 @@ public class CatalogLimitedConfiguration implements Runnable {
 
     public int getNumber() {
         synchronized (this.limitedNumbers) {
-            int num = this.limitedNumbers.pop();
-            if (this.limitedNumbers.isEmpty()) {
-                Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId), Emulator.getConfig().getInt("catalog.ltd.page.soldout"));
-            }
-            return num;
+            return this.limitedNumbers.pop();
         }
     }
 
     public void limitedSold(int catalogItemId, Habbo habbo, HabboItem item) {
         synchronized (this.limitedNumbers) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE catalog_items_limited SET user_id = ?, timestamp = ?, item_id = ? WHERE catalog_item_id = ? AND number = ? AND user_id = 0 LIMIT 1")) {
-                statement.setInt(1, habbo.getHabboInfo().getId());
-                statement.setInt(2, Emulator.getIntUnixTimestamp());
-                statement.setInt(3, item.getId());
-                statement.setInt(4, catalogItemId);
-                statement.setInt(5, item.getLimitedSells());
-                statement.execute();
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+                this.limitedSold(connection, catalogItemId, habbo, item);
+                this.markSoldOutIfEmpty();
             } catch (SQLException e) {
                 LOGGER.error("Caught SQL exception", e);
+            }
+        }
+    }
+
+    public void limitedSold(Connection connection, int catalogItemId, Habbo habbo, HabboItem item) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("UPDATE catalog_items_limited SET user_id = ?, timestamp = ?, item_id = ? WHERE catalog_item_id = ? AND number = ? AND user_id = 0 LIMIT 1")) {
+            statement.setInt(1, habbo.getHabboInfo().getId());
+            statement.setInt(2, Emulator.getIntUnixTimestamp());
+            statement.setInt(3, item.getId());
+            statement.setInt(4, catalogItemId);
+            statement.setInt(5, item.getLimitedSells());
+            if (statement.executeUpdate() != 1) {
+                throw new SQLException("Limited catalog number is no longer available: " + item.getLimitedSells());
+            }
+        }
+    }
+
+    public void restoreNumber(int number) {
+        synchronized (this.limitedNumbers) {
+            if (!this.limitedNumbers.contains(number)) this.limitedNumbers.push(number);
+        }
+    }
+
+    public void markSoldOutIfEmpty() {
+        synchronized (this.limitedNumbers) {
+            if (this.limitedNumbers.isEmpty()) {
+                Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(
+                        Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId),
+                        Emulator.getConfig().getInt("catalog.ltd.page.soldout"));
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -26,7 +26,11 @@ import com.eu.habbo.messages.outgoing.inventory.AddPetComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.modtool.ModToolIssueHandledComposer;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
+import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
+import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
 import com.eu.habbo.plugin.events.emulator.EmulatorLoadCatalogManagerEvent;
+import com.eu.habbo.plugin.events.users.UserCreditsEvent;
+import com.eu.habbo.plugin.events.users.UserPointsEvent;
 import com.eu.habbo.plugin.events.users.catalog.UserCatalogFurnitureBoughtEvent;
 import com.eu.habbo.plugin.events.users.catalog.UserCatalogItemPurchasedEvent;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
@@ -1091,7 +1095,6 @@ public class CatalogManager {
                         limitedConfiguration = this.createOrUpdateLimitedConfig(item);
                     }
 
-                    limitedNumber = limitedConfiguration.getNumber();
                     limitedStack = limitedConfiguration.getTotalSet();
                 }
 
@@ -1101,6 +1104,14 @@ public class CatalogManager {
                 if (totalCredits > 0 && habbo.getHabboInfo().getCredits() - totalCredits < 0) return;
                 if (totalPoints > 0 && habbo.getHabboInfo().getCurrencyAmount(item.getPointsType()) - totalPoints < 0)
                     return;
+
+                if (limitedConfiguration != null) limitedNumber = limitedConfiguration.getNumber();
+
+                if (this.isAtomicFurniturePurchase(item)) {
+                    this.purchaseFurnitureAtomically(item, habbo, amount, extradata, free, limitedConfiguration,
+                            limitedStack, limitedNumber, totalCredits, totalPoints);
+                    return;
+                }
 
                 List<String> badges = new ArrayList<>();
                 Map<AddHabboItemComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();
@@ -1368,6 +1379,176 @@ public class CatalogManager {
         } finally {
             habbo.getHabboStats().isPurchasingFurniture = false;
         }
+    }
+
+    private boolean isAtomicFurniturePurchase(CatalogItem item) {
+        if (item == null || item.getBaseItems().isEmpty()) return false;
+        for (Item baseItem : item.getBaseItems()) {
+            if (baseItem == null || Item.isBot(baseItem) || Item.isPet(baseItem)
+                    || baseItem.getType() == FurnitureType.BADGE || baseItem.getType() == FurnitureType.EFFECT
+                    || baseItem.getInteractionType().getType() == InteractionGuildFurni.class
+                    || baseItem.getInteractionType().getType() == InteractionGuildGate.class
+                    || baseItem.getInteractionType().getType() == InteractionMusicDisc.class) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void purchaseFurnitureAtomically(CatalogItem item, Habbo habbo, int amount, String extraData,
+                                             boolean free, CatalogLimitedConfiguration limitedConfiguration,
+                                             int limitedStack, int limitedNumber, int totalCredits, int totalPoints)
+            throws SQLException {
+        int userId = habbo.getHabboInfo().getId();
+        try {
+            AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(userId, connection -> {
+                Set<HabboItem> createdItems = new HashSet<>();
+                for (int index = 0; index < amount; index++) {
+                    for (Item baseItem : item.getBaseItems()) {
+                        String itemExtraData = this.prepareFurnitureExtraData(habbo, baseItem, extraData);
+                        for (int count = 0; count < item.getItemAmount(baseItem.getId()); count++) {
+                            if (InteractionTeleport.class.isAssignableFrom(baseItem.getInteractionType().getType())) {
+                                HabboItem first = Emulator.getGameEnvironment().getItemManager().createItem(
+                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                HabboItem second = Emulator.getGameEnvironment().getItemManager().createItem(
+                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                if (first == null || second == null) throw new SQLException("Unable to create teleport pair");
+                                Emulator.getGameEnvironment().getItemManager().insertTeleportPair(
+                                        connection, first.getId(), second.getId());
+                                createdItems.add(first);
+                                createdItems.add(second);
+                            } else {
+                                HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
+                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                if (created == null) throw new SQLException("Unable to create catalog furniture");
+                                if (baseItem.getInteractionType().getType() == InteractionHopper.class) {
+                                    Emulator.getGameEnvironment().getItemManager().insertHopper(connection, created);
+                                }
+                                createdItems.add(created);
+                            }
+                        }
+                    }
+                }
+
+                Set<Integer> createdIds = createdItems.stream().map(HabboItem::getId).collect(Collectors.toSet());
+                UserCatalogItemPurchasedEvent purchasedEvent = new UserCatalogItemPurchasedEvent(
+                        habbo, item, createdItems, totalCredits, totalPoints, new ArrayList<>());
+                Emulator.getPluginManager().fireEvent(purchasedEvent);
+                Set<Integer> eventIds = purchasedEvent.itemsList.stream().map(HabboItem::getId).collect(Collectors.toSet());
+                if (!createdIds.equals(eventIds)) {
+                    throw new SQLException("Catalog plugin changed the atomic furniture set");
+                }
+
+                ResolvedCatalogCharges charges = this.resolveCatalogCharges(habbo, item, free, purchasedEvent);
+                if (limitedConfiguration != null) {
+                    HabboItem limitedItem = createdItems.stream().findFirst()
+                            .orElseThrow(() -> new SQLException("Limited purchase created no furniture"));
+                    limitedConfiguration.limitedSold(connection, item.getId(), habbo, limitedItem);
+                }
+                if (!free) {
+                    this.writePurchaseLog(connection, purchasedEvent, charges, amount);
+                }
+                AtomicFurniturePurchase result = new AtomicFurniturePurchase(
+                        purchasedEvent, charges.credits(), charges.points(), charges.pointsType());
+                return new CatalogPurchaseTransaction.PreparedPurchase<>(
+                        result, charges.credits(), charges.points(), charges.pointsType());
+            });
+
+            this.publishAtomicFurniturePurchase(habbo, purchase);
+            if (limitedConfiguration != null) {
+                habbo.getHabboStats().addLtdLog(item.getId(), Emulator.getIntUnixTimestamp());
+                limitedConfiguration.markSoldOutIfEmpty();
+            }
+        } catch (SQLException exception) {
+            if (limitedConfiguration != null && limitedNumber > 0) limitedConfiguration.restoreNumber(limitedNumber);
+            throw exception;
+        }
+    }
+
+    private String prepareFurnitureExtraData(Habbo habbo, Item baseItem, String extraData) {
+        if (baseItem.getInteractionType().getType() != InteractionTrophy.class
+                && baseItem.getInteractionType().getType() != InteractionBadgeDisplay.class) return extraData;
+
+        String value = extraData;
+        if (baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class
+                && !habbo.getInventory().getBadgesComponent().hasBadge(value)) {
+            ScripterManager.scripterDetected(habbo.getClient(),
+                    Emulator.getTexts().getValue("scripter.warning.catalog.badge_display")
+                            .replace("%username%", habbo.getHabboInfo().getUsername())
+                            .replace("%badge%", value));
+            value = "UMAD";
+        }
+        int maximum = Emulator.getConfig().getInt("hotel.trophies.length.max", 300);
+        if (value.length() > maximum) value = value.substring(0, maximum);
+        return habbo.getHabboInfo().getUsername() + (char) 9
+                + Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "-"
+                + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-"
+                + Calendar.getInstance().get(Calendar.YEAR) + (char) 9
+                + Emulator.getGameEnvironment().getWordFilter().filter(value.replace(((char) 9) + "", ""), habbo);
+    }
+
+    private ResolvedCatalogCharges resolveCatalogCharges(Habbo habbo, CatalogItem item, boolean free,
+                                                         UserCatalogItemPurchasedEvent purchasedEvent) {
+        int credits = 0;
+        int points = 0;
+        int pointsType = item.getPointsType();
+        if (!free && !habbo.hasPermission(Permission.ACC_INFINITE_CREDITS) && purchasedEvent.totalCredits > 0) {
+            UserCreditsEvent event = new UserCreditsEvent(habbo, -purchasedEvent.totalCredits);
+            if (!Emulator.getPluginManager().fireEvent(event).isCancelled()) credits = Math.max(0, -event.credits);
+        }
+        if (!free && !habbo.hasPermission(Permission.ACC_INFINITE_POINTS) && purchasedEvent.totalPoints > 0) {
+            UserPointsEvent event = new UserPointsEvent(habbo, -purchasedEvent.totalPoints, pointsType);
+            if (!Emulator.getPluginManager().fireEvent(event).isCancelled()) {
+                points = Math.max(0, -event.points);
+                pointsType = event.type;
+            }
+        }
+        return new ResolvedCatalogCharges(credits, points, pointsType);
+    }
+
+    private void writePurchaseLog(Connection connection, UserCatalogItemPurchasedEvent event,
+                                  ResolvedCatalogCharges charges, int amount) throws SQLException {
+        Set<String> itemIds = event.itemsList.stream().map(item -> Integer.toString(item.getId())).collect(Collectors.toSet());
+        CatalogPurchaseLogEntry entry = new CatalogPurchaseLogEntry(
+                Emulator.getIntUnixTimestamp(), event.habbo.getHabboInfo().getId(), event.catalogItem.getId(),
+                String.join(";", itemIds), event.catalogItem.getName(), charges.credits(), charges.points(),
+                charges.pointsType(), amount);
+        try (PreparedStatement statement = connection.prepareStatement(entry.getQuery())) {
+            entry.log(statement);
+            statement.executeBatch();
+        }
+    }
+
+    private void publishAtomicFurniturePurchase(Habbo habbo, AtomicFurniturePurchase purchase) {
+        if (purchase.credits() > 0) {
+            habbo.getHabboInfo().addCredits(-purchase.credits());
+            habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
+        }
+        if (purchase.points() > 0) {
+            habbo.getHabboInfo().addCurrencyAmount(purchase.pointsType(), -purchase.points());
+            habbo.getClient().sendResponse(new UserPointsComposer(
+                    habbo.getHabboInfo().getCurrencyAmount(purchase.pointsType()),
+                    -purchase.points(), purchase.pointsType()));
+        }
+
+        Set<HabboItem> items = purchase.event().itemsList;
+        habbo.getInventory().getItemsComponent().addItems(items);
+        Map<AddHabboItemComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();
+        unseenItems.put(AddHabboItemComposer.AddHabboItemCategory.OWNED_FURNI,
+                items.stream().map(HabboItem::getId).collect(Collectors.toList()));
+        Emulator.getPluginManager().fireEvent(new UserCatalogFurnitureBoughtEvent(
+                habbo, purchase.event().catalogItem, items));
+        habbo.getHabboStats().addPurchase(purchase.event().catalogItem);
+        habbo.getClient().sendResponse(new AddHabboItemComposer(unseenItems));
+        habbo.getClient().sendResponse(new PurchaseOKComposer(purchase.event().catalogItem));
+        habbo.getClient().sendResponse(new InventoryRefreshComposer());
+    }
+
+    private record ResolvedCatalogCharges(int credits, int points, int pointsType) {
+    }
+
+    private record AtomicFurniturePurchase(UserCatalogItemPurchasedEvent event, int credits, int points,
+                                           int pointsType) {
     }
 
     public List<ClubOffer> getClubOffers() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java
@@ -1,0 +1,70 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import com.eu.habbo.Emulator;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+final class CatalogPurchaseTransaction {
+    private static final String CHARGE_CREDITS =
+            "UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?";
+    private static final String CHARGE_POINTS =
+            "UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?";
+
+    private CatalogPurchaseTransaction() {
+    }
+
+    static <T> T execute(int userId, PurchaseWork<T> work) throws SQLException {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                PreparedPurchase<T> purchase = work.persist(connection);
+                chargeCredits(connection, userId, purchase.credits());
+                chargePoints(connection, userId, purchase.pointsType(), purchase.points());
+                connection.commit();
+                return purchase.value();
+            } catch (Exception exception) {
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackException) {
+                    exception.addSuppressed(rollbackException);
+                }
+                if (exception instanceof SQLException sqlException) throw sqlException;
+                throw new SQLException("Unable to persist catalog purchase", exception);
+            }
+        }
+    }
+
+    private static void chargeCredits(Connection connection, int userId, int credits) throws SQLException {
+        if (credits == 0) return;
+        try (PreparedStatement statement = connection.prepareStatement(CHARGE_CREDITS)) {
+            statement.setInt(1, credits);
+            statement.setInt(2, userId);
+            statement.setInt(3, credits);
+            if (statement.executeUpdate() != 1) throw new SQLException("Insufficient credits for catalog purchase");
+        }
+    }
+
+    private static void chargePoints(Connection connection, int userId, int pointsType, int points) throws SQLException {
+        if (points == 0) return;
+        try (PreparedStatement statement = connection.prepareStatement(CHARGE_POINTS)) {
+            statement.setInt(1, points);
+            statement.setInt(2, userId);
+            statement.setInt(3, pointsType);
+            statement.setInt(4, points);
+            if (statement.executeUpdate() != 1) throw new SQLException("Insufficient points for catalog purchase");
+        }
+    }
+
+    @FunctionalInterface
+    interface PurchaseWork<T> {
+        PreparedPurchase<T> persist(Connection connection) throws Exception;
+    }
+
+    record PreparedPurchase<T>(T value, int credits, int points, int pointsType) {
+        PreparedPurchase {
+            if (credits < 0 || points < 0) throw new IllegalArgumentException("Catalog charges cannot be negative");
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -827,9 +827,22 @@ public class ItemManager {
             return null;
         }
 
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            return this.createItem(connection, habboId, item, limitedStack, limitedSells, extraData);
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+        return null;
+    }
+
+    public HabboItem createItem(Connection connection, int habboId, Item item, int limitedStack, int limitedSells, String extraData) throws SQLException {
+        if (habboId <= 0 || item == null) {
+            return null;
+        }
+
         extraData = ItemDataGuard.normalizeExtraData(extraData);
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items (user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO items (user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, habboId);
             statement.setInt(2, item.getId());
             statement.setString(3, extraData);
@@ -850,10 +863,6 @@ public class ItemManager {
                     }
                 }
             }
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
-        } catch (Exception e) {
-            LOGGER.error("Caught exception", e);
         }
         return null;
     }
@@ -975,22 +984,34 @@ public class ItemManager {
     }
 
     public void insertTeleportPair(int itemOneId, int itemTwoId) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items_teleports (teleport_one_id, teleport_two_id) VALUES (?, ?)")) {
-            statement.setInt(1, itemOneId);
-            statement.setInt(2, itemTwoId);
-            statement.execute();
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.insertTeleportPair(connection, itemOneId, itemTwoId);
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }
     }
 
+    public void insertTeleportPair(Connection connection, int itemOneId, int itemTwoId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO items_teleports (teleport_one_id, teleport_two_id) VALUES (?, ?)")) {
+            statement.setInt(1, itemOneId);
+            statement.setInt(2, itemTwoId);
+            statement.execute();
+        }
+    }
+
     public void insertHopper(HabboItem hopper) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items_hoppers VALUES (?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.insertHopper(connection, hopper);
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    public void insertHopper(Connection connection, HabboItem hopper) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO items_hoppers VALUES (?, ?)")) {
             statement.setInt(1, hopper.getId());
             statement.setInt(2, hopper.getBaseItem().getId());
             statement.execute();
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
         }
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
@@ -1,0 +1,31 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AtomicCatalogPurchaseContractTest {
+    @Test
+    void coordinatorCommitsAssetsAndConditionalChargesTogether() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java"));
+
+        int begin = source.indexOf("connection.setAutoCommit(false)");
+        int persist = source.indexOf("work.persist(connection)", begin);
+        int credit = source.indexOf("chargeCredits(connection", persist);
+        int points = source.indexOf("chargePoints(connection", credit);
+        int commit = source.indexOf("connection.commit()", points);
+
+        assertTrue(begin > -1);
+        assertTrue(persist > begin);
+        assertTrue(credit > persist);
+        assertTrue(points > credit);
+        assertTrue(commit > points);
+        assertTrue(source.contains("UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?"));
+        assertTrue(source.contains("UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?"));
+        assertTrue(source.contains("connection.rollback()"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
@@ -28,4 +28,30 @@ class AtomicCatalogPurchaseContractTest {
         assertTrue(source.contains("UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?"));
         assertTrue(source.contains("connection.rollback()"));
     }
+
+    @Test
+    void catalogPublishesFurnitureOnlyAfterAtomicPurchaseReturns() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+
+        int method = source.indexOf("purchaseFurnitureAtomically(");
+        int transaction = source.indexOf("CatalogPurchaseTransaction.execute(", method);
+        int inventory = source.indexOf("getItemsComponent().addItems(", transaction);
+        int success = source.indexOf("new PurchaseOKComposer(", transaction);
+
+        assertTrue(method > -1);
+        assertTrue(transaction > method);
+        assertTrue(inventory > transaction);
+        assertTrue(success > transaction);
+    }
+
+    @Test
+    void limitedFurnitureReservationUsesThePurchaseConnection() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java"));
+
+        assertTrue(source.contains("limitedSold(Connection connection, int catalogItemId"));
+        assertTrue(source.contains("AND number = ? AND user_id = 0 LIMIT 1"));
+        assertTrue(source.contains("executeUpdate() != 1"));
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogAssetTransactionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogAssetTransactionContractTest.java
@@ -1,0 +1,41 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogAssetTransactionContractTest {
+    private static String itemManagerSource() throws Exception {
+        return Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java"));
+    }
+
+    private static String method(String source, String signature) {
+        int start = source.indexOf(signature);
+        int end = source.indexOf("\n    public ", start + signature.length());
+        return source.substring(start, end);
+    }
+
+    @Test
+    void furnitureFactoriesCanShareTheCatalogTransactionConnection() throws Exception {
+        String source = itemManagerSource();
+
+        assertTrue(source.contains("createItem(Connection connection, int habboId"));
+        assertTrue(source.contains("insertTeleportPair(Connection connection, int itemOneId, int itemTwoId)"));
+        assertTrue(source.contains("insertHopper(Connection connection, HabboItem hopper)"));
+    }
+
+    @Test
+    void connectionAwareFactoriesDoNotOpenAnotherConnection() throws Exception {
+        String source = itemManagerSource();
+        assertTrue(!method(source, "createItem(Connection connection, int habboId")
+                .contains("getDataSource().getConnection()"));
+        assertTrue(!method(source, "insertTeleportPair(Connection connection")
+                .contains("getDataSource().getConnection()"));
+        assertTrue(!method(source, "insertHopper(Connection connection")
+                .contains("getDataSource().getConnection()"));
+    }
+}


### PR DESCRIPTION
## Summary
- persist ordinary and LTD furniture, teleport pairs, hopper relations, charges and purchase logs in one database transaction
- conditionally charge credits and points to prevent concurrent overspending
- restore LTD availability on rollback and publish sold-out state only after commit
- update balances and inventory only after persistence succeeds while preserving currency plugin events

## Scope
Bot, pet, badge, effect, guild/music furniture, gifts, room bundles and subscriptions remain on their existing paths for dedicated follow-up PRs.

## Verification
- mvn clean package
- 450 tests, 0 failures, 0 errors