### PR TITLE
Validate RCON and plugin event IDs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/ButlerBot.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/bots/ButlerBot.java
@@ -5,6 +5,7 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessage;
 import com.eu.habbo.habbohotel.rooms.RoomUnitStatus;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.plugin.events.bots.BotServerItemEvent;
+import com.eu.habbo.plugin.PluginEventInputGuard;
 import com.eu.habbo.threading.runnables.RoomUnitGiveHanditem;
 import com.eu.habbo.threading.runnables.RoomUnitWalkToRoomUnit;
 import org.slf4j.Logger;
@@ -93,6 +94,10 @@ public class ButlerBot extends Bot {
                         // Enable plugins to cancel this event
                         BotServerItemEvent serveEvent = new BotServerItemEvent(this, message.getHabbo(), itemId);
                         if (Emulator.getPluginManager().fireEvent(serveEvent).isCancelled()) {
+                            return;
+                        }
+
+                        if (!PluginEventInputGuard.isPositiveId(serveEvent.itemId)) {
                             return;
                         }
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/camera/CameraPublishToWebEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/camera/CameraPublishToWebEvent.java
@@ -7,6 +7,7 @@ import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.camera.CameraPublishWaitMessageComposer;
 import com.eu.habbo.messages.outgoing.catalog.NotEnoughPointsTypeComposer;
 import com.eu.habbo.plugin.events.users.UserPublishPictureEvent;
+import com.eu.habbo.plugin.PluginEventInputGuard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,11 @@ public class CameraPublishToWebEvent extends MessageHandler {
             UserPublishPictureEvent publishPictureEvent = new UserPublishPictureEvent(habbo, habboInfo.getPhotoURL(), currentTimestamp, habboInfo.getPhotoRoomId());
 
             if (!Emulator.getPluginManager().fireEvent(publishPictureEvent).isCancelled()) {
+                if (!PluginEventInputGuard.isPositiveId(publishPictureEvent.roomId)
+                        || Emulator.getGameEnvironment().getRoomManager().loadRoom(publishPictureEvent.roomId) == null) {
+                    return;
+                }
+
                 try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
                      PreparedStatement statement = connection.prepareStatement("INSERT INTO camera_web (user_id, room_id, timestamp, url) VALUES (?, ?, ?, ?)")) {
                     statement.setInt(1, habboInfo.getId());

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/CreateModToolTicket.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/CreateModToolTicket.java
@@ -4,6 +4,10 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.modtool.ModToolIssue;
 import com.eu.habbo.habbohotel.modtool.ModToolTicketType;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 
 public class CreateModToolTicket extends RCONMessage<CreateModToolTicket.JSON> {
     public CreateModToolTicket() {
@@ -12,28 +16,43 @@ public class CreateModToolTicket extends RCONMessage<CreateModToolTicket.JSON> {
 
     @Override
     public void handle(Gson gson, JSON json) {
+        if (!RconUserLookup.userExists(json.sender_id) || !RconUserLookup.userExists(json.reported_id)) {
+            this.status = HABBO_NOT_FOUND;
+            this.message = "user not found";
+            return;
+        }
+
+        if (json.reported_room_id > 0 && Emulator.getGameEnvironment().getRoomManager().loadRoom(json.reported_room_id) == null) {
+            this.status = ROOM_NOT_FOUND;
+            this.message = "room not found";
+            return;
+        }
+
         ModToolIssue issue = new ModToolIssue(json.sender_id, json.sender_username, json.reported_id, json.reported_username, json.reported_room_id, json.message, ModToolTicketType.NORMAL);
         Emulator.getGameEnvironment().getModToolManager().addTicket(issue);
         Emulator.getGameEnvironment().getModToolManager().updateTicketToMods(issue);
     }
 
     static class JSON {
-
+        @Positive(message = "invalid sender")
         public int sender_id;
 
-
+        @NotBlank(message = "invalid sender username")
+        @Size(max = 64, message = "invalid sender username")
         public String sender_username;
 
-
+        @Positive(message = "invalid reported user")
         public int reported_id;
 
-
+        @NotBlank(message = "invalid reported username")
+        @Size(max = 64, message = "invalid reported username")
         public String reported_username;
 
-
+        @PositiveOrZero(message = "invalid room")
         public int reported_room_id = 0;
 
-
+        @NotBlank(message = "invalid message")
+        @Size(max = 4096, message = "invalid message")
         public String message;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/DisconnectUser.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/DisconnectUser.java
@@ -14,9 +14,9 @@ public class DisconnectUser extends RCONMessage<DisconnectUser.DisconnectUserJSO
     public void handle(Gson gson, DisconnectUserJSON json) {
         Habbo target;
 
-        if (json.user_id >= 0) {
+        if (json.user_id > 0) {
             target = Emulator.getGameEnvironment().getHabboManager().getHabbo(json.user_id);
-        } else if (!json.username.isEmpty()) {
+        } else if (json.username != null && !json.username.isBlank()) {
             target = Emulator.getGameEnvironment().getHabboManager().getHabbo(json.username);
         } else {
             this.status = RCONMessage.HABBO_NOT_FOUND;

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveUserClothing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveUserClothing.java
@@ -7,6 +7,7 @@ import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.users.UserClothesComposer;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.Positive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +101,10 @@ public class GiveUserClothing extends RCONMessage<GiveUserClothing.JSONGiveUserC
     }
 
     static class JSONGiveUserClothing {
+        @Positive(message = "invalid user")
         public int user_id;
+
+        @Positive(message = "invalid clothing")
         public int clothing_id;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendRoomBundle.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendRoomBundle.java
@@ -7,6 +7,7 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.Positive;
 
 public class SendRoomBundle extends RCONMessage<SendRoomBundle.JSON> {
     public SendRoomBundle() {
@@ -34,10 +35,10 @@ public class SendRoomBundle extends RCONMessage<SendRoomBundle.JSON> {
     }
 
     static class JSON {
-
+        @Positive(message = "invalid user")
         public int user_id;
 
-
+        @Positive(message = "invalid catalog page")
         public int catalog_page;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/SetMotto.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/SetMotto.java
@@ -4,6 +4,9 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDataComposer;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,10 +44,11 @@ public class SetMotto extends RCONMessage<SetMotto.SetMottoJSON> {
     }
 
     static class SetMottoJSON {
-
+        @Positive(message = "invalid user")
         public int user_id;
 
-
+        @NotNull(message = "invalid motto")
+        @Size(max = 127, message = "invalid motto")
         public String motto;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginEventInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginEventInputGuard.java
@@ -1,0 +1,10 @@
+package com.eu.habbo.plugin;
+
+public final class PluginEventInputGuard {
+    private PluginEventInputGuard() {
+    }
+
+    public static boolean isPositiveId(int id) {
+        return id > 0;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/RconIdBoundaryContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/RconIdBoundaryContractTest.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.messages.rcon;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RconIdBoundaryContractTest {
+    private static String source(String file) throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/rcon/" + file));
+    }
+
+    @Test
+    void ticketIdsAreValidatedBeforeCreatingTheTicket() throws Exception {
+        String ticket = source("CreateModToolTicket.java");
+
+        assertTrue(ticket.contains("@Positive(message = \"invalid sender\")"));
+        assertTrue(ticket.contains("@Positive(message = \"invalid reported user\")"));
+        assertTrue(ticket.contains("@PositiveOrZero(message = \"invalid room\")"));
+        assertTrue(ticket.contains("RconUserLookup.userExists(json.sender_id)"));
+        assertTrue(ticket.contains("RconUserLookup.userExists(json.reported_id)"));
+        assertTrue(ticket.contains("getRoomManager().loadRoom(json.reported_room_id)"));
+    }
+
+    @Test
+    void mottoAndMandatoryResourceIdsUseBeanValidation() throws Exception {
+        String motto = source("SetMotto.java");
+        String clothing = source("GiveUserClothing.java");
+        String bundle = source("SendRoomBundle.java");
+
+        assertTrue(motto.contains("@Positive(message = \"invalid user\")"));
+        assertTrue(clothing.contains("@Positive(message = \"invalid clothing\")"));
+        assertTrue(bundle.contains("@Positive(message = \"invalid catalog page\")"));
+    }
+
+    @Test
+    void disconnectTreatsZeroAsAnInvalidIdAndUsesOnlyARealUsernameFallback() throws Exception {
+        String disconnect = source("DisconnectUser.java");
+
+        assertTrue(disconnect.contains("if (json.user_id > 0)"));
+        assertTrue(disconnect.contains("json.username != null && !json.username.isBlank()"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/plugin/PluginMutableIdGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/PluginMutableIdGuardContractTest.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PluginMutableIdGuardContractTest {
+    private static String source(String path) throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/" + path));
+    }
+
+    @Test
+    void pluginMutatedButlerItemIdIsValidatedBeforeUse() throws Exception {
+        String butler = source("habbohotel/bots/ButlerBot.java");
+        int fireEvent = butler.indexOf("fireEvent(serveEvent)");
+        int idGuard = butler.indexOf("PluginEventInputGuard.isPositiveId(serveEvent.itemId)", fireEvent);
+        int handItem = butler.indexOf("new RoomUnitGiveHanditem", fireEvent);
+
+        assertTrue(idGuard > fireEvent, "plugin-mutated hand-item id must be checked after event dispatch");
+        assertTrue(handItem > idGuard, "hand-item id must be checked before task creation");
+    }
+
+    @Test
+    void pluginMutatedPhotoRoomIdMustResolveBeforePersistence() throws Exception {
+        String publish = source("messages/incoming/camera/CameraPublishToWebEvent.java");
+        int fireEvent = publish.indexOf("fireEvent(publishPictureEvent)");
+        int idGuard = publish.indexOf("PluginEventInputGuard.isPositiveId(publishPictureEvent.roomId)", fireEvent);
+        int roomLookup = publish.indexOf("getRoomManager().loadRoom(publishPictureEvent.roomId)", idGuard);
+        int persistence = publish.indexOf("statement.setInt(2, publishPictureEvent.roomId)", fireEvent);
+
+        assertTrue(idGuard > fireEvent, "plugin-mutated room id must be checked after event dispatch");
+        assertTrue(roomLookup > idGuard, "plugin-mutated room id must resolve server-side");
+        assertTrue(persistence > roomLookup, "room validation must happen before database persistence");
+    }
+}


### PR DESCRIPTION
## Summary
- validate RCON ticket user and room IDs before ticket creation
- reject invalid RCON user, clothing, catalog page and motto targets at payload validation
- treat disconnect user ID zero as invalid and require a real username fallback
- revalidate plugin-mutated hand-item and camera room IDs before core use

## Verification
- `mvn '-Dtest=RconIdBoundaryContractTest,PluginMutableIdGuardContractTest,RconPayloadValidatorTest' test`
- `mvn clean package`
- 450 tests, 0 failures, 0 errors