### PR TITLE
Validate every item ID in multi-item trades

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/trading/TradeItemIdGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/trading/TradeItemIdGuard.java
@@ -1,0 +1,20 @@
+package com.eu.habbo.messages.incoming.trading;
+
+import java.util.HashSet;
+import java.util.Set;
+
+final class TradeItemIdGuard {
+    private TradeItemIdGuard() {
+    }
+
+    static boolean arePositiveAndUnique(int[] itemIds) {
+        if (itemIds == null || itemIds.length == 0) return false;
+
+        Set<Integer> uniqueIds = new HashSet<>(itemIds.length);
+        for (int itemId : itemIds) {
+            if (itemId <= 0 || !uniqueIds.add(itemId)) return false;
+        }
+
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/trading/TradeOfferMultipleItemsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/trading/TradeOfferMultipleItemsEvent.java
@@ -24,16 +24,24 @@ public class TradeOfferMultipleItemsEvent extends MessageHandler {
         if (count <= 0 || count > RoomTrade.MAX_OFFERED_ITEMS)
             return;
 
+        int[] itemIds = new int[count];
         for (int i = 0; i < count; i++) {
-            int itemId = this.packet.readInt();
-            if (itemId <= 0)
-                continue;
-
-            HabboItem item = this.client.getHabbo().getInventory().getItemsComponent().getHabboItem(itemId);
-            if (item != null && item.getBaseItem().allowTrade()) {
-                items.add(item);
-            }
+            itemIds[i] = this.packet.readInt();
         }
+
+        if (!TradeItemIdGuard.arePositiveAndUnique(itemIds))
+            return;
+
+        for (int itemId : itemIds) {
+            HabboItem item = this.client.getHabbo().getInventory().getItemsComponent().getHabboItem(itemId);
+            if (item == null || !item.getBaseItem().allowTrade())
+                return;
+
+            items.add(item);
+        }
+
+        if (items.size() != count)
+            return;
 
         trade.offerMultipleItems(this.client.getHabbo(), items);
     }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/trading/TradeItemIdGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/trading/TradeItemIdGuardTest.java
@@ -1,0 +1,18 @@
+package com.eu.habbo.messages.incoming.trading;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TradeItemIdGuardTest {
+    @Test
+    void acceptsOnlyPositiveUniqueIds() {
+        assertTrue(TradeItemIdGuard.arePositiveAndUnique(new int[]{10, 20, 30}));
+        assertFalse(TradeItemIdGuard.arePositiveAndUnique(new int[]{10, 0, 30}));
+        assertFalse(TradeItemIdGuard.arePositiveAndUnique(new int[]{10, -1, 30}));
+        assertFalse(TradeItemIdGuard.arePositiveAndUnique(new int[]{10, 20, 10}));
+        assertFalse(TradeItemIdGuard.arePositiveAndUnique(new int[]{}));
+        assertFalse(TradeItemIdGuard.arePositiveAndUnique(null));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/trading/TradeOfferGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/trading/TradeOfferGuardContractTest.java
@@ -22,15 +22,19 @@ class TradeOfferGuardContractTest {
 
         int count = source.indexOf("int count = this.packet.readInt()");
         int guard = source.indexOf("count <= 0 || count > RoomTrade.MAX_OFFERED_ITEMS", count);
-        int loop = source.indexOf("for (int i = 0; i < count; i++)", count);
-        int lookup = source.indexOf("getHabboItem(itemId)", loop);
+        int readLoop = source.indexOf("for (int i = 0; i < count; i++)", count);
+        int idGuard = source.indexOf("TradeItemIdGuard.arePositiveAndUnique(itemIds)", readLoop);
+        int resolveLoop = source.indexOf("for (int itemId : itemIds)", idGuard);
+        int lookup = source.indexOf("getHabboItem(itemId)", resolveLoop);
 
         assertTrue(count > -1, "TradeOfferMultipleItemsEvent must read the client supplied count");
         assertTrue(guard > count, "TradeOfferMultipleItemsEvent must validate the count after reading it");
-        assertTrue(guard < loop, "TradeOfferMultipleItemsEvent must validate the count before looping");
-        assertTrue(loop < lookup, "TradeOfferMultipleItemsEvent should only resolve inventory items inside the bounded loop");
-        assertTrue(source.contains("itemId <= 0"),
-                "TradeOfferMultipleItemsEvent must skip invalid item ids before inventory lookup");
+        assertTrue(guard < readLoop, "TradeOfferMultipleItemsEvent must validate the count before reading ids");
+        assertTrue(readLoop < idGuard, "TradeOfferMultipleItemsEvent must validate all ids after reading the packet");
+        assertTrue(idGuard < resolveLoop, "TradeOfferMultipleItemsEvent must reject invalid or duplicate ids before resolving inventory");
+        assertTrue(resolveLoop < lookup, "TradeOfferMultipleItemsEvent should resolve only a fully validated id list");
+        assertTrue(source.contains("item == null || !item.getBaseItem().allowTrade()"),
+                "TradeOfferMultipleItemsEvent must reject the entire request when an item is missing or not tradable");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- reject a multi-item trade packet when any supplied item ID is invalid or duplicated
- resolve every item strictly from the sender inventory
- reject the whole request if one item is missing or not tradable
- update the trade packet contract and add focused guard tests

## Verification
- `mvn clean package`
- 446 tests, 0 failures, 0 errors
- `git diff --check`