### PR TITLE
Migrate emulator build and CI to Java 25

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,11 +22,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
           cache: maven
 
       - name: Bump patch version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
           cache: maven
 
       - name: Build and test

--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
 
         <netty.version>4.2.16.Final</netty.version>
         <gson.version>2.14.0</gson.version>

--- a/Emulator/src/test/java/com/eu/habbo/Java25BuildContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/Java25BuildContractTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Java25BuildContractTest {
+    @Test
+    void mavenAndGithubWorkflowsUseJava25Consistently() throws Exception {
+        String pom = Files.readString(Path.of("pom.xml"));
+        String ci = Files.readString(Path.of("../.github/workflows/ci.yml"));
+        String release = Files.readString(Path.of("../.github/workflows/build-release.yml"));
+
+        assertTrue(pom.contains("<maven.compiler.release>25</maven.compiler.release>"));
+        assertTrue(ci.contains("Set up JDK 25"));
+        assertTrue(ci.contains("java-version: \"25\""));
+        assertTrue(release.contains("Set up JDK 25"));
+        assertTrue(release.contains("java-version: '25'"));
+        assertFalse(ci.contains("JDK 21"));
+        assertFalse(release.contains("JDK 21"));
+    }
+}


### PR DESCRIPTION
## Summary
- compile the emulator with Maven `release 25`
- run pull-request CI on Temurin 25
- build release artifacts on Temurin 25
- add a contract test preventing Maven and GitHub workflows from drifting back to Java 21

## Verification
- `mvn clean package` using Temurin 25.0.3
- 446 tests, 0 failures, 0 errors
- generated bytecode major version 69 (Java 25)
- `git diff --check`