### PR TITLE
Validate private report author IDs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolReportInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ModToolReportInputGuard.java
@@ -27,4 +27,8 @@ final class ModToolReportInputGuard {
     static boolean isPositiveId(int id) {
         return id > 0;
     }
+
+    static boolean isPrivateChatParticipant(int authorId, int reporterId, int reportedUserId) {
+        return authorId > 0 && (authorId == reporterId || authorId == reportedUserId);
+    }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ReportFriendPrivateChatEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/modtool/ReportFriendPrivateChatEvent.java
@@ -45,16 +45,20 @@ public class ReportFriendPrivateChatEvent extends MessageHandler {
 
         if (info == null) return;
 
+        int reporterId = this.client.getHabbo().getHabboInfo().getId();
         for (int i = 0; i < count; i++) {
             int chatUserId = this.packet.readInt();
-            String username = this.packet.readInt() == info.getId() ? info.getUsername() : this.client.getHabbo().getHabboInfo().getUsername();
-            String chatMessage = ModToolReportInputGuard.normalize(this.packet.readString());
 
-            if (!ModToolReportInputGuard.isPositiveId(chatUserId) ||
-                    !ModToolReportInputGuard.isValidChatLogMessage(chatMessage)) {
+            if (!ModToolReportInputGuard.isPrivateChatParticipant(chatUserId, reporterId, info.getId())) {
                 return;
             }
 
+            String chatMessage = ModToolReportInputGuard.normalize(this.packet.readString());
+            if (!ModToolReportInputGuard.isValidChatLogMessage(chatMessage)) return;
+
+            String username = chatUserId == info.getId()
+                    ? info.getUsername()
+                    : this.client.getHabbo().getHabboInfo().getUsername();
             chatLogs.add(new ModToolChatLog(0, chatUserId, username, chatMessage));
         }
 

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/modtool/ModToolReportInputContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/modtool/ModToolReportInputContractTest.java
@@ -66,4 +66,19 @@ class ModToolReportInputContractTest {
         assertTrue(source.contains("if (!this.client.getHabbo().getHabboStats().allowTalk())"),
                 "bully reports must reject muted users instead of rejecting users who can talk");
     }
+
+    @Test
+    void privateChatReportBindsEveryLogAuthorToTheConversation() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/modtool/ReportFriendPrivateChatEvent.java"));
+
+        int authorRead = source.indexOf("int chatUserId = this.packet.readInt()");
+        int participantGuard = source.indexOf("isPrivateChatParticipant(chatUserId", authorRead);
+        int messageRead = source.indexOf("this.packet.readString()", authorRead);
+
+        assertTrue(authorRead > -1, "private chat reports must read the composer author id");
+        assertTrue(participantGuard > authorRead, "private chat reports must bind authors to reporter or reported user");
+        assertTrue(participantGuard < messageRead, "invalid authors must be rejected before their message is accepted");
+        assertTrue(!source.contains("this.packet.readInt() == info.getId()"),
+                "private chat reports must not consume a second, unauthenticated author id");
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/modtool/ModToolReportInputGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/modtool/ModToolReportInputGuardTest.java
@@ -34,4 +34,15 @@ class ModToolReportInputGuardTest {
         assertFalse(ModToolReportInputGuard.isPositiveId(-1));
         assertTrue(ModToolReportInputGuard.isPositiveId(1));
     }
+
+    @Test
+    void privateChatAuthorsMustBelongToTheReportedConversation() {
+        int reporterId = 7;
+        int reportedUserId = 11;
+
+        assertTrue(ModToolReportInputGuard.isPrivateChatParticipant(reporterId, reporterId, reportedUserId));
+        assertTrue(ModToolReportInputGuard.isPrivateChatParticipant(reportedUserId, reporterId, reportedUserId));
+        assertFalse(ModToolReportInputGuard.isPrivateChatParticipant(99, reporterId, reportedUserId));
+        assertFalse(ModToolReportInputGuard.isPrivateChatParticipant(0, reporterId, reportedUserId));
+    }
 }


### PR DESCRIPTION
## Summary
- parse private-chat report entries using the renderer's real `(authorId, message)` contract
- accept log authors only when they are the reporter or reported user
- remove the second unauthenticated author ID that desynchronized packet parsing
- add guard and packet-contract regression coverage

## Verification
- `mvn clean package`
- 447 tests, 0 failures, 0 errors
- `git diff --check`