### PR TITLE
Validate guild packet IDs server-side

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildAcceptMembershipEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildAcceptMembershipEvent.java
@@ -24,6 +24,10 @@ public class GuildAcceptMembershipEvent extends MessageHandler {
         int guildId = this.packet.readInt();
         int userId = this.packet.readInt();
 
+        if (!GuildInputGuard.arePositiveIds(guildId, userId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild == null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeBadgeEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeBadgeEvent.java
@@ -18,6 +18,10 @@ public class GuildChangeBadgeEvent extends MessageHandler {
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
         if (guild != null) {
             if (guild.getOwnerId() == this.client.getHabbo().getHabboInfo().getId() || this.client.getHabbo().hasPermission(Permission.ACC_GUILD_ADMIN)) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeColorsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeColorsEvent.java
@@ -17,6 +17,10 @@ public class GuildChangeColorsEvent extends MessageHandler {
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeNameDescEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeNameDescEvent.java
@@ -17,6 +17,10 @@ public class GuildChangeNameDescEvent extends MessageHandler {
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeSettingsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeSettingsEvent.java
@@ -36,6 +36,10 @@ public class GuildChangeSettingsEvent extends MessageHandler {
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildConfirmRemoveMemberEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildConfirmRemoveMemberEvent.java
@@ -19,6 +19,10 @@ public class GuildConfirmRemoveMemberEvent extends MessageHandler {
         int guildId = this.packet.readInt();
         int userId = this.packet.readInt();
 
+        if (!GuildInputGuard.arePositiveIds(guildId, userId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildDeclineMembershipEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildDeclineMembershipEvent.java
@@ -24,6 +24,10 @@ public class GuildDeclineMembershipEvent extends MessageHandler {
         int guildId = this.packet.readInt();
         int userId = this.packet.readInt();
 
+        if (!GuildInputGuard.arePositiveIds(guildId, userId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildDeleteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildDeleteEvent.java
@@ -22,6 +22,10 @@ public class GuildDeleteEvent extends MessageHandler {
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildInputGuard.java
@@ -1,0 +1,20 @@
+package com.eu.habbo.messages.incoming.guilds;
+
+final class GuildInputGuard {
+    private GuildInputGuard() {
+    }
+
+    static boolean isPositiveId(int id) {
+        return id > 0;
+    }
+
+    static boolean arePositiveIds(int... ids) {
+        for (int id : ids) {
+            if (!isPositiveId(id)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildRemoveAdminEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildRemoveAdminEvent.java
@@ -20,13 +20,16 @@ public class GuildRemoveAdminEvent extends MessageHandler {
     @Override
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
+        int userId = this.packet.readInt();
+
+        if (!GuildInputGuard.arePositiveIds(guildId, userId)) {
+            return;
+        }
 
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {
             if (guild.getOwnerId() == this.client.getHabbo().getHabboInfo().getId() || this.client.getHabbo().hasPermission(Permission.ACC_GUILD_ADMIN)) {
-                int userId = this.packet.readInt();
-
                 Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(guild.getRoomId());
                 Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildRemoveFavoriteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildRemoveFavoriteEvent.java
@@ -17,6 +17,10 @@ public class GuildRemoveFavoriteEvent extends MessageHandler {
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         if (this.client.getHabbo().getHabboStats().hasGuild(guildId)) {
             Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
             GuildRemovedFavoriteEvent favoriteEvent = new GuildRemovedFavoriteEvent(guild, this.client.getHabbo());

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildRemoveMemberEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildRemoveMemberEvent.java
@@ -24,6 +24,10 @@ public class GuildRemoveMemberEvent extends MessageHandler {
         int guildId = this.packet.readInt();
         int userId = this.packet.readInt();
 
+        if (!GuildInputGuard.arePositiveIds(guildId, userId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if(guild == null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildSetAdminEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildSetAdminEvent.java
@@ -21,6 +21,10 @@ public class GuildSetAdminEvent extends MessageHandler {
         int guildId = this.packet.readInt();
         int userId = this.packet.readInt();
 
+        if (!GuildInputGuard.arePositiveIds(guildId, userId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildSetFavoriteEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildSetFavoriteEvent.java
@@ -18,6 +18,10 @@ public class GuildSetFavoriteEvent extends MessageHandler {
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (this.client.getHabbo().getHabboStats().hasGuild(guildId)) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildBuyEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildBuyEvent.java
@@ -46,6 +46,11 @@ public class RequestGuildBuyEvent extends MessageHandler {
 
         int roomId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(roomId)) {
+            this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+            return;
+        }
+
         Room r = Emulator.getGameEnvironment().getRoomManager().getRoom(roomId);
 
         if (r == null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildFurniWidgetEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildFurniWidgetEvent.java
@@ -17,6 +17,10 @@ public class RequestGuildFurniWidgetEvent extends MessageHandler {
         int itemId = this.packet.readInt();
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.arePositiveIds(itemId, guildId)) {
+            return;
+        }
+
         if (this.client.getHabbo().getHabboInfo().getCurrentRoom() != null) {
             HabboItem item = this.client.getHabbo().getHabboInfo().getCurrentRoom().getHabboItem(itemId);
             Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildInfoEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildInfoEvent.java
@@ -16,6 +16,10 @@ public class RequestGuildInfoEvent extends MessageHandler {
         int guildId = this.packet.readInt();
         boolean newWindow = this.packet.readBoolean();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
 
         if (guild != null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildJoinEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildJoinEvent.java
@@ -18,6 +18,10 @@ public class RequestGuildJoinEvent extends MessageHandler {
     public void handle() throws Exception {
         int guildId = this.packet.readInt();
 
+        if (!GuildInputGuard.isPositiveId(guildId)) {
+            return;
+        }
+
         if (this.client.getHabbo().getHabboStats().hasGuild(guildId))
             return;
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildManageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildManageEvent.java
@@ -28,7 +28,7 @@ public class RequestGuildManageEvent extends MessageHandler {
         if (habboInfo == null) return;
 
         final int guildId = this.packet.readInt();
-        if (guildId <= 0) return;
+        if (!GuildInputGuard.isPositiveId(guildId)) return;
 
         final GuildManager guildManager = Emulator.getGameEnvironment().getGuildManager();
         final Guild guild = guildManager.getGuild(guildId);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildMembersEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/RequestGuildMembersEvent.java
@@ -24,7 +24,7 @@ public class RequestGuildMembersEvent extends MessageHandler {
         int pageId = this.packet.readInt();
         String query = this.packet.readString();
         int levelId = this.packet.readInt();
-        if (pageId < 0 || pageId > MAX_PAGE_ID || levelId < 0 || levelId > MAX_LEVEL_ID || query == null || query.length() > MAX_QUERY_LENGTH) {
+        if (!GuildInputGuard.isPositiveId(groupId) || pageId < 0 || pageId > MAX_PAGE_ID || levelId < 0 || levelId > MAX_LEVEL_ID || query == null || query.length() > MAX_QUERY_LENGTH) {
             return;
         }
 

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/guilds/GuildIdInputGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/guilds/GuildIdInputGuardContractTest.java
@@ -1,0 +1,55 @@
+package com.eu.habbo.messages.incoming.guilds;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GuildIdInputGuardContractTest {
+    private static final Path SOURCE_ROOT = Path.of("src/main/java/com/eu/habbo/messages/incoming/guilds");
+
+    private static String source(String file) throws Exception {
+        return Files.readString(SOURCE_ROOT.resolve(file));
+    }
+
+    @Test
+    void guildPacketIdsUseTheSharedPositiveIdGuard() throws Exception {
+        Map<String, String> expectedGuards = Map.ofEntries(
+                Map.entry("GuildAcceptMembershipEvent.java", "GuildInputGuard.arePositiveIds(guildId, userId)"),
+                Map.entry("GuildChangeBadgeEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("GuildChangeColorsEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("GuildChangeNameDescEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("GuildChangeSettingsEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("GuildConfirmRemoveMemberEvent.java", "GuildInputGuard.arePositiveIds(guildId, userId)"),
+                Map.entry("GuildDeclineMembershipEvent.java", "GuildInputGuard.arePositiveIds(guildId, userId)"),
+                Map.entry("GuildDeleteEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("GuildRemoveAdminEvent.java", "GuildInputGuard.arePositiveIds(guildId, userId)"),
+                Map.entry("GuildRemoveFavoriteEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("GuildRemoveMemberEvent.java", "GuildInputGuard.arePositiveIds(guildId, userId)"),
+                Map.entry("GuildSetAdminEvent.java", "GuildInputGuard.arePositiveIds(guildId, userId)"),
+                Map.entry("GuildSetFavoriteEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("RequestGuildBuyEvent.java", "GuildInputGuard.isPositiveId(roomId)"),
+                Map.entry("RequestGuildFurniWidgetEvent.java", "GuildInputGuard.arePositiveIds(itemId, guildId)"),
+                Map.entry("RequestGuildInfoEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("RequestGuildJoinEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("RequestGuildManageEvent.java", "GuildInputGuard.isPositiveId(guildId)"),
+                Map.entry("RequestGuildMembersEvent.java", "GuildInputGuard.isPositiveId(groupId)"));
+
+        for (Map.Entry<String, String> entry : expectedGuards.entrySet()) {
+            assertTrue(source(entry.getKey()).contains(entry.getValue()),
+                    entry.getKey() + " must reject non-positive packet IDs before lookup");
+        }
+    }
+
+    @Test
+    void sharedGuardRejectsEveryNonPositiveId() throws Exception {
+        String guard = source("GuildInputGuard.java");
+
+        assertTrue(guard.contains("return id > 0;"));
+        assertTrue(guard.contains("for (int id : ids)"));
+        assertTrue(guard.contains("if (!isPositiveId(id))"));
+    }
+}


### PR DESCRIPTION
## Summary
- add one shared positive-ID guard for guild packet boundaries
- reject invalid guild, user, room and furniture IDs before lookups or mutations
- cover every non-forum guild handler that receives an ID from the client
- retain the existing dedicated forum ID validation

## Verification
- `mvn -Dtest=GuildIdInputGuardContractTest test`
- `mvn clean package`
- 447 tests, 0 failures, 0 errors