### PR TITLE
Verify client release before SSO login

### DIFF
--- a/Database/Database Updates/027_client_release_contract.sql
+++ b/Database/Database Updates/027_client_release_contract.sql
@@ -1,0 +1,3 @@
+INSERT INTO `emulator_settings` (`key`, `value`, `comment`)
+VALUES ('client.release.allowed', 'NITRO-3-6-0', 'Comma-separated client release versions accepted before SSO login.')
+ON DUPLICATE KEY UPDATE `comment` = VALUES(`comment`);

--- a/Database/Default Database/FullDatabase.sql
+++ b/Database/Default Database/FullDatabase.sql
@@ -15151,6 +15151,7 @@ INSERT INTO `emulator_settings` (`key`, `value`, `comment`) VALUES
 	('hotel.welcome.alert.enabled', '0', 'Enable the welcome alert shown after login.'),
 	('hotel.welcome.alert.message', 'Welcome to Habbo Hotel %user%!', 'Message template used by the welcome alert.'),
 	('hotel.welcome.alert.oldstyle', '0', 'Use the legacy welcome alert window style.'),
+	('client.release.allowed', 'NITRO-3-6-0', 'Comma-separated client release versions accepted before SSO login.'),
 	('hotel.wordfilter.automute', '1', 'Mute duration in minutes applied when word-filter automute is triggered.'),
 	('hotel.wordfilter.enabled', '1', 'Enable the word filter system.'),
 	('hotel.wordfilter.messenger', '1', 'Apply the word filter to messenger messages.'),

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
@@ -29,6 +29,7 @@ public class GameClient {
     private boolean handshakeFinished;
     private String machineId = "";
     private String ssoTicket = "";
+    private String releaseVersion = "";
 
     public final ConcurrentHashMap<Integer, Integer> incomingPacketCounter = new ConcurrentHashMap<>(25);
     public final ConcurrentHashMap<Class<? extends MessageHandler>, Long> messageTimestamps = new ConcurrentHashMap<>();
@@ -91,6 +92,14 @@ public class GameClient {
 
     public void setSsoTicket(String ssoTicket) {
         this.ssoTicket = ssoTicket != null ? ssoTicket : "";
+    }
+
+    public String getReleaseVersion() {
+        return this.releaseVersion;
+    }
+
+    public void setReleaseVersion(String releaseVersion) {
+        this.releaseVersion = releaseVersion != null ? releaseVersion : "";
     }
 
     public void sendResponse(MessageComposer composer) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/ClientReleaseGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/ClientReleaseGuard.java
@@ -1,0 +1,32 @@
+package com.eu.habbo.messages.incoming.handshake;
+
+import java.util.Arrays;
+
+final class ClientReleaseGuard {
+    static final String DEFAULT_ALLOWED_RELEASES = "NITRO-3-6-0";
+    private static final int MAX_RELEASE_LENGTH = 64;
+
+    private ClientReleaseGuard() {
+    }
+
+    static String normalize(String release) {
+        return release == null ? "" : release.trim();
+    }
+
+    static boolean isAllowed(String release, String configuredReleases) {
+        String normalized = normalize(release);
+        if (normalized.isEmpty() || normalized.length() > MAX_RELEASE_LENGTH
+                || !normalized.matches("[A-Za-z0-9][A-Za-z0-9._-]*")) {
+            return false;
+        }
+
+        String allowed = normalize(configuredReleases);
+        if (allowed.isEmpty()) {
+            allowed = DEFAULT_ALLOWED_RELEASES;
+        }
+
+        return Arrays.stream(allowed.split("[;,]"))
+                .map(ClientReleaseGuard::normalize)
+                .anyMatch(normalized::equalsIgnoreCase);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/ReleaseVersionEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/ReleaseVersionEvent.java
@@ -8,6 +8,6 @@ public class ReleaseVersionEvent extends MessageHandler {
 
     @Override
     public void handle() throws Exception {
-        this.packet.readString();
+        this.client.setReleaseVersion(ClientReleaseGuard.normalize(this.packet.readString()));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
@@ -74,6 +74,15 @@ public class SecureLoginEvent extends MessageHandler {
             return;
         }
 
+        String allowedReleases = Emulator.getConfig().getValue(
+                "client.release.allowed", ClientReleaseGuard.DEFAULT_ALLOWED_RELEASES);
+        if (!ClientReleaseGuard.isAllowed(this.client.getReleaseVersion(), allowedReleases)) {
+            LOGGER.warn("Rejected client release '{}' (allowed: '{}')",
+                    this.client.getReleaseVersion(), allowedReleases);
+            Emulator.getGameServer().getGameClientManager().disposeClient(this.client);
+            return;
+        }
+
         String sso = SecureLoginInputGuard.normalizeSsoTicket(this.packet.readString());
 
         if (!SecureLoginInputGuard.isValidSsoTicket(sso)) {

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/handshake/ClientReleaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/handshake/ClientReleaseContractTest.java
@@ -1,0 +1,45 @@
+package com.eu.habbo.messages.incoming.handshake;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientReleaseContractTest {
+    @Test
+    void releaseGuardMatchesExactConfiguredVersions() throws Exception {
+        Class<?> guard = assertDoesNotThrow(() -> Class.forName(
+                "com.eu.habbo.messages.incoming.handshake.ClientReleaseGuard"));
+        Method isAllowed = guard.getDeclaredMethod("isAllowed", String.class, String.class);
+        isAllowed.setAccessible(true);
+
+        assertTrue((boolean) isAllowed.invoke(null, "NITRO-3-6-0", "NITRO-3-6-0"));
+        assertTrue((boolean) isAllowed.invoke(null, "NITRO-3-6-0", "LEGACY-1,NITRO-3-6-0"));
+        assertFalse((boolean) isAllowed.invoke(null, "NITRO-3-5-0", "NITRO-3-6-0"));
+        assertFalse((boolean) isAllowed.invoke(null, "", "NITRO-3-6-0"));
+        assertFalse((boolean) isAllowed.invoke(null, "NITRO-3-6-0\nFORGED", "NITRO-3-6-0"));
+    }
+
+    @Test
+    void releaseIsStoredBeforeSecureLoginAndCheckedBeforeSsoLookup() throws Exception {
+        String release = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/messages/incoming/handshake/ReleaseVersionEvent.java"));
+        String login = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java"));
+        String client = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java"));
+
+        assertTrue(release.contains("setReleaseVersion"));
+        assertTrue(client.contains("private String releaseVersion"));
+
+        int releaseCheck = login.indexOf("ClientReleaseGuard.isAllowed");
+        int ssoRead = login.indexOf("this.packet.readString()");
+        assertTrue(releaseCheck > -1 && releaseCheck < ssoRead,
+                "client release must be accepted before the SSO ticket is consumed");
+    }
+}


### PR DESCRIPTION
## Summary
- store the renderer release announced during the initial handshake
- reject missing, malformed, or unsupported releases before reading the SSO ticket
- add an exact configurable allow-list with the current Nitro release as default

## Verification
- mvn clean package (465 tests, before rebase)
- mvn '-Dtest=ClientReleaseContractTest,AuthTokenGuardContractTest' test (4 tests, after rebase)