### PR TITLE
build: complete RCON and artifact handoff contracts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Build JAR
         run: mvn -B clean package -DskipTests
 
+      - name: Generate SHA-256 checksum
+        run: |
+          JAR="target/Polaris-${{ steps.bump.outputs.new_version }}-jar-with-dependencies.jar"
+          sha256sum "$JAR" > "$JAR.sha256"
+
       - name: Commit bumped pom.xml
         run: |
           git config user.name  "github-actions[bot]"
@@ -76,4 +81,6 @@ jobs:
           tag_name: v${{ steps.bump.outputs.new_version }}
           name: Release v${{ steps.bump.outputs.new_version }}
           body_path: release_notes.md
-          files: Emulator/target/Habbo-${{ steps.bump.outputs.new_version }}-jar-with-dependencies.jar
+          files: |
+            Emulator/target/Polaris-${{ steps.bump.outputs.new_version }}-jar-with-dependencies.jar
+            Emulator/target/Polaris-${{ steps.bump.outputs.new_version }}-jar-with-dependencies.jar.sha256

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Verify local build handoff
         shell: pwsh
-        run: ./scripts/build-latest.test.ps1
+        run: ../scripts/build-latest.test.ps1
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Verify local build handoff
+        shell: pwsh
+        run: ./scripts/build-latest.test.ps1
+
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServer.java
@@ -110,7 +110,7 @@ public class RCONServer extends Server {
     public String handle(ChannelHandlerContext ctx, String key, String body) throws Exception {
         if (!this.acquirePermit(ctx)) {
             LOGGER.warn("RCON rate limit exceeded for {}", remoteAddress(ctx));
-            return "RATE_LIMITED";
+            return RconResponse.error(RCONMessage.STATUS_ERROR, "rate limited").toJson(this.gsonBuilder.create());
         }
 
         Class<? extends RCONMessage> message = this.messages.get(key.replace("_", "").toLowerCase());
@@ -137,9 +137,10 @@ public class RCONServer extends Server {
             }
         } else {
             LOGGER.error("Couldn't find: {}", key);
+            return RconResponse.error(RCONMessage.STATUS_ERROR, "unknown command").toJson(this.gsonBuilder.create());
         }
 
-        throw new ArrayIndexOutOfBoundsException("Unhandled RCON Message");
+        return RconResponse.error(RCONMessage.SYSTEM_ERROR, "command failed").toJson(this.gsonBuilder.create());
     }
 
     public List<String> getCommands() {

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java
@@ -50,7 +50,9 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
             int readableBytes = data.readableBytes();
             int maxPayloadBytes = maxPayloadBytes();
             if (readableBytes > maxPayloadBytes) {
-                writeAndClose(ctx, "PAYLOAD_TOO_LARGE");
+                writeAndClose(ctx, RconResponse.error(
+                        com.eu.habbo.messages.rcon.RCONMessage.STATUS_ERROR,
+                        "payload too large").toJson(GSON));
                 LOGGER.warn("Rejected oversized RCON payload: {} bytes (max {})", readableBytes, maxPayloadBytes);
                 return;
             }
@@ -59,7 +61,9 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
             data.getBytes(0, d);
             String message = new String(d, java.nio.charset.StandardCharsets.UTF_8);
             Gson gson = GSON;
-            String response = "ERROR";
+            String response = RconResponse.error(
+                    com.eu.habbo.messages.rcon.RCONMessage.STATUS_ERROR,
+                    "invalid request").toJson(GSON);
             String key = "";
             try {
                 JsonObject object = gson.fromJson(message, JsonObject.class);
@@ -69,7 +73,7 @@ public class RCONServerHandler extends ChannelInboundHandlerAdapter {
                 LOGGER.error("Unknown RCON Message: {}", key);
             } catch (Exception e) {
                 LOGGER.error("Invalid RCON Message: {}", message);
-            LOGGER.error("Caught exception", e);
+                LOGGER.error("Caught exception", e);
             }
 
             writeAndClose(ctx, response);

--- a/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RconResponse.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/rconserver/RconResponse.java
@@ -1,0 +1,18 @@
+package com.eu.habbo.networking.rconserver;
+
+import com.eu.habbo.messages.rcon.RCONMessage;
+import com.google.gson.Gson;
+
+record RconResponse(int status, String message) {
+    static RconResponse success() {
+        return new RconResponse(RCONMessage.STATUS_OK, "");
+    }
+
+    static RconResponse error(int status, String message) {
+        return new RconResponse(status, message == null ? "" : message);
+    }
+
+    String toJson(Gson gson) {
+        return gson.toJson(this);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RCONServerHandlerContractTest.java
@@ -30,8 +30,10 @@ class RCONServerHandlerContractTest {
                 "RCON rate limiters must expire instead of growing forever");
         assertTrue(source.contains(".acquirePermission()"),
                 "RCON handler must consume a Resilience4j permit before dispatching commands");
-        assertTrue(source.contains("RATE_LIMITED"),
-                "RCON callers need a deterministic response when the rate limit rejects a request");
+        assertTrue(source.contains("RconResponse.error"),
+                "RCON rate-limit failures must use the shared JSON response envelope");
+        assertTrue(source.contains("rate limited"),
+                "RCON callers need a deterministic message when the rate limit rejects a request");
     }
 
     @Test
@@ -68,8 +70,10 @@ class RCONServerHandlerContractTest {
         assertTrue(maxPayload > readableBytes, "RCON handler must resolve max payload before allocation");
         assertTrue(oversizedGuard > maxPayload, "RCON handler must reject oversized payloads");
         assertTrue(oversizedGuard < byteArray, "Oversized RCON payloads must be rejected before byte array allocation");
-        assertTrue(handler.contains("PAYLOAD_TOO_LARGE"),
-                "RCON callers need a deterministic response for oversized payloads");
+        assertTrue(handler.contains("RconResponse.error"),
+                "Oversized payload failures must use the shared JSON response envelope");
+        assertTrue(handler.contains("payload too large"),
+                "RCON callers need a deterministic message for oversized payloads");
         assertTrue(emulator.contains("register(\"rcon.max_payload_bytes\", \"65536\")"),
                 "RCON max payload default must be registered before startup");
     }

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RconProtocolManifestTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RconProtocolManifestTest.java
@@ -1,0 +1,59 @@
+package com.eu.habbo.networking.rconserver;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RconProtocolManifestTest {
+    private static final Path MANIFEST = Path.of("../protocol/rcon-contract.json");
+    private static final Path SERVER = Path.of("src/main/java/com/eu/habbo/networking/rconserver/RCONServer.java");
+    private static final Pattern REGISTRATION = Pattern.compile("addRCONMessage\\(\"([^\"]+)\"");
+
+    @Test
+    void manifestDefinesTheStableWireEnvelope() throws Exception {
+        JsonObject manifest = readManifest();
+
+        assertEquals(1, manifest.get("version").getAsInt());
+        assertEquals(Set.of("key", "data"), keys(manifest.getAsJsonObject("request")));
+        assertEquals(Set.of("status", "message"), keys(manifest.getAsJsonObject("response")));
+        assertEquals("remove underscores and lowercase", manifest.get("commandNormalization").getAsString());
+        assertEquals(0, manifest.getAsJsonObject("statuses").get("ok").getAsInt());
+        assertEquals(1, manifest.getAsJsonObject("statuses").get("error").getAsInt());
+        assertEquals(2, manifest.getAsJsonObject("statuses").get("systemError").getAsInt());
+    }
+
+    @Test
+    void manifestCommandsExactlyMatchServerRegistrations() throws Exception {
+        Set<String> registered = new LinkedHashSet<>();
+        Matcher matcher = REGISTRATION.matcher(Files.readString(SERVER));
+        while (matcher.find()) registered.add(matcher.group(1));
+
+        JsonArray commands = readManifest().getAsJsonArray("commands");
+        Set<String> documented = new LinkedHashSet<>();
+        commands.forEach(command -> documented.add(command.getAsString()));
+
+        assertEquals(commands.size(), documented.size(), "RCON manifest must not contain duplicate commands");
+        assertEquals(registered, documented,
+                "Every server command must be documented and removed commands must leave the manifest");
+    }
+
+    private static JsonObject readManifest() throws Exception {
+        assertTrue(Files.isRegularFile(MANIFEST), "Missing versioned RCON contract: " + MANIFEST);
+        return JsonParser.parseString(Files.readString(MANIFEST)).getAsJsonObject();
+    }
+
+    private static Set<String> keys(JsonObject object) {
+        return object.keySet();
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RconResponseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/rconserver/RconResponseContractTest.java
@@ -1,0 +1,42 @@
+package com.eu.habbo.networking.rconserver;
+
+import com.eu.habbo.messages.rcon.RCONMessage;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RconResponseContractTest {
+    private final Gson gson = new Gson();
+
+    @Test
+    void infrastructureErrorsUseTheSameJsonEnvelopeAsCommandResponses() {
+        String json = RconResponse.error(RCONMessage.STATUS_ERROR, "rate limited").toJson(gson);
+        JsonObject response = gson.fromJson(json, JsonObject.class);
+
+        assertEquals(RCONMessage.STATUS_ERROR, response.get("status").getAsInt());
+        assertEquals("rate limited", response.get("message").getAsString());
+        assertEquals(2, response.size());
+    }
+
+    @Test
+    void infrastructureSuccessUsesStatusZero() {
+        JsonObject response = gson.fromJson(RconResponse.success().toJson(gson), JsonObject.class);
+
+        assertEquals(RCONMessage.STATUS_OK, response.get("status").getAsInt());
+        assertEquals("", response.get("message").getAsString());
+    }
+
+    @Test
+    void handlerAndServerDoNotReturnLegacyPlainTextErrors() throws Exception {
+        String handler = java.nio.file.Files.readString(java.nio.file.Path.of(
+                "src/main/java/com/eu/habbo/networking/rconserver/RCONServerHandler.java"));
+        String server = java.nio.file.Files.readString(java.nio.file.Path.of(
+                "src/main/java/com/eu/habbo/networking/rconserver/RCONServer.java"));
+
+        assertTrue(handler.contains("RconResponse.error"));
+        assertTrue(server.contains("RconResponse.error"));
+    }
+}

--- a/protocol/rcon-contract.json
+++ b/protocol/rcon-contract.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "transport": "tcp-json",
+  "request": {
+    "key": "string",
+    "data": "object"
+  },
+  "response": {
+    "status": "integer",
+    "message": "string"
+  },
+  "statuses": {
+    "ok": 0,
+    "error": 1,
+    "systemError": 2
+  },
+  "commandNormalization": "remove underscores and lowercase",
+  "commands": [
+    "alertuser",
+    "disconnect",
+    "forwarduser",
+    "givebadge",
+    "givecredits",
+    "givepixels",
+    "givepoints",
+    "hotelalert",
+    "sendgift",
+    "sendroombundle",
+    "setrank",
+    "updatewordfilter",
+    "updatewheel",
+    "updatesoundboard",
+    "updatecatalog",
+    "executecommand",
+    "progressachievement",
+    "updateuser",
+    "friendrequest",
+    "imagehotelalert",
+    "imagealertuser",
+    "stalkuser",
+    "staffalert",
+    "modticket",
+    "talkuser",
+    "changeroomowner",
+    "muteuser",
+    "giverespect",
+    "ignoreuser",
+    "setmotto",
+    "giveuserclothing",
+    "modifysubscription",
+    "changeusername",
+    "updateitems"
+  ]
+}

--- a/scripts/build-latest.ps1
+++ b/scripts/build-latest.ps1
@@ -1,0 +1,65 @@
+[CmdletBinding()]
+param(
+    [string]$Destination,
+    [switch]$SkipTests,
+    [string]$SourceJar
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$moduleRoot = Join-Path $repoRoot 'Emulator'
+
+if([string]::IsNullOrWhiteSpace($Destination)) {
+    $Destination = Join-Path $repoRoot 'Latest_Compiled_Version'
+}
+
+if([string]::IsNullOrWhiteSpace($SourceJar)) {
+    Push-Location $moduleRoot
+    try {
+        $mavenArguments = @('-B', 'clean', 'package')
+        if($SkipTests) { $mavenArguments += '-DskipTests' }
+        & mvn @mavenArguments
+        if($LASTEXITCODE -ne 0) { throw "Maven build failed with exit code $LASTEXITCODE" }
+    }
+    finally {
+        Pop-Location
+    }
+
+    [xml]$pom = Get-Content -Raw -LiteralPath (Join-Path $moduleRoot 'pom.xml')
+    $artifactId = [string]$pom.project.artifactId
+    $version = [string]$pom.project.version
+    $SourceJar = Join-Path $moduleRoot "target\$artifactId-$version-jar-with-dependencies.jar"
+}
+
+$sourcePath = [System.IO.Path]::GetFullPath($SourceJar)
+$destinationPath = [System.IO.Path]::GetFullPath($Destination)
+if(!(Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+    throw "Built JAR not found: $sourcePath"
+}
+
+New-Item -ItemType Directory -Path $destinationPath -Force | Out-Null
+$fileName = Split-Path $sourcePath -Leaf
+$finalJar = Join-Path $destinationPath $fileName
+$temporaryJar = "$finalJar.tmp-$PID"
+$finalHash = "$finalJar.sha256"
+$temporaryHash = "$finalHash.tmp-$PID"
+
+try {
+    Copy-Item -LiteralPath $sourcePath -Destination $temporaryJar -Force
+    Move-Item -LiteralPath $temporaryJar -Destination $finalJar -Force
+
+    $hash = (Get-FileHash -LiteralPath $finalJar -Algorithm SHA256).Hash.ToLowerInvariant()
+    $checksum = "$hash  $fileName$([Environment]::NewLine)"
+    [System.IO.File]::WriteAllText(
+        $temporaryHash,
+        $checksum,
+        [System.Text.UTF8Encoding]::new($false))
+    Move-Item -LiteralPath $temporaryHash -Destination $finalHash -Force
+}
+finally {
+    Remove-Item -LiteralPath $temporaryJar -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $temporaryHash -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output "JAR: $finalJar"
+Write-Output "SHA256: $finalHash"

--- a/scripts/build-latest.test.ps1
+++ b/scripts/build-latest.test.ps1
@@ -1,0 +1,44 @@
+$ErrorActionPreference = 'Stop'
+
+$script = Join-Path $PSScriptRoot 'build-latest.ps1'
+$temporary = Join-Path ([System.IO.Path]::GetTempPath()) ("polaris-build-latest-" + [guid]::NewGuid())
+$sourceDirectory = Join-Path $temporary 'source'
+$destination = Join-Path $temporary 'latest'
+$source = Join-Path $sourceDirectory 'Polaris-4.2.50-jar-with-dependencies.jar'
+
+try {
+    New-Item -ItemType Directory -Path $sourceDirectory -Force | Out-Null
+    [System.IO.File]::WriteAllBytes($source, [byte[]](1, 2, 3, 4, 5, 255))
+
+    & $script -SourceJar $source -Destination $destination
+
+    $copy = Join-Path $destination (Split-Path $source -Leaf)
+    $hashFile = "$copy.sha256"
+    if(!(Test-Path -LiteralPath $copy)) { throw "Copied JAR is missing: $copy" }
+    if(!(Test-Path -LiteralPath $hashFile)) { throw "SHA-256 file is missing: $hashFile" }
+
+    $sourceHash = (Get-FileHash -LiteralPath $source -Algorithm SHA256).Hash.ToLowerInvariant()
+    $copyHash = (Get-FileHash -LiteralPath $copy -Algorithm SHA256).Hash.ToLowerInvariant()
+    if($sourceHash -ne $copyHash) { throw 'Copied JAR hash differs from source' }
+
+    $expected = "$sourceHash  $(Split-Path $copy -Leaf)"
+    $actual = (Get-Content -Raw -LiteralPath $hashFile).Trim()
+    if($actual -ne $expected) { throw "Unexpected checksum file: $actual" }
+
+    $ci = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot '..\.github\workflows\ci.yml')
+    if($ci -notmatch 'build-latest\.test\.ps1') {
+        throw 'CI does not run the build-latest contract test'
+    }
+
+    $release = Get-Content -Raw -LiteralPath (Join-Path $PSScriptRoot '..\.github\workflows\build-release.yml')
+    if($release -notmatch 'sha256sum' -or $release -notmatch '\.sha256') {
+        throw 'Release workflow does not publish the SHA-256 file'
+    }
+
+    Write-Output 'build-latest contract verified.'
+}
+finally {
+    if(Test-Path -LiteralPath $temporary) {
+        Remove-Item -LiteralPath $temporary -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary

- return structured JSON envelopes for RCON infrastructure errors
- publish a versioned request/response and command manifest for housekeeping consumers
- enforce manifest parity with every registered RCON command
- add a reproducible Java 25 build handoff into Latest_Compiled_Version
- require the RCON and artifact contracts in CI and release builds

## Verification

- mvn -B verify: 589 tests, 0 failures, 0 errors, 1 skipped
- scripts/build-latest.test.ps1
- real artifact handoff verified with matching SHA-256 hashes

## Contract

Consumers can validate against protocol/rcon-contract.json; CI fails when the server command registry or stable envelope drifts.