### PR TITLE
Keep periodic emulator tasks alive after failures

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/threading/HabboExecutorService.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/HabboExecutorService.java
@@ -4,8 +4,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 public class HabboExecutorService extends ScheduledThreadPoolExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(HabboExecutorService.class);
@@ -15,11 +21,52 @@ public class HabboExecutorService extends ScheduledThreadPoolExecutor {
     }
 
     @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return super.scheduleAtFixedRate(guardPeriodicTask(command), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return super.scheduleWithFixedDelay(guardPeriodicTask(command), initialDelay, delay, unit);
+    }
+
+    private Runnable guardPeriodicTask(Runnable command) {
+        Objects.requireNonNull(command, "command");
+        return () -> {
+            try {
+                command.run();
+            } catch (Exception exception) {
+                logFailure(exception);
+            }
+        };
+    }
+
+    @Override
     protected void afterExecute(Runnable r, Throwable t) {
         super.afterExecute(r, t);
 
-        if (t != null && !(t instanceof IOException)) {
-            LOGGER.error("Error in HabboExecutorService", t);
+        Throwable failure = t;
+        if (failure == null && r instanceof Future<?> future && future.isDone()) {
+            try {
+                future.get();
+            } catch (CancellationException ignored) {
+                return;
+            } catch (ExecutionException exception) {
+                failure = exception.getCause();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+
+        if (failure != null) {
+            logFailure(failure);
+        }
+    }
+
+    private void logFailure(Throwable failure) {
+        if (!(failure instanceof IOException)) {
+            LOGGER.error("Error in HabboExecutorService", failure);
         }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServicePeriodicTaskTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/HabboExecutorServicePeriodicTaskTest.java
@@ -1,0 +1,33 @@
+package com.eu.habbo.threading;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HabboExecutorServicePeriodicTaskTest {
+    @Test
+    void periodicTaskContinuesAfterOneExecutionThrows() throws Exception {
+        HabboExecutorService executor = new HabboExecutorService(1, Executors.defaultThreadFactory());
+        AtomicInteger executions = new AtomicInteger();
+        CountDownLatch recoveredExecution = new CountDownLatch(1);
+
+        try {
+            executor.scheduleAtFixedRate(() -> {
+                if (executions.incrementAndGet() == 1) {
+                    throw new IllegalStateException("first execution fails");
+                }
+                recoveredExecution.countDown();
+            }, 0, 10, TimeUnit.MILLISECONDS);
+
+            assertTrue(recoveredExecution.await(2, TimeUnit.SECONDS),
+                    "an exception must not permanently cancel a periodic emulator task");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- guard every periodic task scheduled through the emulator executor
- log a failed execution without letting Java cancel all future runs
- surface exceptions hidden inside completed one-shot futures
- preserve cancellation and thread interruption semantics

## Verification
- `mvn -Dtest=HabboExecutorServicePeriodicTaskTest test`
- `mvn clean package`
- 446 tests, 0 failures, 0 errors