### PR TITLE
Complete catalog purchases atomically

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/BotManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/BotManager.java
@@ -81,8 +81,19 @@ public class BotManager {
             return null;
         }
 
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            return this.createBot(connection, data, type, ownerId);
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+            return null;
+        }
+    }
+
+    public Bot createBot(Connection connection, Map<String, String> data, String type, int ownerId) throws SQLException {
+        if (ownerId <= 0) return null;
+
         Bot bot = null;
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO bots (user_id, room_id, name, motto, figure, gender, type) VALUES (?, 0, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO bots (user_id, room_id, name, motto, figure, gender, type) VALUES (?, 0, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, ownerId);
             statement.setString(2, data.get("name"));
             statement.setString(3, data.get("motto"));
@@ -99,13 +110,9 @@ public class BotManager {
                                 bot = this.loadBot(resultSet);
                             }
                         }
-                    } catch (SQLException e) {
-                        LOGGER.error("Caught SQL exception", e);
                     }
                 }
             }
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
         }
 
         return bot;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java
@@ -33,25 +33,46 @@ public class CatalogLimitedConfiguration implements Runnable {
 
     public int getNumber() {
         synchronized (this.limitedNumbers) {
-            int num = this.limitedNumbers.pop();
-            if (this.limitedNumbers.isEmpty()) {
-                Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId), Emulator.getConfig().getInt("catalog.ltd.page.soldout"));
-            }
-            return num;
+            return this.limitedNumbers.pop();
         }
     }
 
     public void limitedSold(int catalogItemId, Habbo habbo, HabboItem item) {
         synchronized (this.limitedNumbers) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE catalog_items_limited SET user_id = ?, timestamp = ?, item_id = ? WHERE catalog_item_id = ? AND number = ? AND user_id = 0 LIMIT 1")) {
-                statement.setInt(1, habbo.getHabboInfo().getId());
-                statement.setInt(2, Emulator.getIntUnixTimestamp());
-                statement.setInt(3, item.getId());
-                statement.setInt(4, catalogItemId);
-                statement.setInt(5, item.getLimitedSells());
-                statement.execute();
+            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+                this.limitedSold(connection, catalogItemId, habbo, item);
+                this.markSoldOutIfEmpty();
             } catch (SQLException e) {
                 LOGGER.error("Caught SQL exception", e);
+            }
+        }
+    }
+
+    public void limitedSold(Connection connection, int catalogItemId, Habbo habbo, HabboItem item) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("UPDATE catalog_items_limited SET user_id = ?, timestamp = ?, item_id = ? WHERE catalog_item_id = ? AND number = ? AND user_id = 0 LIMIT 1")) {
+            statement.setInt(1, habbo.getHabboInfo().getId());
+            statement.setInt(2, Emulator.getIntUnixTimestamp());
+            statement.setInt(3, item.getId());
+            statement.setInt(4, catalogItemId);
+            statement.setInt(5, item.getLimitedSells());
+            if (statement.executeUpdate() != 1) {
+                throw new SQLException("Limited catalog number is no longer available: " + item.getLimitedSells());
+            }
+        }
+    }
+
+    public void restoreNumber(int number) {
+        synchronized (this.limitedNumbers) {
+            if (!this.limitedNumbers.contains(number)) this.limitedNumbers.push(number);
+        }
+    }
+
+    public void markSoldOutIfEmpty() {
+        synchronized (this.limitedNumbers) {
+            if (this.limitedNumbers.isEmpty()) {
+                Emulator.getGameEnvironment().getCatalogManager().moveCatalogItem(
+                        Emulator.getGameEnvironment().getCatalogManager().getCatalogItem(this.itemId),
+                        Emulator.getConfig().getInt("catalog.ltd.page.soldout"));
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -26,7 +26,11 @@ import com.eu.habbo.messages.outgoing.inventory.AddPetComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.modtool.ModToolIssueHandledComposer;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
+import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
+import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
 import com.eu.habbo.plugin.events.emulator.EmulatorLoadCatalogManagerEvent;
+import com.eu.habbo.plugin.events.users.UserCreditsEvent;
+import com.eu.habbo.plugin.events.users.UserPointsEvent;
 import com.eu.habbo.plugin.events.users.catalog.UserCatalogFurnitureBoughtEvent;
 import com.eu.habbo.plugin.events.users.catalog.UserCatalogItemPurchasedEvent;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
@@ -1091,7 +1095,6 @@ public class CatalogManager {
                         limitedConfiguration = this.createOrUpdateLimitedConfig(item);
                     }
 
-                    limitedNumber = limitedConfiguration.getNumber();
                     limitedStack = limitedConfiguration.getTotalSet();
                 }
 
@@ -1101,6 +1104,14 @@ public class CatalogManager {
                 if (totalCredits > 0 && habbo.getHabboInfo().getCredits() - totalCredits < 0) return;
                 if (totalPoints > 0 && habbo.getHabboInfo().getCurrencyAmount(item.getPointsType()) - totalPoints < 0)
                     return;
+
+                if (limitedConfiguration != null) limitedNumber = limitedConfiguration.getNumber();
+
+                if (this.isAtomicFurniturePurchase(item)) {
+                    this.purchaseFurnitureAtomically(item, habbo, amount, extradata, free, limitedConfiguration,
+                            limitedStack, limitedNumber, totalCredits, totalPoints);
+                    return;
+                }
 
                 List<String> badges = new ArrayList<>();
                 Map<AddHabboItemComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();
@@ -1368,6 +1379,176 @@ public class CatalogManager {
         } finally {
             habbo.getHabboStats().isPurchasingFurniture = false;
         }
+    }
+
+    private boolean isAtomicFurniturePurchase(CatalogItem item) {
+        if (item == null || item.getBaseItems().isEmpty()) return false;
+        for (Item baseItem : item.getBaseItems()) {
+            if (baseItem == null || Item.isBot(baseItem) || Item.isPet(baseItem)
+                    || baseItem.getType() == FurnitureType.BADGE || baseItem.getType() == FurnitureType.EFFECT
+                    || baseItem.getInteractionType().getType() == InteractionGuildFurni.class
+                    || baseItem.getInteractionType().getType() == InteractionGuildGate.class
+                    || baseItem.getInteractionType().getType() == InteractionMusicDisc.class) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void purchaseFurnitureAtomically(CatalogItem item, Habbo habbo, int amount, String extraData,
+                                             boolean free, CatalogLimitedConfiguration limitedConfiguration,
+                                             int limitedStack, int limitedNumber, int totalCredits, int totalPoints)
+            throws SQLException {
+        int userId = habbo.getHabboInfo().getId();
+        try {
+            AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(userId, connection -> {
+                Set<HabboItem> createdItems = new HashSet<>();
+                for (int index = 0; index < amount; index++) {
+                    for (Item baseItem : item.getBaseItems()) {
+                        String itemExtraData = this.prepareFurnitureExtraData(habbo, baseItem, extraData);
+                        for (int count = 0; count < item.getItemAmount(baseItem.getId()); count++) {
+                            if (InteractionTeleport.class.isAssignableFrom(baseItem.getInteractionType().getType())) {
+                                HabboItem first = Emulator.getGameEnvironment().getItemManager().createItem(
+                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                HabboItem second = Emulator.getGameEnvironment().getItemManager().createItem(
+                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                if (first == null || second == null) throw new SQLException("Unable to create teleport pair");
+                                Emulator.getGameEnvironment().getItemManager().insertTeleportPair(
+                                        connection, first.getId(), second.getId());
+                                createdItems.add(first);
+                                createdItems.add(second);
+                            } else {
+                                HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
+                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                if (created == null) throw new SQLException("Unable to create catalog furniture");
+                                if (baseItem.getInteractionType().getType() == InteractionHopper.class) {
+                                    Emulator.getGameEnvironment().getItemManager().insertHopper(connection, created);
+                                }
+                                createdItems.add(created);
+                            }
+                        }
+                    }
+                }
+
+                Set<Integer> createdIds = createdItems.stream().map(HabboItem::getId).collect(Collectors.toSet());
+                UserCatalogItemPurchasedEvent purchasedEvent = new UserCatalogItemPurchasedEvent(
+                        habbo, item, createdItems, totalCredits, totalPoints, new ArrayList<>());
+                Emulator.getPluginManager().fireEvent(purchasedEvent);
+                Set<Integer> eventIds = purchasedEvent.itemsList.stream().map(HabboItem::getId).collect(Collectors.toSet());
+                if (!createdIds.equals(eventIds)) {
+                    throw new SQLException("Catalog plugin changed the atomic furniture set");
+                }
+
+                ResolvedCatalogCharges charges = this.resolveCatalogCharges(habbo, item, free, purchasedEvent);
+                if (limitedConfiguration != null) {
+                    HabboItem limitedItem = createdItems.stream().findFirst()
+                            .orElseThrow(() -> new SQLException("Limited purchase created no furniture"));
+                    limitedConfiguration.limitedSold(connection, item.getId(), habbo, limitedItem);
+                }
+                if (!free) {
+                    this.writePurchaseLog(connection, purchasedEvent, charges, amount);
+                }
+                AtomicFurniturePurchase result = new AtomicFurniturePurchase(
+                        purchasedEvent, charges.credits(), charges.points(), charges.pointsType());
+                return new CatalogPurchaseTransaction.PreparedPurchase<>(
+                        result, charges.credits(), charges.points(), charges.pointsType());
+            });
+
+            this.publishAtomicFurniturePurchase(habbo, purchase);
+            if (limitedConfiguration != null) {
+                habbo.getHabboStats().addLtdLog(item.getId(), Emulator.getIntUnixTimestamp());
+                limitedConfiguration.markSoldOutIfEmpty();
+            }
+        } catch (SQLException exception) {
+            if (limitedConfiguration != null && limitedNumber > 0) limitedConfiguration.restoreNumber(limitedNumber);
+            throw exception;
+        }
+    }
+
+    private String prepareFurnitureExtraData(Habbo habbo, Item baseItem, String extraData) {
+        if (baseItem.getInteractionType().getType() != InteractionTrophy.class
+                && baseItem.getInteractionType().getType() != InteractionBadgeDisplay.class) return extraData;
+
+        String value = extraData;
+        if (baseItem.getInteractionType().getType() == InteractionBadgeDisplay.class
+                && !habbo.getInventory().getBadgesComponent().hasBadge(value)) {
+            ScripterManager.scripterDetected(habbo.getClient(),
+                    Emulator.getTexts().getValue("scripter.warning.catalog.badge_display")
+                            .replace("%username%", habbo.getHabboInfo().getUsername())
+                            .replace("%badge%", value));
+            value = "UMAD";
+        }
+        int maximum = Emulator.getConfig().getInt("hotel.trophies.length.max", 300);
+        if (value.length() > maximum) value = value.substring(0, maximum);
+        return habbo.getHabboInfo().getUsername() + (char) 9
+                + Calendar.getInstance().get(Calendar.DAY_OF_MONTH) + "-"
+                + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-"
+                + Calendar.getInstance().get(Calendar.YEAR) + (char) 9
+                + Emulator.getGameEnvironment().getWordFilter().filter(value.replace(((char) 9) + "", ""), habbo);
+    }
+
+    private ResolvedCatalogCharges resolveCatalogCharges(Habbo habbo, CatalogItem item, boolean free,
+                                                         UserCatalogItemPurchasedEvent purchasedEvent) {
+        int credits = 0;
+        int points = 0;
+        int pointsType = item.getPointsType();
+        if (!free && !habbo.hasPermission(Permission.ACC_INFINITE_CREDITS) && purchasedEvent.totalCredits > 0) {
+            UserCreditsEvent event = new UserCreditsEvent(habbo, -purchasedEvent.totalCredits);
+            if (!Emulator.getPluginManager().fireEvent(event).isCancelled()) credits = Math.max(0, -event.credits);
+        }
+        if (!free && !habbo.hasPermission(Permission.ACC_INFINITE_POINTS) && purchasedEvent.totalPoints > 0) {
+            UserPointsEvent event = new UserPointsEvent(habbo, -purchasedEvent.totalPoints, pointsType);
+            if (!Emulator.getPluginManager().fireEvent(event).isCancelled()) {
+                points = Math.max(0, -event.points);
+                pointsType = event.type;
+            }
+        }
+        return new ResolvedCatalogCharges(credits, points, pointsType);
+    }
+
+    private void writePurchaseLog(Connection connection, UserCatalogItemPurchasedEvent event,
+                                  ResolvedCatalogCharges charges, int amount) throws SQLException {
+        Set<String> itemIds = event.itemsList.stream().map(item -> Integer.toString(item.getId())).collect(Collectors.toSet());
+        CatalogPurchaseLogEntry entry = new CatalogPurchaseLogEntry(
+                Emulator.getIntUnixTimestamp(), event.habbo.getHabboInfo().getId(), event.catalogItem.getId(),
+                String.join(";", itemIds), event.catalogItem.getName(), charges.credits(), charges.points(),
+                charges.pointsType(), amount);
+        try (PreparedStatement statement = connection.prepareStatement(entry.getQuery())) {
+            entry.log(statement);
+            statement.executeBatch();
+        }
+    }
+
+    private void publishAtomicFurniturePurchase(Habbo habbo, AtomicFurniturePurchase purchase) {
+        if (purchase.credits() > 0) {
+            habbo.getHabboInfo().addCredits(-purchase.credits());
+            habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
+        }
+        if (purchase.points() > 0) {
+            habbo.getHabboInfo().addCurrencyAmount(purchase.pointsType(), -purchase.points());
+            habbo.getClient().sendResponse(new UserPointsComposer(
+                    habbo.getHabboInfo().getCurrencyAmount(purchase.pointsType()),
+                    -purchase.points(), purchase.pointsType()));
+        }
+
+        Set<HabboItem> items = purchase.event().itemsList;
+        habbo.getInventory().getItemsComponent().addItems(items);
+        Map<AddHabboItemComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();
+        unseenItems.put(AddHabboItemComposer.AddHabboItemCategory.OWNED_FURNI,
+                items.stream().map(HabboItem::getId).collect(Collectors.toList()));
+        Emulator.getPluginManager().fireEvent(new UserCatalogFurnitureBoughtEvent(
+                habbo, purchase.event().catalogItem, items));
+        habbo.getHabboStats().addPurchase(purchase.event().catalogItem);
+        habbo.getClient().sendResponse(new AddHabboItemComposer(unseenItems));
+        habbo.getClient().sendResponse(new PurchaseOKComposer(purchase.event().catalogItem));
+        habbo.getClient().sendResponse(new InventoryRefreshComposer());
+    }
+
+    private record ResolvedCatalogCharges(int credits, int points, int pointsType) {
+    }
+
+    private record AtomicFurniturePurchase(UserCatalogItemPurchasedEvent event, int credits, int points,
+                                           int pointsType) {
     }
 
     public List<ClubOffer> getClubOffers() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -17,6 +17,7 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboBadge;
 import com.eu.habbo.habbohotel.users.HabboGender;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.inventory.EffectsComponent;
 import com.eu.habbo.messages.outgoing.catalog.*;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
@@ -1107,6 +1108,11 @@ public class CatalogManager {
 
                 if (limitedConfiguration != null) limitedNumber = limitedConfiguration.getNumber();
 
+                if (this.isAtomicEntitlementPurchase(item)) {
+                    this.purchaseEntitlementsAtomically(item, habbo, amount, free, totalCredits, totalPoints);
+                    return;
+                }
+
                 if (this.isAtomicFurniturePurchase(item)) {
                     this.purchaseFurnitureAtomically(item, habbo, amount, extradata, free, limitedConfiguration,
                             limitedStack, limitedNumber, totalCredits, totalPoints);
@@ -1395,6 +1401,94 @@ public class CatalogManager {
         return true;
     }
 
+    private boolean isAtomicEntitlementPurchase(CatalogItem item) {
+        if (item == null || item.getBaseItems().isEmpty()) return false;
+        for (Item baseItem : item.getBaseItems()) {
+            if (baseItem == null || (baseItem.getType() != FurnitureType.BADGE
+                    && baseItem.getType() != FurnitureType.EFFECT)) return false;
+        }
+        return true;
+    }
+
+    private void purchaseEntitlementsAtomically(CatalogItem item, Habbo habbo, int amount, boolean free,
+                                                int totalCredits, int totalPoints) throws SQLException {
+        List<String> requestedBadges = new ArrayList<>();
+        Map<Integer, Integer> requestedEffects = new HashMap<>();
+        for (int index = 0; index < amount; index++) {
+            for (Item baseItem : item.getBaseItems()) {
+                int count = item.getItemAmount(baseItem.getId());
+                if (baseItem.getType() == FurnitureType.BADGE) {
+                    if (habbo.getInventory().getBadgesComponent().hasBadge(baseItem.getName())) {
+                        if (item.getBaseItems().size() == 1) {
+                            habbo.getClient().sendResponse(new AlertPurchaseFailedComposer(
+                                    AlertPurchaseFailedComposer.ALREADY_HAVE_BADGE));
+                            return;
+                        }
+                    } else if (!requestedBadges.contains(baseItem.getName())) {
+                        requestedBadges.add(baseItem.getName());
+                    }
+                } else {
+                    int effectId = habbo.getHabboInfo().getGender() == HabboGender.F
+                            ? baseItem.getEffectF() : baseItem.getEffectM();
+                    if (effectId > 0) requestedEffects.merge(effectId, count, Integer::sum);
+                }
+            }
+        }
+
+        EntitlementPurchase purchase = CatalogPurchaseTransaction.execute(habbo.getHabboInfo().getId(), connection -> {
+            UserCatalogItemPurchasedEvent event = new UserCatalogItemPurchasedEvent(
+                    habbo, item, new HashSet<>(), totalCredits, totalPoints, new ArrayList<>(requestedBadges));
+            Emulator.getPluginManager().fireEvent(event);
+            ResolvedCatalogCharges charges = this.resolveCatalogCharges(habbo, item, free, event);
+
+            List<HabboBadge> badges = new ArrayList<>();
+            for (String code : event.badges) {
+                if (habbo.getInventory().getBadgesComponent().hasBadge(code)) continue;
+                HabboBadge badge = new HabboBadge(0, code, 0, habbo);
+                badge.insert(connection);
+                badges.add(badge);
+            }
+
+            Map<Integer, EffectsComponent.HabboEffect> effects = new HashMap<>();
+            for (Map.Entry<Integer, Integer> requested : requestedEffects.entrySet()) {
+                for (int count = 0; count < requested.getValue(); count++) {
+                    EffectsComponent.HabboEffect effect = EffectsComponent.persistEffect(connection,
+                            habbo.getHabboInfo().getId(), requested.getKey(), 86400);
+                    effects.put(requested.getKey(), effect);
+                }
+            }
+
+            if (!free) this.writePurchaseLog(connection, event, charges, amount);
+            EntitlementPurchase result = new EntitlementPurchase(
+                    event, badges, effects, charges.credits(), charges.points(), charges.pointsType());
+            return new CatalogPurchaseTransaction.PreparedPurchase<>(
+                    result, charges.credits(), charges.points(), charges.pointsType());
+        });
+
+        this.publishCommittedCharges(habbo, purchase.credits(), purchase.points(), purchase.pointsType());
+        Map<AddHabboItemComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();
+        if (!purchase.badges().isEmpty()) {
+            unseenItems.put(AddHabboItemComposer.AddHabboItemCategory.BADGE, new ArrayList<>());
+        }
+        for (HabboBadge badge : purchase.badges()) {
+            habbo.getInventory().getBadgesComponent().addBadge(badge);
+            habbo.getClient().sendResponse(new AddUserBadgeComposer(badge));
+            unseenItems.get(AddHabboItemComposer.AddHabboItemCategory.BADGE).add(badge.getId());
+            Map<String, String> keys = new HashMap<>();
+            keys.put("display", "BUBBLE");
+            keys.put("image", "${image.library.url}album1584/" + badge.getCode() + ".gif");
+            keys.put("message", Emulator.getTexts().getValue("commands.generic.cmd_badge.received"));
+            habbo.getClient().sendResponse(new BubbleAlertComposer(BubbleAlertKeys.RECEIVED_BADGE.key, keys));
+        }
+        for (EffectsComponent.HabboEffect effect : purchase.effects().values()) {
+            habbo.getInventory().getEffectsComponent().publishEffect(effect);
+        }
+        habbo.getHabboStats().addPurchase(purchase.event().catalogItem);
+        habbo.getClient().sendResponse(new AddHabboItemComposer(unseenItems));
+        habbo.getClient().sendResponse(new PurchaseOKComposer(purchase.event().catalogItem));
+        habbo.getClient().sendResponse(new InventoryRefreshComposer());
+    }
+
     private void purchaseFurnitureAtomically(CatalogItem item, Habbo habbo, int amount, String extraData,
                                              boolean free, CatalogLimitedConfiguration limitedConfiguration,
                                              int limitedStack, int limitedNumber, int totalCredits, int totalPoints)
@@ -1520,16 +1614,7 @@ public class CatalogManager {
     }
 
     private void publishAtomicFurniturePurchase(Habbo habbo, AtomicFurniturePurchase purchase) {
-        if (purchase.credits() > 0) {
-            habbo.getHabboInfo().addCredits(-purchase.credits());
-            habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
-        }
-        if (purchase.points() > 0) {
-            habbo.getHabboInfo().addCurrencyAmount(purchase.pointsType(), -purchase.points());
-            habbo.getClient().sendResponse(new UserPointsComposer(
-                    habbo.getHabboInfo().getCurrencyAmount(purchase.pointsType()),
-                    -purchase.points(), purchase.pointsType()));
-        }
+        this.publishCommittedCharges(habbo, purchase.credits(), purchase.points(), purchase.pointsType());
 
         Set<HabboItem> items = purchase.event().itemsList;
         habbo.getInventory().getItemsComponent().addItems(items);
@@ -1544,11 +1629,28 @@ public class CatalogManager {
         habbo.getClient().sendResponse(new InventoryRefreshComposer());
     }
 
+    private void publishCommittedCharges(Habbo habbo, int credits, int points, int pointsType) {
+        if (credits > 0) {
+            habbo.getHabboInfo().addCredits(-credits);
+            habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
+        }
+        if (points > 0) {
+            habbo.getHabboInfo().addCurrencyAmount(pointsType, -points);
+            habbo.getClient().sendResponse(new UserPointsComposer(
+                    habbo.getHabboInfo().getCurrencyAmount(pointsType), -points, pointsType));
+        }
+    }
+
     private record ResolvedCatalogCharges(int credits, int points, int pointsType) {
     }
 
     private record AtomicFurniturePurchase(UserCatalogItemPurchasedEvent event, int credits, int points,
                                            int pointsType) {
+    }
+
+    private record EntitlementPurchase(UserCatalogItemPurchasedEvent event, List<HabboBadge> badges,
+                                       Map<Integer, EffectsComponent.HabboEffect> effects, int credits, int points,
+                                       int pointsType) {
     }
 
     public List<ClubOffer> getClubOffers() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -1113,6 +1113,11 @@ public class CatalogManager {
                     return;
                 }
 
+                if (this.isAtomicBotOrPetPurchase(item)) {
+                    this.purchaseBotsAndPetsAtomically(item, habbo, amount, extradata, free, totalCredits, totalPoints);
+                    return;
+                }
+
                 if (this.isAtomicFurniturePurchase(item)) {
                     this.purchaseFurnitureAtomically(item, habbo, amount, extradata, free, limitedConfiguration,
                             limitedStack, limitedNumber, totalCredits, totalPoints);
@@ -1391,10 +1396,7 @@ public class CatalogManager {
         if (item == null || item.getBaseItems().isEmpty()) return false;
         for (Item baseItem : item.getBaseItems()) {
             if (baseItem == null || Item.isBot(baseItem) || Item.isPet(baseItem)
-                    || baseItem.getType() == FurnitureType.BADGE || baseItem.getType() == FurnitureType.EFFECT
-                    || baseItem.getInteractionType().getType() == InteractionGuildFurni.class
-                    || baseItem.getInteractionType().getType() == InteractionGuildGate.class
-                    || baseItem.getInteractionType().getType() == InteractionMusicDisc.class) {
+                    || baseItem.getType() == FurnitureType.BADGE || baseItem.getType() == FurnitureType.EFFECT) {
                 return false;
             }
         }
@@ -1408,6 +1410,97 @@ public class CatalogManager {
                     && baseItem.getType() != FurnitureType.EFFECT)) return false;
         }
         return true;
+    }
+
+    private boolean isAtomicBotOrPetPurchase(CatalogItem item) {
+        if (item == null || item.getBaseItems().isEmpty()) return false;
+        for (Item baseItem : item.getBaseItems()) {
+            if (baseItem == null || (!Item.isBot(baseItem) && !Item.isPet(baseItem))) return false;
+            if (Item.isPet(baseItem)) {
+                try {
+                    int type = Integer.parseInt(baseItem.getName().toLowerCase().replace("a0 pet", ""));
+                    if (type == 16) return false;
+                } catch (NumberFormatException exception) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void purchaseBotsAndPetsAtomically(CatalogItem item, Habbo habbo, int amount, String extraData,
+                                               boolean free, int totalCredits, int totalPoints) throws SQLException {
+        String[] petData = extraData.split("\n");
+        SpecialCompanionPurchase purchase = CatalogPurchaseTransaction.execute(
+                habbo.getHabboInfo().getId(), connection -> {
+                    List<Bot> bots = new ArrayList<>();
+                    List<Pet> pets = new ArrayList<>();
+                    for (int index = 0; index < amount; index++) {
+                        for (Item baseItem : item.getBaseItems()) {
+                            for (int count = 0; count < item.getItemAmount(baseItem.getId()); count++) {
+                                if (Item.isBot(baseItem)) {
+                                    String baseName = baseItem.getName();
+                                    String type = item.getName().replace("rentable_bot_", "").replace("bot_", "")
+                                            .replace("visitor_logger", "visitor_log");
+                                    if (("bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE).equals(baseName)
+                                            || ("rentable_bot_" + com.eu.habbo.habbohotel.bots.FrankBot.BOT_TYPE)
+                                            .equals(baseName)) {
+                                        if (!habbo.hasPermission(com.eu.habbo.habbohotel.bots.FrankBot.PERMISSION_USE)) {
+                                            throw new SQLException("Missing permission for Frank bot");
+                                        }
+                                    }
+                                    Map<String, String> data = new HashMap<>();
+                                    for (String value : item.getExtradata().split(";")) {
+                                        String[] pair = value.split(":", 2);
+                                        if (pair.length == 2) data.put(pair[0], pair[1]);
+                                    }
+                                    Bot bot = Emulator.getGameEnvironment().getBotManager().createBot(connection,
+                                            data, type, habbo.getHabboInfo().getId());
+                                    if (bot == null) throw new SQLException("Unable to create catalog bot");
+                                    bots.add(bot);
+                                } else {
+                                    if (petData.length < 3) throw new SQLException("Invalid catalog pet data");
+                                    Pet pet = Emulator.getGameEnvironment().getPetManager().createPet(connection,
+                                            baseItem, petData[0], petData[1], petData[2], habbo.getClient());
+                                    if (pet == null) throw new SQLException("Unable to create catalog pet");
+                                    pets.add(pet);
+                                }
+                            }
+                        }
+                    }
+
+                    UserCatalogItemPurchasedEvent event = new UserCatalogItemPurchasedEvent(
+                            habbo, item, new HashSet<>(), totalCredits, totalPoints, new ArrayList<>());
+                    Emulator.getPluginManager().fireEvent(event);
+                    ResolvedCatalogCharges charges = this.resolveCatalogCharges(habbo, item, free, event);
+                    if (!free) this.writePurchaseLog(connection, event, charges, amount);
+                    SpecialCompanionPurchase result = new SpecialCompanionPurchase(
+                            event, bots, pets, charges.credits(), charges.points(), charges.pointsType());
+                    return new CatalogPurchaseTransaction.PreparedPurchase<>(
+                            result, charges.credits(), charges.points(), charges.pointsType());
+                });
+
+        this.publishCommittedCharges(habbo, purchase.credits(), purchase.points(), purchase.pointsType());
+        Map<AddHabboItemComposer.AddHabboItemCategory, List<Integer>> unseenItems = new HashMap<>();
+        for (Bot bot : purchase.bots()) {
+            habbo.getInventory().getBotsComponent().addBot(bot);
+            habbo.getClient().sendResponse(new AddBotComposer(bot));
+            unseenItems.computeIfAbsent(AddHabboItemComposer.AddHabboItemCategory.BOT, ignored -> new ArrayList<>())
+                    .add(bot.getId());
+        }
+        for (Pet pet : purchase.pets()) {
+            habbo.getInventory().getPetsComponent().addPet(pet);
+            habbo.getClient().sendResponse(new AddPetComposer(pet));
+            habbo.getClient().sendResponse(new PetBoughtNotificationComposer(pet, false));
+            AchievementManager.progressAchievement(habbo,
+                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("PetLover"));
+            unseenItems.computeIfAbsent(AddHabboItemComposer.AddHabboItemCategory.PET, ignored -> new ArrayList<>())
+                    .add(pet.getId());
+        }
+        habbo.getHabboStats().addPurchase(purchase.event().catalogItem);
+        habbo.getClient().sendResponse(new AddHabboItemComposer(unseenItems));
+        habbo.getClient().sendResponse(new PurchaseOKComposer(purchase.event().catalogItem));
+        habbo.getClient().sendResponse(new InventoryRefreshComposer());
     }
 
     private void purchaseEntitlementsAtomically(CatalogItem item, Habbo habbo, int amount, boolean free,
@@ -1497,11 +1590,49 @@ public class CatalogManager {
         try {
             AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(userId, connection -> {
                 Set<HabboItem> createdItems = new HashSet<>();
+                Map<InteractionGuildFurni, Guild> guildFurniture = new HashMap<>();
+                boolean includesMusicDisc = false;
                 for (int index = 0; index < amount; index++) {
                     for (Item baseItem : item.getBaseItems()) {
                         String itemExtraData = this.prepareFurnitureExtraData(habbo, baseItem, extraData);
                         for (int count = 0; count < item.getItemAmount(baseItem.getId()); count++) {
-                            if (InteractionTeleport.class.isAssignableFrom(baseItem.getInteractionType().getType())) {
+                            if (baseItem.getInteractionType().getType() == InteractionGuildFurni.class
+                                    || baseItem.getInteractionType().getType() == InteractionGuildGate.class) {
+                                int guildId;
+                                try {
+                                    guildId = Integer.parseInt(extraData);
+                                } catch (NumberFormatException exception) {
+                                    throw new SQLException("Invalid guild furniture id", exception);
+                                }
+                                Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
+                                if (guild == null || Emulator.getGameEnvironment().getGuildManager()
+                                        .getGuildMember(guild, habbo) == null) {
+                                    throw new SQLException("User cannot purchase furniture for guild " + guildId);
+                                }
+                                if (baseItem.getName().equals("guild_forum")
+                                        && guild.getOwnerId() != habbo.getHabboInfo().getId()) {
+                                    throw new SQLException("Only the guild owner can purchase its forum");
+                                }
+                                InteractionGuildFurni created = (InteractionGuildFurni) Emulator.getGameEnvironment()
+                                        .getItemManager().createItem(connection, userId, baseItem,
+                                                limitedStack, limitedNumber, "");
+                                if (created == null) throw new SQLException("Unable to create guild furniture");
+                                Emulator.getGameEnvironment().getGuildManager().persistGuild(connection,
+                                        created.getId(), guildId);
+                                created.setGuildId(guildId);
+                                guildFurniture.put(created, guild);
+                                createdItems.add(created);
+                            } else if (baseItem.getInteractionType().getType() == InteractionMusicDisc.class) {
+                                SoundTrack track = Emulator.getGameEnvironment().getItemManager()
+                                        .getSoundTrack(item.getExtradata());
+                                if (track == null) throw new SQLException("Unknown catalog music track");
+                                itemExtraData = this.createMusicDiscExtraData(habbo, track);
+                                HabboItem created = Emulator.getGameEnvironment().getItemManager().createItem(
+                                        connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
+                                if (created == null) throw new SQLException("Unable to create music disc");
+                                createdItems.add(created);
+                                includesMusicDisc = true;
+                            } else if (InteractionTeleport.class.isAssignableFrom(baseItem.getInteractionType().getType())) {
                                 HabboItem first = Emulator.getGameEnvironment().getItemManager().createItem(
                                         connection, userId, baseItem, limitedStack, limitedNumber, itemExtraData);
                                 HabboItem second = Emulator.getGameEnvironment().getItemManager().createItem(
@@ -1543,7 +1674,8 @@ public class CatalogManager {
                     this.writePurchaseLog(connection, purchasedEvent, charges, amount);
                 }
                 AtomicFurniturePurchase result = new AtomicFurniturePurchase(
-                        purchasedEvent, charges.credits(), charges.points(), charges.pointsType());
+                        purchasedEvent, guildFurniture, includesMusicDisc,
+                        charges.credits(), charges.points(), charges.pointsType());
                 return new CatalogPurchaseTransaction.PreparedPurchase<>(
                         result, charges.credits(), charges.points(), charges.pointsType());
             });
@@ -1579,6 +1711,15 @@ public class CatalogManager {
                 + (Calendar.getInstance().get(Calendar.MONTH) + 1) + "-"
                 + Calendar.getInstance().get(Calendar.YEAR) + (char) 9
                 + Emulator.getGameEnvironment().getWordFilter().filter(value.replace(((char) 9) + "", ""), habbo);
+    }
+
+    private String createMusicDiscExtraData(Habbo habbo, SoundTrack track) {
+        Calendar calendar = Calendar.getInstance();
+        return habbo.getHabboInfo().getUsername() + "\n"
+                + calendar.get(Calendar.DAY_OF_MONTH) + "\n"
+                + (calendar.get(Calendar.MONTH) + 1) + "\n"
+                + calendar.get(Calendar.YEAR) + "\n"
+                + track.getLength() + "\n" + track.getName() + "\n" + track.getId();
     }
 
     private ResolvedCatalogCharges resolveCatalogCharges(Habbo habbo, CatalogItem item, boolean free,
@@ -1623,6 +1764,17 @@ public class CatalogManager {
                 items.stream().map(HabboItem::getId).collect(Collectors.toList()));
         Emulator.getPluginManager().fireEvent(new UserCatalogFurnitureBoughtEvent(
                 habbo, purchase.event().catalogItem, items));
+        for (Map.Entry<InteractionGuildFurni, Guild> guildEntry : purchase.guildFurniture().entrySet()) {
+            if (guildEntry.getKey().getBaseItem().getName().equals("guild_forum")) {
+                guildEntry.getValue().setForum(true);
+                guildEntry.getValue().needsUpdate = true;
+                Emulator.getThreading().run(guildEntry.getValue());
+            }
+        }
+        if (purchase.includesMusicDisc()) {
+            AchievementManager.progressAchievement(habbo,
+                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("MusicCollector"));
+        }
         habbo.getHabboStats().addPurchase(purchase.event().catalogItem);
         habbo.getClient().sendResponse(new AddHabboItemComposer(unseenItems));
         habbo.getClient().sendResponse(new PurchaseOKComposer(purchase.event().catalogItem));
@@ -1644,13 +1796,18 @@ public class CatalogManager {
     private record ResolvedCatalogCharges(int credits, int points, int pointsType) {
     }
 
-    private record AtomicFurniturePurchase(UserCatalogItemPurchasedEvent event, int credits, int points,
-                                           int pointsType) {
+    private record AtomicFurniturePurchase(UserCatalogItemPurchasedEvent event,
+                                           Map<InteractionGuildFurni, Guild> guildFurniture,
+                                           boolean includesMusicDisc, int credits, int points, int pointsType) {
     }
 
     private record EntitlementPurchase(UserCatalogItemPurchasedEvent event, List<HabboBadge> badges,
                                        Map<Integer, EffectsComponent.HabboEffect> effects, int credits, int points,
                                        int pointsType) {
+    }
+
+    private record SpecialCompanionPurchase(UserCatalogItemPurchasedEvent event, List<Bot> bots, List<Pet> pets,
+                                            int credits, int points, int pointsType) {
     }
 
     public List<ClubOffer> getClubOffers() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java
@@ -1,0 +1,70 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import com.eu.habbo.Emulator;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+final class CatalogPurchaseTransaction {
+    private static final String CHARGE_CREDITS =
+            "UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?";
+    private static final String CHARGE_POINTS =
+            "UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?";
+
+    private CatalogPurchaseTransaction() {
+    }
+
+    static <T> T execute(int userId, PurchaseWork<T> work) throws SQLException {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                PreparedPurchase<T> purchase = work.persist(connection);
+                chargeCredits(connection, userId, purchase.credits());
+                chargePoints(connection, userId, purchase.pointsType(), purchase.points());
+                connection.commit();
+                return purchase.value();
+            } catch (Exception exception) {
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackException) {
+                    exception.addSuppressed(rollbackException);
+                }
+                if (exception instanceof SQLException sqlException) throw sqlException;
+                throw new SQLException("Unable to persist catalog purchase", exception);
+            }
+        }
+    }
+
+    private static void chargeCredits(Connection connection, int userId, int credits) throws SQLException {
+        if (credits == 0) return;
+        try (PreparedStatement statement = connection.prepareStatement(CHARGE_CREDITS)) {
+            statement.setInt(1, credits);
+            statement.setInt(2, userId);
+            statement.setInt(3, credits);
+            if (statement.executeUpdate() != 1) throw new SQLException("Insufficient credits for catalog purchase");
+        }
+    }
+
+    private static void chargePoints(Connection connection, int userId, int pointsType, int points) throws SQLException {
+        if (points == 0) return;
+        try (PreparedStatement statement = connection.prepareStatement(CHARGE_POINTS)) {
+            statement.setInt(1, points);
+            statement.setInt(2, userId);
+            statement.setInt(3, pointsType);
+            statement.setInt(4, points);
+            if (statement.executeUpdate() != 1) throw new SQLException("Insufficient points for catalog purchase");
+        }
+    }
+
+    @FunctionalInterface
+    interface PurchaseWork<T> {
+        PreparedPurchase<T> persist(Connection connection) throws Exception;
+    }
+
+    record PreparedPurchase<T>(T value, int credits, int points, int pointsType) {
+        PreparedPurchase {
+            if (credits < 0 || points < 0) throw new IllegalArgumentException("Catalog charges cannot be negative");
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/guilds/GuildManager.java
@@ -633,13 +633,19 @@ public class GuildManager {
 
 
     public void setGuild(InteractionGuildFurni furni, int guildId) {
-        furni.setGuildId(guildId);
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE items SET guild_id = ? WHERE id = ?")) {
-            statement.setInt(1, guildId);
-            statement.setInt(2, furni.getId());
-            statement.execute();
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.persistGuild(connection, furni.getId(), guildId);
+            furni.setGuildId(guildId);
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    public void persistGuild(Connection connection, int furniId, int guildId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("UPDATE items SET guild_id = ? WHERE id = ?")) {
+            statement.setInt(1, guildId);
+            statement.setInt(2, furniId);
+            if (statement.executeUpdate() != 1) throw new SQLException("Unable to assign guild furniture " + furniId);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java
@@ -827,9 +827,22 @@ public class ItemManager {
             return null;
         }
 
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            return this.createItem(connection, habboId, item, limitedStack, limitedSells, extraData);
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+        return null;
+    }
+
+    public HabboItem createItem(Connection connection, int habboId, Item item, int limitedStack, int limitedSells, String extraData) throws SQLException {
+        if (habboId <= 0 || item == null) {
+            return null;
+        }
+
         extraData = ItemDataGuard.normalizeExtraData(extraData);
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items (user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO items (user_id, item_id, extra_data, limited_data) VALUES (?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, habboId);
             statement.setInt(2, item.getId());
             statement.setString(3, extraData);
@@ -850,10 +863,6 @@ public class ItemManager {
                     }
                 }
             }
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
-        } catch (Exception e) {
-            LOGGER.error("Caught exception", e);
         }
         return null;
     }
@@ -975,22 +984,34 @@ public class ItemManager {
     }
 
     public void insertTeleportPair(int itemOneId, int itemTwoId) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items_teleports (teleport_one_id, teleport_two_id) VALUES (?, ?)")) {
-            statement.setInt(1, itemOneId);
-            statement.setInt(2, itemTwoId);
-            statement.execute();
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.insertTeleportPair(connection, itemOneId, itemTwoId);
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }
     }
 
+    public void insertTeleportPair(Connection connection, int itemOneId, int itemTwoId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO items_teleports (teleport_one_id, teleport_two_id) VALUES (?, ?)")) {
+            statement.setInt(1, itemOneId);
+            statement.setInt(2, itemTwoId);
+            statement.execute();
+        }
+    }
+
     public void insertHopper(HabboItem hopper) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO items_hoppers VALUES (?, ?)")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.insertHopper(connection, hopper);
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
+
+    public void insertHopper(Connection connection, HabboItem hopper) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO items_hoppers VALUES (?, ?)")) {
             statement.setInt(1, hopper.getId());
             statement.setInt(2, hopper.getBaseItem().getId());
             statement.execute();
-        } catch (SQLException e) {
-            LOGGER.error("Caught SQL exception", e);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/Pet.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/Pet.java
@@ -192,53 +192,52 @@ public class Pet implements ISerialize, Runnable {
 
     @Override
     public void run() {
-        if (this.needsUpdate) {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-                if (this.id > 0) {
-                    try (PreparedStatement statement = connection.prepareStatement("UPDATE users_pets SET room_id = ?, experience = ?, energy = ?, respect = ?, x = ?, y = ?, z = ?, rot = ?, hunger = ?, thirst = ?, happiness = ?, created = ? WHERE id = ?")) {
-                        statement.setInt(1, (this.room == null ? 0 : this.room.getId()));
-                        statement.setInt(2, this.experience);
-                        statement.setInt(3, this.energy);
-                        statement.setInt(4, this.respect);
-                        statement.setInt(5, this.roomUnit != null ? this.roomUnit.getX() : 0);
-                        statement.setInt(6, this.roomUnit != null ? this.roomUnit.getY() : 0);
-                        statement.setDouble(7, this.roomUnit != null ? this.roomUnit.getZ() : 0.0);
-                        statement.setInt(8, this.roomUnit != null ? this.roomUnit.getBodyRotation().getValue() : 0);
-                        statement.setInt(9, this.levelHunger);
-                        statement.setInt(10, this.levelThirst);
-                        statement.setInt(11, this.happiness);
-                        statement.setInt(12, this.created);
-                        statement.setInt(13, this.id);
-                        statement.execute();
-                    }
-                } else if (this.id == 0) {
-                    try (PreparedStatement statement = connection.prepareStatement("INSERT INTO users_pets (user_id, room_id, name, race, type, color, experience, energy, respect, created) VALUES (?, 0, ?, ?, ?, ?, 0, 0, 0, ?)", Statement.RETURN_GENERATED_KEYS)) {
-                        statement.setInt(1, this.userId);
-                        statement.setString(2, this.name);
-                        statement.setInt(3, this.race);
-                        statement.setInt(4, 0);
+        if (!this.needsUpdate) return;
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            this.save(connection);
+        } catch (SQLException e) {
+            LOGGER.error("Caught SQL exception", e);
+        }
+    }
 
-                        if (this.petData != null) {
-                            statement.setInt(4, this.petData.getType());
-                        }
-
-                        statement.setString(5, this.color);
-                        statement.setInt(6, this.created);
-                        statement.execute();
-
-                        try (ResultSet set = statement.getGeneratedKeys()) {
-                            if (set.next()) {
-                                this.id = set.getInt(1);
-                            }
-                        }
-                    }
+    public void save(Connection connection) throws SQLException {
+        if (!this.needsUpdate) return;
+        if (this.id > 0) {
+            try (PreparedStatement statement = connection.prepareStatement("UPDATE users_pets SET room_id = ?, experience = ?, energy = ?, respect = ?, x = ?, y = ?, z = ?, rot = ?, hunger = ?, thirst = ?, happiness = ?, created = ? WHERE id = ?")) {
+                statement.setInt(1, (this.room == null ? 0 : this.room.getId()));
+                statement.setInt(2, this.experience);
+                statement.setInt(3, this.energy);
+                statement.setInt(4, this.respect);
+                statement.setInt(5, this.roomUnit != null ? this.roomUnit.getX() : 0);
+                statement.setInt(6, this.roomUnit != null ? this.roomUnit.getY() : 0);
+                statement.setDouble(7, this.roomUnit != null ? this.roomUnit.getZ() : 0.0);
+                statement.setInt(8, this.roomUnit != null ? this.roomUnit.getBodyRotation().getValue() : 0);
+                statement.setInt(9, this.levelHunger);
+                statement.setInt(10, this.levelThirst);
+                statement.setInt(11, this.happiness);
+                statement.setInt(12, this.created);
+                statement.setInt(13, this.id);
+                if (statement.executeUpdate() != 1) throw new SQLException("Unable to update pet " + this.id);
+            }
+        } else if (this.id == 0) {
+            try (PreparedStatement statement = connection.prepareStatement("INSERT INTO users_pets (user_id, room_id, name, race, type, color, experience, energy, respect, created) VALUES (?, 0, ?, ?, ?, ?, 0, 0, 0, ?)", Statement.RETURN_GENERATED_KEYS)) {
+                statement.setInt(1, this.userId);
+                statement.setString(2, this.name);
+                statement.setInt(3, this.race);
+                statement.setInt(4, this.petData == null ? 0 : this.petData.getType());
+                statement.setString(5, this.color);
+                statement.setInt(6, this.created);
+                statement.executeUpdate();
+                try (ResultSet set = statement.getGeneratedKeys()) {
+                    if (!set.next()) throw new SQLException("Unable to create pet");
+                    this.id = set.getInt(1);
                 }
             } catch (SQLException e) {
-                LOGGER.error("Caught SQL exception", e);
+                this.id = 0;
+                throw e;
             }
-
-            this.needsUpdate = false;
         }
+        this.needsUpdate = false;
     }
 
     public void cycle() {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/PetManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/pets/PetManager.java
@@ -473,6 +473,18 @@ public class PetManager {
         return null;
     }
 
+    public Pet createPet(Connection connection, Item item, String name, String race, String color, GameClient client) throws SQLException {
+        int type = Integer.parseInt(item.getName().toLowerCase().replace("a0 pet", ""));
+        if (!this.petData.containsKey(type) || type == 16) return null;
+
+        Pet pet = type == 15
+                ? new HorsePet(type, Integer.parseInt(race), color, name, client.getHabbo().getHabboInfo().getId())
+                : new Pet(type, Integer.parseInt(race), color, name, client.getHabbo().getHabboInfo().getId());
+        pet.needsUpdate = true;
+        pet.save(connection);
+        return pet;
+    }
+
     public Pet createPet(int type, String name, GameClient client) {
         return this.createPet(type, Emulator.getRandom().nextInt(this.petRaces.get(type).size() + 1), name, client);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboBadge.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboBadge.java
@@ -57,18 +57,9 @@ public class HabboBadge implements Runnable {
     public void run() {
         try {
             if (this.needsInsert) {
-                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_badges (user_id, slot_id, badge_code) VALUES (?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
-                    statement.setInt(1, this.habbo.getHabboInfo().getId());
-                    statement.setInt(2, this.slot);
-                    statement.setString(3, this.code);
-                    statement.execute();
-                    try (ResultSet set = statement.getGeneratedKeys()) {
-                        if (set.next()) {
-                            this.id = set.getInt(1);
-                        }
-                    }
+                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+                    this.insert(connection);
                 }
-                this.needsInsert = false;
             } else if (this.needsUpdate) {
                 try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users_badges SET slot_id = ?, badge_code = ? WHERE id = ? AND user_id = ?")) {
                     statement.setInt(1, this.slot);
@@ -82,6 +73,22 @@ public class HabboBadge implements Runnable {
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
         }
+    }
+
+    public void insert(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO users_badges (user_id, slot_id, badge_code) VALUES (?, ?, ?)",
+                Statement.RETURN_GENERATED_KEYS)) {
+            statement.setInt(1, this.habbo.getHabboInfo().getId());
+            statement.setInt(2, this.slot);
+            statement.setString(3, this.code);
+            statement.executeUpdate();
+            try (ResultSet set = statement.getGeneratedKeys()) {
+                if (!set.next()) throw new SQLException("Unable to create user badge");
+                this.id = set.getInt(1);
+            }
+        }
+        this.needsInsert = false;
     }
 
     public void needsUpdate(boolean needsUpdate) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/EffectsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/EffectsComponent.java
@@ -63,6 +63,32 @@ public class EffectsComponent {
         return effect;
     }
 
+    public static HabboEffect persistEffect(Connection connection, int userId, int effectId, int duration) throws SQLException {
+        String upsert = "INSERT INTO users_effects (user_id, effect, total, duration) VALUES (?, ?, 1, ?) "
+                + "ON DUPLICATE KEY UPDATE total = LEAST(total + 1, 100), duration = VALUES(duration)";
+        try (PreparedStatement statement = connection.prepareStatement(upsert)) {
+            statement.setInt(1, userId);
+            statement.setInt(2, effectId);
+            statement.setInt(3, duration);
+            statement.executeUpdate();
+        }
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT * FROM users_effects WHERE user_id = ? AND effect = ? LIMIT 1")) {
+            statement.setInt(1, userId);
+            statement.setInt(2, effectId);
+            try (ResultSet result = statement.executeQuery()) {
+                if (!result.next()) throw new SQLException("Unable to load persisted effect " + effectId);
+                return new HabboEffect(result);
+            }
+        }
+    }
+
+    public void publishEffect(HabboEffect effect) {
+        synchronized (this.effects) {
+            this.addEffect(effect);
+        }
+    }
+
     public HabboEffect createRankEffect(int effectId) {
         HabboEffect rankEffect = new HabboEffect(effectId, habbo.getHabboInfo().getId());
         rankEffect.duration = 0;

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
@@ -1,0 +1,31 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AtomicCatalogPurchaseContractTest {
+    @Test
+    void coordinatorCommitsAssetsAndConditionalChargesTogether() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java"));
+
+        int begin = source.indexOf("connection.setAutoCommit(false)");
+        int persist = source.indexOf("work.persist(connection)", begin);
+        int credit = source.indexOf("chargeCredits(connection", persist);
+        int points = source.indexOf("chargePoints(connection", credit);
+        int commit = source.indexOf("connection.commit()", points);
+
+        assertTrue(begin > -1);
+        assertTrue(persist > begin);
+        assertTrue(credit > persist);
+        assertTrue(points > credit);
+        assertTrue(commit > points);
+        assertTrue(source.contains("UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?"));
+        assertTrue(source.contains("UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?"));
+        assertTrue(source.contains("connection.rollback()"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
@@ -28,4 +28,30 @@ class AtomicCatalogPurchaseContractTest {
         assertTrue(source.contains("UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?"));
         assertTrue(source.contains("connection.rollback()"));
     }
+
+    @Test
+    void catalogPublishesFurnitureOnlyAfterAtomicPurchaseReturns() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+
+        int method = source.indexOf("purchaseFurnitureAtomically(");
+        int transaction = source.indexOf("CatalogPurchaseTransaction.execute(", method);
+        int inventory = source.indexOf("getItemsComponent().addItems(", transaction);
+        int success = source.indexOf("new PurchaseOKComposer(", transaction);
+
+        assertTrue(method > -1);
+        assertTrue(transaction > method);
+        assertTrue(inventory > transaction);
+        assertTrue(success > transaction);
+    }
+
+    @Test
+    void limitedFurnitureReservationUsesThePurchaseConnection() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogLimitedConfiguration.java"));
+
+        assertTrue(source.contains("limitedSold(Connection connection, int catalogItemId"));
+        assertTrue(source.contains("AND number = ? AND user_id = 0 LIMIT 1"));
+        assertTrue(source.contains("executeUpdate() != 1"));
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
@@ -74,4 +74,41 @@ class AtomicCatalogPurchaseContractTest {
         assertTrue(badgePublish > effectInsert);
         assertTrue(effectPublish > effectInsert);
     }
+
+    @Test
+    void botsAndPetsPublishOnlyAfterTheirTransactionCommits() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+
+        int method = source.indexOf("purchaseBotsAndPetsAtomically(");
+        int transaction = source.indexOf("CatalogPurchaseTransaction.execute(", method);
+        int botPersist = source.indexOf("createBot(connection", transaction);
+        int petPersist = source.indexOf("createPet(connection", transaction);
+        int botPublish = source.indexOf("getBotsComponent().addBot(", petPersist);
+        int petPublish = source.indexOf("getPetsComponent().addPet(", petPersist);
+
+        assertTrue(method > -1);
+        assertTrue(transaction > method);
+        assertTrue(botPersist > transaction);
+        assertTrue(petPersist > transaction);
+        assertTrue(botPublish > petPersist);
+        assertTrue(petPublish > petPersist);
+    }
+
+    @Test
+    void guildAndMusicFurnitureUseTheFurnitureTransaction() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+        int transaction = source.indexOf("CatalogPurchaseTransaction.execute(",
+                source.indexOf("purchaseFurnitureAtomically("));
+        int guildPersist = source.indexOf("persistGuild(connection", transaction);
+        int musicCreate = source.indexOf("createMusicDiscExtraData(", transaction);
+        int inventory = source.indexOf("getItemsComponent().addItems(", transaction);
+        int musicAchievement = source.indexOf("MusicCollector", inventory);
+
+        assertTrue(guildPersist > transaction);
+        assertTrue(musicCreate > transaction);
+        assertTrue(inventory > guildPersist);
+        assertTrue(musicAchievement > inventory);
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
@@ -54,4 +54,24 @@ class AtomicCatalogPurchaseContractTest {
         assertTrue(source.contains("AND number = ? AND user_id = 0 LIMIT 1"));
         assertTrue(source.contains("executeUpdate() != 1"));
     }
+
+    @Test
+    void badgesAndEffectsPublishOnlyAfterTheirTransactionCommits() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java"));
+
+        int method = source.indexOf("purchaseEntitlementsAtomically(");
+        int transaction = source.indexOf("CatalogPurchaseTransaction.execute(", method);
+        int badgeInsert = source.indexOf("badge.insert(connection)", transaction);
+        int effectInsert = source.indexOf("EffectsComponent.persistEffect(connection", transaction);
+        int badgePublish = source.indexOf("getBadgesComponent().addBadge(", effectInsert);
+        int effectPublish = source.indexOf("getEffectsComponent().publishEffect(", effectInsert);
+
+        assertTrue(method > -1);
+        assertTrue(transaction > method);
+        assertTrue(badgeInsert > transaction);
+        assertTrue(effectInsert > transaction);
+        assertTrue(badgePublish > effectInsert);
+        assertTrue(effectPublish > effectInsert);
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogAssetTransactionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogAssetTransactionContractTest.java
@@ -1,0 +1,41 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogAssetTransactionContractTest {
+    private static String itemManagerSource() throws Exception {
+        return Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/items/ItemManager.java"));
+    }
+
+    private static String method(String source, String signature) {
+        int start = source.indexOf(signature);
+        int end = source.indexOf("\n    public ", start + signature.length());
+        return source.substring(start, end);
+    }
+
+    @Test
+    void furnitureFactoriesCanShareTheCatalogTransactionConnection() throws Exception {
+        String source = itemManagerSource();
+
+        assertTrue(source.contains("createItem(Connection connection, int habboId"));
+        assertTrue(source.contains("insertTeleportPair(Connection connection, int itemOneId, int itemTwoId)"));
+        assertTrue(source.contains("insertHopper(Connection connection, HabboItem hopper)"));
+    }
+
+    @Test
+    void connectionAwareFactoriesDoNotOpenAnotherConnection() throws Exception {
+        String source = itemManagerSource();
+        assertTrue(!method(source, "createItem(Connection connection, int habboId")
+                .contains("getDataSource().getConnection()"));
+        assertTrue(!method(source, "insertTeleportPair(Connection connection")
+                .contains("getDataSource().getConnection()"));
+        assertTrue(!method(source, "insertHopper(Connection connection")
+                .contains("getDataSource().getConnection()"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogSpecialAssetTransactionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogSpecialAssetTransactionContractTest.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogSpecialAssetTransactionContractTest {
+    private static String source(String relativePath) throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/habbohotel/" + relativePath));
+    }
+
+    @Test
+    void specialAssetsAcceptTheOwningTransactionConnection() throws Exception {
+        assertTrue(source("bots/BotManager.java").contains(
+                "createBot(Connection connection, Map<String, String> data, String type, int ownerId)"));
+        assertTrue(source("users/HabboBadge.java").contains("insert(Connection connection)"));
+        assertTrue(source("pets/Pet.java").contains("save(Connection connection)"));
+        assertTrue(source("users/inventory/EffectsComponent.java").contains(
+                "persistEffect(Connection connection, int userId, int effectId, int duration)"));
+        assertTrue(source("guilds/GuildManager.java").contains(
+                "persistGuild(Connection connection, int furniId, int guildId)"));
+    }
+
+    @Test
+    void connectionAwareMethodsPropagateSqlFailures() throws Exception {
+        assertTrue(source("bots/BotManager.java").contains(
+                "createBot(Connection connection, Map<String, String> data, String type, int ownerId) throws SQLException"));
+        assertTrue(source("users/HabboBadge.java").contains("insert(Connection connection) throws SQLException"));
+        assertTrue(source("pets/Pet.java").contains("save(Connection connection) throws SQLException"));
+        assertTrue(source("users/inventory/EffectsComponent.java").contains(
+                "persistEffect(Connection connection, int userId, int effectId, int duration) throws SQLException"));
+        assertTrue(source("guilds/GuildManager.java").contains(
+                "persistGuild(Connection connection, int furniId, int guildId) throws SQLException"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogSpecialAssetTransactionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogSpecialAssetTransactionContractTest.java
@@ -18,6 +18,8 @@ class CatalogSpecialAssetTransactionContractTest {
                 "createBot(Connection connection, Map<String, String> data, String type, int ownerId)"));
         assertTrue(source("users/HabboBadge.java").contains("insert(Connection connection)"));
         assertTrue(source("pets/Pet.java").contains("save(Connection connection)"));
+        assertTrue(source("pets/PetManager.java").contains(
+                "createPet(Connection connection, Item item, String name, String race, String color, GameClient client)"));
         assertTrue(source("users/inventory/EffectsComponent.java").contains(
                 "persistEffect(Connection connection, int userId, int effectId, int duration)"));
         assertTrue(source("guilds/GuildManager.java").contains(


### PR DESCRIPTION
## Summary
- atomically persist ordinary and LTD furniture, teleport pairs, hoppers and guild/music furniture
- atomically persist catalog badges, effects, bots and supported pets
- conditionally charge credits and points in the same transaction to prevent concurrent overspending
- include LTD reservations, asset relations and purchase logs in the transaction
- publish balances, inventories, achievements and composers only after commit
- retain legacy paths for monster plants, gifts, room bundles and subscriptions

## Fork integration
The verified PR head is also fast-forwarded into simoleo89/Arcturus-Morningstar-Extended:dev. The dedicated PR branch remains the head here so the upstream diff stays isolated and reviewable.

## Supersedes
- #345
- #346

## Verification
- mvn clean package
- 455 tests, 0 failures, 0 errors