### PR TITLE
Reject invalid clicked furniture IDs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ClickFurniEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/ClickFurniEvent.java
@@ -16,8 +16,12 @@ public class ClickFurniEvent extends MessageHandler {
             return;
         }
 
-        int itemId = Math.abs(this.packet.readInt());
+        int itemId = this.packet.readInt();
         this.packet.readInt();
+
+        if (!RoomItemInputGuard.isPositiveId(itemId)) {
+            return;
+        }
 
         HabboItem item = room.getHabboItem(itemId);
 

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/ClickFurniIdGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/ClickFurniIdGuardContractTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.messages.incoming.rooms.items;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClickFurniIdGuardContractTest {
+    @Test
+    void rejectsNonPositiveClientIdsBeforeRoomLookup() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/messages/incoming/rooms/items/ClickFurniEvent.java"));
+
+        int read = source.indexOf("int itemId = this.packet.readInt()");
+        int guard = source.indexOf("RoomItemInputGuard.isPositiveId(itemId)", read);
+        int lookup = source.indexOf("room.getHabboItem(itemId)", read);
+
+        assertTrue(read > -1, "ClickFurniEvent must preserve the exact client-provided id");
+        assertTrue(guard > read, "ClickFurniEvent must validate the id after reading it");
+        assertTrue(guard < lookup, "ClickFurniEvent must reject invalid ids before room lookup");
+        assertFalse(source.contains("Math.abs"), "negative ids must not alias valid room item ids");
+    }
+}


### PR DESCRIPTION
## Summary
- preserve the exact furniture ID supplied by the client
- reject zero and negative IDs before room lookup
- remove `Math.abs` aliasing that allowed `-123` to target room item `123`
- add packet-order regression coverage

## Verification
- `mvn clean package`
- 446 tests, 0 failures, 0 errors
- `git diff --check`