### PR TITLE
Prevent duplicate user sessions

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClientManager.java
@@ -15,9 +15,11 @@ import java.util.concurrent.ConcurrentMap;
 public class GameClientManager {
 
     private final ConcurrentMap<ChannelId, GameClient> clients;
+    private final ConcurrentMap<Integer, GameClient> authenticatedClients;
 
     public GameClientManager() {
         this.clients = new ConcurrentHashMap<>();
+        this.authenticatedClients = new ConcurrentHashMap<>();
     }
 
 
@@ -70,6 +72,9 @@ public class GameClientManager {
         GameClient client = channel.attr(GameServerAttributes.CLIENT).get();
 
         if (client != null) {
+            if (client.getHabbo() != null && client.getHabbo().getHabboInfo() != null) {
+                this.releaseAuthenticatedSession(client.getHabbo().getHabboInfo().getId(), client);
+            }
             client.dispose(allowSessionResume);
         }
         channel.deregister();
@@ -77,6 +82,21 @@ public class GameClientManager {
         channel.closeFuture();
         channel.close();
         this.clients.remove(channel.id());
+    }
+
+    public GameClient claimAuthenticatedSession(int userId, GameClient client) {
+        if (userId <= 0 || client == null) return null;
+        return this.authenticatedClients.put(userId, client);
+    }
+
+    public void releaseAuthenticatedSession(int userId, GameClient client) {
+        if (userId <= 0 || client == null) return;
+        this.authenticatedClients.remove(userId, client);
+    }
+
+    public GameClient getAuthenticatedClient(int userId) {
+        if (userId <= 0) return null;
+        return this.authenticatedClients.get(userId);
     }
 
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
@@ -3,6 +3,7 @@ package com.eu.habbo.messages.incoming.handshake;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.messenger.Messenger;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.gameclients.GameClientManager;
 import com.eu.habbo.habbohotel.gameclients.SessionResumeManager;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctionItem;
 import com.eu.habbo.habbohotel.modtool.ModToolSanctions;
@@ -144,6 +145,14 @@ public class SecureLoginEvent extends MessageHandler {
             }
 
             if (habbo != null) {
+                GameClientManager clientManager = Emulator.getGameServer().getGameClientManager();
+                GameClient previousClient = clientManager.claimAuthenticatedSession(
+                        habbo.getHabboInfo().getId(), this.client);
+                if (previousClient != null && previousClient != this.client) {
+                    LOGGER.info("Replacing duplicate active session for user {}", habbo.getHabboInfo().getId());
+                    clientManager.forceDisposeClient(previousClient);
+                }
+
                 if (!isSessionResume) {
                     try {
                         habbo.setClient(this.client);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/DuplicateUserSessionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/gameclients/DuplicateUserSessionContractTest.java
@@ -1,0 +1,46 @@
+package com.eu.habbo.habbohotel.gameclients;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.CryptoConfig;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DuplicateUserSessionContractTest {
+    @Test
+    void latestClientAtomicallyOwnsTheUserSession() throws Exception {
+        var crypto = Emulator.class.getDeclaredField("crypto");
+        crypto.setAccessible(true);
+        crypto.set(null, new CryptoConfig(false, "", "", ""));
+
+        GameClientManager manager = new GameClientManager();
+        GameClient first = new GameClient(new EmbeddedChannel());
+        GameClient second = new GameClient(new EmbeddedChannel());
+
+        assertNull(manager.claimAuthenticatedSession(7, first));
+        assertSame(first, manager.claimAuthenticatedSession(7, second));
+        manager.releaseAuthenticatedSession(7, first);
+        assertSame(second, manager.getAuthenticatedClient(7));
+        manager.releaseAuthenticatedSession(7, second);
+        assertNull(manager.getAuthenticatedClient(7));
+    }
+
+    @Test
+    void secureLoginClaimsByUserIdBeforeConnecting() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java"));
+        int claim = source.indexOf("claimAuthenticatedSession(");
+        int connect = source.indexOf(".connect()", claim);
+        int forcedDispose = source.indexOf("forceDisposeClient(previousClient)", claim);
+
+        assertTrue(claim > -1, "SecureLoginEvent must atomically claim the user id");
+        assertTrue(forcedDispose > claim, "the displaced client must be closed without parking a ghost session");
+        assertTrue(connect > forcedDispose, "the previous session must be removed before the new login connects");
+    }
+}


### PR DESCRIPTION
## Summary
- atomically associate each authenticated user id with one active client
- close the displaced client before connecting a replacement session
- use compare-and-remove during disposal so an old disconnect cannot unregister the new session
- add regression coverage for ownership handoff and login ordering

## Verification
- `mvn clean package`
- 447 tests, 0 failures, 0 errors