### PR TITLE
Centralize generic error protocol codes

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -29,6 +29,7 @@ import com.eu.habbo.habbohotel.users.*;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.messages.incoming.users.UserNuxEvent;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorCode;
 import com.eu.habbo.messages.outgoing.hotelview.HotelViewComposer;
 import com.eu.habbo.messages.outgoing.polls.PollStartComposer;
 import com.eu.habbo.messages.outgoing.polls.infobus.SimplePollAnswersComposer;
@@ -619,7 +620,7 @@ public class RoomManager {
             if (room.getPassword().equalsIgnoreCase(password))
                 this.openRoom(habbo, room, doorLocation, isReconnectSpawn);
             else {
-                habbo.getClient().sendResponse(new GenericErrorMessagesComposer(GenericErrorMessagesComposer.WRONG_PASSWORD_USED));
+                habbo.getClient().sendResponse(new GenericErrorMessagesComposer(GenericErrorCode.WRONG_ROOM_PASSWORD));
                 habbo.getClient().sendResponse(new HotelViewComposer());
                 habbo.getHabboInfo().setLoadingRoom(0);
             }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomUnitManager.java
@@ -18,6 +18,7 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredMoveCarryHelper;
 import com.eu.habbo.habbohotel.wired.core.WiredUserMovementHelper;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorMessagesComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericErrorCode;
 import com.eu.habbo.messages.outgoing.inventory.AddPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.pets.RoomPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.*;
@@ -228,7 +229,7 @@ public class RoomUnitManager {
      public void kickHabbo(Habbo habbo, boolean alert) {
         if (alert) {
             habbo.getClient().sendResponse(
-                    new GenericErrorMessagesComposer(GenericErrorMessagesComposer.KICKED_OUT_OF_THE_ROOM));
+                    new GenericErrorMessagesComposer(GenericErrorCode.KICKED_OUT_OF_ROOM));
         }
 
         habbo.getRoomUnit().isKicked = true;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/generic/alerts/GenericErrorCode.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/generic/alerts/GenericErrorCode.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.messages.outgoing.generic.alerts;
+
+public enum GenericErrorCode {
+    AUTHENTICATION_FAILED(-3),
+    CONNECTING_TO_SERVER_FAILED(-400),
+    KICKED_OUT_OF_ROOM(4008),
+    VIP_REQUIRED(4009),
+    ROOM_NAME_UNACCEPTABLE(4010),
+    CANNOT_BAN_GROUP_MEMBER(4011),
+    WRONG_ROOM_PASSWORD(-100002),
+    TRADE_STRIP_LOCKED(-13001);
+
+    private final int code;
+
+    GenericErrorCode(int code) {
+        this.code = code;
+    }
+
+    public int code() {
+        return this.code;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/generic/alerts/GenericErrorMessagesComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/generic/alerts/GenericErrorMessagesComposer.java
@@ -5,18 +5,29 @@ import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 
 public class GenericErrorMessagesComposer extends MessageComposer {
-    public static final int AUTHENTICATION_FAILED = -3;
-    public static final int CONNECTING_TO_THE_SERVER_FAILED = -400;
-    public static final int KICKED_OUT_OF_THE_ROOM = 4008;
-    public static final int NEED_TO_BE_VIP = 4009;
-    public static final int ROOM_NAME_UNACCEPTABLE = 4010;
-    public static final int CANNOT_BAN_GROUP_MEMBER = 4011;
-    public static final int WRONG_PASSWORD_USED = -100002;
+    /** @deprecated Use {@link GenericErrorCode#AUTHENTICATION_FAILED}. */
+    @Deprecated public static final int AUTHENTICATION_FAILED = GenericErrorCode.AUTHENTICATION_FAILED.code();
+    /** @deprecated Use {@link GenericErrorCode#CONNECTING_TO_SERVER_FAILED}. */
+    @Deprecated public static final int CONNECTING_TO_THE_SERVER_FAILED = GenericErrorCode.CONNECTING_TO_SERVER_FAILED.code();
+    /** @deprecated Use {@link GenericErrorCode#KICKED_OUT_OF_ROOM}. */
+    @Deprecated public static final int KICKED_OUT_OF_THE_ROOM = GenericErrorCode.KICKED_OUT_OF_ROOM.code();
+    /** @deprecated Use {@link GenericErrorCode#VIP_REQUIRED}. */
+    @Deprecated public static final int NEED_TO_BE_VIP = GenericErrorCode.VIP_REQUIRED.code();
+    /** @deprecated Use {@link GenericErrorCode#ROOM_NAME_UNACCEPTABLE}. */
+    @Deprecated public static final int ROOM_NAME_UNACCEPTABLE = GenericErrorCode.ROOM_NAME_UNACCEPTABLE.code();
+    /** @deprecated Use {@link GenericErrorCode#CANNOT_BAN_GROUP_MEMBER}. */
+    @Deprecated public static final int CANNOT_BAN_GROUP_MEMBER = GenericErrorCode.CANNOT_BAN_GROUP_MEMBER.code();
+    /** @deprecated Use {@link GenericErrorCode#WRONG_ROOM_PASSWORD}. */
+    @Deprecated public static final int WRONG_PASSWORD_USED = GenericErrorCode.WRONG_ROOM_PASSWORD.code();
 
     private final int errorCode;
 
     public GenericErrorMessagesComposer(int errorCode) {
         this.errorCode = errorCode;
+    }
+
+    public GenericErrorMessagesComposer(GenericErrorCode errorCode) {
+        this(errorCode.code());
     }
 
     @Override

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/generic/alerts/GenericErrorCodeContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/generic/alerts/GenericErrorCodeContractTest.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.outgoing.generic.alerts;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GenericErrorCodeContractTest {
+    @Test
+    void definesTheStableGenericErrorProtocolCodes() {
+        assertEquals(-3, GenericErrorCode.AUTHENTICATION_FAILED.code());
+        assertEquals(-400, GenericErrorCode.CONNECTING_TO_SERVER_FAILED.code());
+        assertEquals(4008, GenericErrorCode.KICKED_OUT_OF_ROOM.code());
+        assertEquals(4009, GenericErrorCode.VIP_REQUIRED.code());
+        assertEquals(4010, GenericErrorCode.ROOM_NAME_UNACCEPTABLE.code());
+        assertEquals(4011, GenericErrorCode.CANNOT_BAN_GROUP_MEMBER.code());
+        assertEquals(-100002, GenericErrorCode.WRONG_ROOM_PASSWORD.code());
+        assertEquals(-13001, GenericErrorCode.TRADE_STRIP_LOCKED.code());
+    }
+
+    @Test
+    void protocolCodesAreUnique() {
+        Set<Integer> uniqueCodes = Arrays.stream(GenericErrorCode.values())
+                .map(GenericErrorCode::code)
+                .collect(Collectors.toSet());
+
+        assertEquals(GenericErrorCode.values().length, uniqueCodes.size());
+    }
+
+    @Test
+    void composerAcceptsTheTypedProtocolCode() {
+        GenericErrorMessagesComposer composer =
+                new GenericErrorMessagesComposer(GenericErrorCode.WRONG_ROOM_PASSWORD);
+
+        assertEquals(GenericErrorCode.WRONG_ROOM_PASSWORD.code(), composer.getErrorCode());
+    }
+}


### PR DESCRIPTION
Protocol companion PRs: renderer duckietm/Nitro_Render_V3#125 and UI duckietm/Nitro-V3#322. Introduces the authoritative Java GenericError catalog while preserving legacy plugin aliases. Verification: targeted contract tests pass; emulator CI is green.