### PR TITLE
Allow special catalog assets to share transactions

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/BotManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/BotManager.java
@@ -81,8 +81,19 @@ public class BotManager {
             return null;
         }
 
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            return this.createBot(connection, data, type, ownerId);
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+            return null;
+        }
+    }
+
+    public Bot createBot(Connection connection, Map<String, String> data, String type, int ownerId) throws SQLException {
+        if (ownerId <= 0) return null;
+
         Bot bot = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO bots (user_id, room_id, name, motto, figure, gender, type) VALUES (?, 0, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO bots (user_id, room_id, name, motto, figure, gender, type) VALUES (?, 0, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, ownerId);
             statement.setString(2, data.get("name"));
             statement.setString(3, data.get("motto"));
@@ -99,13 +110,9 @@ public class BotManager {
                                 bot = this.loadBot(resultSet);
                             }
                         }
-                    } catch (SQLException e) {
-                        LOGGER.error("Caught SQL exception", e);
                     }
                 }
             }
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
         }
 
         return bot;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java
@@ -633,13 +633,19 @@ public class GuildManager {
 
 
     public void setGuild(InteractionGuildFurni furni, int guildId) {
-        furni.setGuildId(guildId);
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE items SET guild_id = ? WHERE id = ?")) {
-            statement.setInt(1, guildId);
-            statement.setInt(2, furni.getId());
-            statement.execute();
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.persistGuild(connection, furni.getId(), guildId);
+            furni.setGuildId(guildId);
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    public void persistGuild(Connection connection, int furniId, int guildId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("UPDATE items SET guild_id = ? WHERE id = ?")) {
+            statement.setInt(1, guildId);
+            statement.setInt(2, furniId);
+            if (statement.executeUpdate() != 1) throw new SQLException("Unable to assign guild furniture " + furniId);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/Pet.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/Pet.java
@@ -192,53 +192,52 @@ public class Pet implements ISerialize, Runnable {
 
     @Override
     public void run() {
-        if (this.needsUpdate) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-                if (this.id > 0) {
-                    try (PreparedStatement statement = connection.prepareStatement("UPDATE users_pets SET room_id = ?, experience = ?, energy = ?, respect = ?, x = ?, y = ?, z = ?, rot = ?, hunger = ?, thirst = ?, happiness = ?, created = ? WHERE id = ?")) {
-                        statement.setInt(1, (this.room == null ? 0 : this.room.getId()));
-                        statement.setInt(2, this.experience);
-                        statement.setInt(3, this.energy);
-                        statement.setInt(4, this.respect);
-                        statement.setInt(5, this.roomUnit != null ? this.roomUnit.getX() : 0);
-                        statement.setInt(6, this.roomUnit != null ? this.roomUnit.getY() : 0);
-                        statement.setDouble(7, this.roomUnit != null ? this.roomUnit.getZ() : 0.0);
-                        statement.setInt(8, this.roomUnit != null ? this.roomUnit.getBodyRotation().getValue() : 0);
-                        statement.setInt(9, this.levelHunger);
-                        statement.setInt(10, this.levelThirst);
-                        statement.setInt(11, this.happiness);
-                        statement.setInt(12, this.created);
-                        statement.setInt(13, this.id);
-                        statement.execute();
-                    }
-                } else if (this.id == 0) {
-                    try (PreparedStatement statement = connection.prepareStatement("INSERT INTO users_pets (user_id, room_id, name, race, type, color, experience, energy, respect, created) VALUES (?, 0, ?, ?, ?, ?, 0, 0, 0, ?)", Statement.RETURN_GENERATED_KEYS)) {
-                        statement.setInt(1, this.userId);
-                        statement.setString(2, this.name);
-                        statement.setInt(3, this.race);
-                        statement.setInt(4, 0);
+        if (!this.needsUpdate) return;
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.save(connection);
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
 
-                        if (this.petData != null) {
-                            statement.setInt(4, this.petData.getType());
-                        }
-
-                        statement.setString(5, this.color);
-                        statement.setInt(6, this.created);
-                        statement.execute();
-
-                        try (ResultSet set = statement.getGeneratedKeys()) {
-                            if (set.next()) {
-                                this.id = set.getInt(1);
-                            }
-                        }
-                    }
+    public void save(Connection connection) throws SQLException {
+        if (!this.needsUpdate) return;
+        if (this.id > 0) {
+            try (PreparedStatement statement = connection.prepareStatement("UPDATE users_pets SET room_id = ?, experience = ?, energy = ?, respect = ?, x = ?, y = ?, z = ?, rot = ?, hunger = ?, thirst = ?, happiness = ?, created = ? WHERE id = ?")) {
+                statement.setInt(1, (this.room == null ? 0 : this.room.getId()));
+                statement.setInt(2, this.experience);
+                statement.setInt(3, this.energy);
+                statement.setInt(4, this.respect);
+                statement.setInt(5, this.roomUnit != null ? this.roomUnit.getX() : 0);
+                statement.setInt(6, this.roomUnit != null ? this.roomUnit.getY() : 0);
+                statement.setDouble(7, this.roomUnit != null ? this.roomUnit.getZ() : 0.0);
+                statement.setInt(8, this.roomUnit != null ? this.roomUnit.getBodyRotation().getValue() : 0);
+                statement.setInt(9, this.levelHunger);
+                statement.setInt(10, this.levelThirst);
+                statement.setInt(11, this.happiness);
+                statement.setInt(12, this.created);
+                statement.setInt(13, this.id);
+                if (statement.executeUpdate() != 1) throw new SQLException("Unable to update pet " + this.id);
+            }
+        } else if (this.id == 0) {
+            try (PreparedStatement statement = connection.prepareStatement("INSERT INTO users_pets (user_id, room_id, name, race, type, color, experience, energy, respect, created) VALUES (?, 0, ?, ?, ?, ?, 0, 0, 0, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                statement.setInt(1, this.userId);
+                statement.setString(2, this.name);
+                statement.setInt(3, this.race);
+                statement.setInt(4, this.petData == null ? 0 : this.petData.getType());
+                statement.setString(5, this.color);
+                statement.setInt(6, this.created);
+                statement.executeUpdate();
+                try (ResultSet set = statement.getGeneratedKeys()) {
+                    if (!set.next()) throw new SQLException("Unable to create pet");
+                    this.id = set.getInt(1);
                 }
             } catch (SQLException e) {
-                LOGGER.error("Caught SQL exception", e);
+                this.id = 0;
+                throw e;
             }
-
-            this.needsUpdate = false;
         }
+        this.needsUpdate = false;
     }
 
     public void cycle() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboBadge.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboBadge.java
@@ -57,18 +57,9 @@ public class HabboBadge implements Runnable {
     public void run() {
         try {
             if (this.needsInsert) {
-                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_badges (user_id, slot_id, badge_code) VALUES (?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
-                    statement.setInt(1, this.habbo.getHabboInfo().getId());
-                    statement.setInt(2, this.slot);
-                    statement.setString(3, this.code);
-                    statement.execute();
-                    try (ResultSet set = statement.getGeneratedKeys()) {
-                        if (set.next()) {
-                            this.id = set.getInt(1);
-                        }
-                    }
+                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+                    this.insert(connection);
                 }
-                this.needsInsert = false;
             } else if (this.needsUpdate) {
                 try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users_badges SET slot_id = ?, badge_code = ? WHERE id = ? AND user_id = ?")) {
                     statement.setInt(1, this.slot);
@@ -82,6 +73,22 @@ public class HabboBadge implements Runnable {
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }
+    }
+
+    public void insert(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO users_badges (user_id, slot_id, badge_code) VALUES (?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS)) {
+            statement.setInt(1, this.habbo.getHabboInfo().getId());
+            statement.setInt(2, this.slot);
+            statement.setString(3, this.code);
+            statement.executeUpdate();
+            try (ResultSet set = statement.getGeneratedKeys()) {
+                if (!set.next()) throw new SQLException("Unable to create user badge");
+                this.id = set.getInt(1);
+            }
+        }
+        this.needsInsert = false;
     }
 
     public void needsUpdate(boolean needsUpdate) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/EffectsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/EffectsComponent.java
@@ -63,6 +63,32 @@ public class EffectsComponent {
         return effect;
     }
 
+    public static HabboEffect persistEffect(Connection connection, int userId, int effectId, int duration) throws SQLException {
+        String upsert = "INSERT INTO users_effects (user_id, effect, total, duration) VALUES (?, ?, 1, ?) "
+                + "ON DUPLICATE KEY UPDATE total = LEAST(total + 1, 100), duration = VALUES(duration)";
+        try (PreparedStatement statement = connection.prepareStatement(upsert)) {
+            statement.setInt(1, userId);
+            statement.setInt(2, effectId);
+            statement.setInt(3, duration);
+            statement.executeUpdate();
+        }
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT * FROM users_effects WHERE user_id = ? AND effect = ? LIMIT 1")) {
+            statement.setInt(1, userId);
+            statement.setInt(2, effectId);
+            try (ResultSet result = statement.executeQuery()) {
+                if (!result.next()) throw new SQLException("Unable to load persisted effect " + effectId);
+                return new HabboEffect(result);
+            }
+        }
+    }
+
+    public void publishEffect(HabboEffect effect) {
+        synchronized (this.effects) {
+            this.addEffect(effect);
+        }
+    }
+
     public HabboEffect createRankEffect(int effectId) {
         HabboEffect rankEffect = new HabboEffect(effectId, habbo.getHabboInfo().getId());
         rankEffect.duration = 0;

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogSpecialAssetTransactionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogSpecialAssetTransactionContractTest.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogSpecialAssetTransactionContractTest {
+    private static String source(String relativePath) throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/" + relativePath));
+    }
+
+    @Test
+    void specialAssetsAcceptTheOwningTransactionConnection() throws Exception {
+        assertTrue(source("bots/BotManager.java").contains(
+                "createBot(Connection connection, Map<String, String> data, String type, int ownerId)"));
+        assertTrue(source("users/HabboBadge.java").contains("insert(Connection connection)"));
+        assertTrue(source("pets/Pet.java").contains("save(Connection connection)"));
+        assertTrue(source("users/inventory/EffectsComponent.java").contains(
+                "persistEffect(Connection connection, int userId, int effectId, int duration)"));
+        assertTrue(source("guilds/GuildManager.java").contains(
+                "persistGuild(Connection connection, int furniId, int guildId)"));
+    }
+
+    @Test
+    void connectionAwareMethodsPropagateSqlFailures() throws Exception {
+        assertTrue(source("bots/BotManager.java").contains(
+                "createBot(Connection connection, Map<String, String> data, String type, int ownerId) throws SQLException"));
+        assertTrue(source("users/HabboBadge.java").contains("insert(Connection connection) throws SQLException"));
+        assertTrue(source("pets/Pet.java").contains("save(Connection connection) throws SQLException"));
+        assertTrue(source("users/inventory/EffectsComponent.java").contains(
+                "persistEffect(Connection connection, int userId, int effectId, int duration) throws SQLException"));
+        assertTrue(source("guilds/GuildManager.java").contains(
+                "persistGuild(Connection connection, int furniId, int guildId) throws SQLException"));
+    }
+}


### PR DESCRIPTION
## Summary
- add caller-owned JDBC persistence paths for bots, pets, badges, effects and guild furniture relations
- keep existing public behavior through compatibility wrappers
- propagate SQL failures so catalog transactions can roll back instead of logging partial writes
- defer in-memory guild/effect publication from the persistence operation

## Follow-up
This is the independent persistence prerequisite for atomically integrating special assets after #345 lands.

## Verification
- mvn clean package
- 447 tests, 0 failures, 0 errors