### PR TITLE
feat: complete P1 database and economy integrity

### DIFF
--- a/Database/Database Updates/028_immutable_economy_ledger.sql
+++ b/Database/Database Updates/028_immutable_economy_ledger.sql
@@ -1,0 +1,17 @@
+ALTER TABLE `logs_economy`
+    ADD COLUMN IF NOT EXISTS `actor_id` INT UNSIGNED NULL AFTER `user_id`,
+    ADD COLUMN IF NOT EXISTS `reason` VARCHAR(96) NOT NULL DEFAULT 'legacy.unspecified' AFTER `operation`,
+    ADD INDEX IF NOT EXISTS `idx_logs_economy_actor_created` (`actor_id`, `created_at`),
+    ADD INDEX IF NOT EXISTS `idx_logs_economy_reason_created` (`reason`, `created_at`);
+
+DROP TRIGGER IF EXISTS `logs_economy_immutable_update`;
+CREATE TRIGGER `logs_economy_immutable_update`
+    BEFORE UPDATE ON `logs_economy`
+    FOR EACH ROW
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'logs_economy is append-only';
+
+DROP TRIGGER IF EXISTS `logs_economy_immutable_delete`;
+CREATE TRIGGER `logs_economy_immutable_delete`
+    BEFORE DELETE ON `logs_economy`
+    FOR EACH ROW
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'logs_economy is append-only';

--- a/Emulator/src/main/java/com/eu/habbo/database/compat/MariaDbSqlCompatibilityAudit.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/compat/MariaDbSqlCompatibilityAudit.java
@@ -1,0 +1,161 @@
+package com.eu.habbo.database.compat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public final class MariaDbSqlCompatibilityAudit {
+    private static final List<Rule> RULES = List.of(
+            new Rule("PostgreSQL ILIKE", Pattern.compile("\\bILIKE\\b", Pattern.CASE_INSENSITIVE)),
+            new Rule("PostgreSQL NULLS FIRST/LAST", Pattern.compile("\\bNULLS\\s+(?:FIRST|LAST)\\b", Pattern.CASE_INSENSITIVE)),
+            new Rule("SQLite INSERT OR IGNORE/REPLACE", Pattern.compile("\\bINSERT\\s+OR\\s+(?:IGNORE|REPLACE)\\b", Pattern.CASE_INSENSITIVE)),
+            new Rule("SQLite AUTOINCREMENT", Pattern.compile("\\bAUTOINCREMENT\\b", Pattern.CASE_INSENSITIVE)),
+            new Rule("PostgreSQL ON CONFLICT", Pattern.compile("\\bON\\s+CONFLICT\\b", Pattern.CASE_INSENSITIVE)),
+            new Rule("PostgreSQL FILTER WHERE", Pattern.compile("\\bFILTER\\s*\\(\\s*WHERE\\b", Pattern.CASE_INSENSITIVE)),
+            new Rule("PostgreSQL cast operator", Pattern.compile("::\\s*[a-z][a-z0-9_]*", Pattern.CASE_INSENSITIVE)),
+            new Rule("reserved ROW_NUMBER alias", Pattern.compile("\\bAS\\s+ROW_NUMBER\\b", Pattern.CASE_INSENSITIVE))
+    );
+
+    private MariaDbSqlCompatibilityAudit() {
+    }
+
+    public static List<Finding> scanRepository(Path repositoryRoot) throws IOException {
+        List<Path> files = new ArrayList<>();
+        collect(files, repositoryRoot.resolve("Emulator/src/main/java"), ".java", true);
+        collect(files, repositoryRoot.resolve("Database/Database Updates"), ".sql", false);
+        files.removeIf(path -> path.getFileName().toString().equals("MariaDbSqlCompatibilityAudit.java"));
+        files.sort(Comparator.comparing(Path::toString));
+
+        List<Finding> findings = new ArrayList<>();
+        for (Path file : files) {
+            String location = repositoryRoot.relativize(file).toString().replace('\\', '/');
+            String source = Files.readString(file);
+            findings.addAll(file.getFileName().toString().endsWith(".java")
+                    ? scanJavaStrings(location, source)
+                    : scan(location, source));
+        }
+        return List.copyOf(findings);
+    }
+
+    public static List<Finding> scan(String location, String sql) {
+        return scan(location, sql, 1);
+    }
+
+    private static List<Finding> scan(String location, String sql, int firstLine) {
+        List<Finding> findings = new ArrayList<>();
+        String[] lines = sql.split("\\R", -1);
+        for (int lineNumber = 0; lineNumber < lines.length; lineNumber++) {
+            String line = lines[lineNumber];
+            for (Rule rule : RULES) {
+                if (rule.pattern().matcher(line).find()) {
+                    findings.add(new Finding(location + ":" + (firstLine + lineNumber), rule.description(), line.strip()));
+                }
+            }
+        }
+        return List.copyOf(findings);
+    }
+
+    private static List<Finding> scanJavaStrings(String location, String source) {
+        List<Finding> findings = new ArrayList<>();
+        int line = 1;
+        for (int index = 0; index < source.length();) {
+            char current = source.charAt(index);
+            if (current == '\n') {
+                line++;
+                index++;
+                continue;
+            }
+            if (current == '/' && index + 1 < source.length() && source.charAt(index + 1) == '/') {
+                index += 2;
+                while (index < source.length() && source.charAt(index) != '\n') index++;
+                continue;
+            }
+            if (current == '/' && index + 1 < source.length() && source.charAt(index + 1) == '*') {
+                index += 2;
+                while (index + 1 < source.length()
+                        && !(source.charAt(index) == '*' && source.charAt(index + 1) == '/')) {
+                    if (source.charAt(index++) == '\n') line++;
+                }
+                index = Math.min(source.length(), index + 2);
+                continue;
+            }
+            if (current == '\'' ) {
+                index = skipQuoted(source, index + 1, '\'');
+                continue;
+            }
+            if (current != '"') {
+                index++;
+                continue;
+            }
+
+            boolean textBlock = index + 2 < source.length()
+                    && source.charAt(index + 1) == '"' && source.charAt(index + 2) == '"';
+            int startLine = line;
+            int contentStart = index + (textBlock ? 3 : 1);
+            int end = contentStart;
+            if (textBlock) {
+                while (end + 2 < source.length()
+                        && !(source.charAt(end) == '"' && source.charAt(end + 1) == '"'
+                        && source.charAt(end + 2) == '"')) {
+                    if (source.charAt(end++) == '\n') line++;
+                }
+            } else {
+                boolean escaped = false;
+                while (end < source.length()) {
+                    char value = source.charAt(end);
+                    if (value == '\n') line++;
+                    if (!escaped && value == '"') break;
+                    escaped = !escaped && value == '\\';
+                    if (value != '\\') escaped = false;
+                    end++;
+                }
+            }
+
+            String literal = source.substring(contentStart, Math.min(end, source.length()));
+            if (looksLikeSql(literal)) findings.addAll(scan(location, literal, startLine));
+            index = Math.min(source.length(), end + (textBlock ? 3 : 1));
+        }
+        return findings;
+    }
+
+    private static int skipQuoted(String source, int index, char delimiter) {
+        boolean escaped = false;
+        while (index < source.length()) {
+            char value = source.charAt(index++);
+            if (!escaped && value == delimiter) break;
+            escaped = !escaped && value == '\\';
+            if (value != '\\') escaped = false;
+        }
+        return index;
+    }
+
+    private static boolean looksLikeSql(String value) {
+        return Pattern.compile("\\b(?:SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|WITH|MERGE|REPLACE)\\b",
+                Pattern.CASE_INSENSITIVE).matcher(value).find();
+    }
+
+    private static void collect(List<Path> target, Path root, String suffix, boolean recursive) throws IOException {
+        if (!Files.isDirectory(root)) return;
+        try (Stream<Path> paths = recursive ? Files.walk(root) : Files.list(root)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(suffix))
+                    .forEach(target::add);
+        }
+    }
+
+    private record Rule(String description, Pattern pattern) {
+    }
+
+    public record Finding(String location, String rule, String source) {
+        @Override
+        public String toString() {
+            return location + " [" + rule + "] " + source;
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.bots.Bot;
 import com.eu.habbo.habbohotel.catalog.layouts.*;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.guilds.Guild;
 import com.eu.habbo.habbohotel.items.FurnitureType;
@@ -474,6 +475,11 @@ public class CatalogManager {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); Statement statement = connection.createStatement(); ResultSet set = statement.executeQuery("SELECT * FROM catalog_items")) {
             CatalogItem item;
             while (set.next()) {
+                List<String> valueErrors = CatalogValueValidator.validate(CatalogValueValidator.Values.from(set));
+                if (!valueErrors.isEmpty()) {
+                    valueErrors.forEach(error -> LOGGER.error("Catalog value validation: {}", error));
+                    continue;
+                }
                 if (set.getString("item_ids").equals("0"))
                     continue;
 
@@ -1431,8 +1437,10 @@ public class CatalogManager {
     private void purchaseBotsAndPetsAtomically(CatalogItem item, Habbo habbo, int amount, String extraData,
                                                boolean free, int totalCredits, int totalPoints) throws SQLException {
         String[] petData = extraData.split("\n");
+        String operationId = EconomyOperationId.create(
+                "catalog:" + habbo.getHabboInfo().getId() + ":" + item.getId());
         SpecialCompanionPurchase purchase = CatalogPurchaseTransaction.execute(
-                habbo.getHabboInfo().getId(), connection -> {
+                habbo.getHabboInfo().getId(), operationId, connection -> {
                     List<Bot> bots = new ArrayList<>();
                     List<Pet> pets = new ArrayList<>();
                     for (int index = 0; index < amount; index++) {
@@ -1528,7 +1536,10 @@ public class CatalogManager {
             }
         }
 
-        EntitlementPurchase purchase = CatalogPurchaseTransaction.execute(habbo.getHabboInfo().getId(), connection -> {
+        String operationId = EconomyOperationId.create(
+                "catalog:" + habbo.getHabboInfo().getId() + ":" + item.getId());
+        EntitlementPurchase purchase = CatalogPurchaseTransaction.execute(
+                habbo.getHabboInfo().getId(), operationId, connection -> {
             UserCatalogItemPurchasedEvent event = new UserCatalogItemPurchasedEvent(
                     habbo, item, new HashSet<>(), totalCredits, totalPoints, new ArrayList<>(requestedBadges));
             Emulator.getPluginManager().fireEvent(event);
@@ -1588,7 +1599,8 @@ public class CatalogManager {
             throws SQLException {
         int userId = habbo.getHabboInfo().getId();
         try {
-            AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(userId, connection -> {
+            String operationId = EconomyOperationId.create("catalog:" + userId + ":" + item.getId());
+            AtomicFurniturePurchase purchase = CatalogPurchaseTransaction.execute(userId, operationId, connection -> {
                 Set<HabboItem> createdItems = new HashSet<>();
                 Map<InteractionGuildFurni, Guild> guildFurniture = new HashMap<>();
                 boolean includesMusicDisc = false;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java
@@ -1,27 +1,23 @@
 package com.eu.habbo.habbohotel.catalog;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 final class CatalogPurchaseTransaction {
-    private static final String CHARGE_CREDITS =
-            "UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?";
-    private static final String CHARGE_POINTS =
-            "UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?";
-
     private CatalogPurchaseTransaction() {
     }
 
-    static <T> T execute(int userId, PurchaseWork<T> work) throws SQLException {
+    static <T> T execute(int userId, String operationId, PurchaseWork<T> work) throws SQLException {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
             connection.setAutoCommit(false);
             try {
                 PreparedPurchase<T> purchase = work.persist(connection);
-                chargeCredits(connection, userId, purchase.credits());
-                chargePoints(connection, userId, purchase.pointsType(), purchase.points());
+                chargeCredits(connection, operationId, userId, purchase.credits());
+                chargePoints(connection, operationId, userId, purchase.pointsType(), purchase.points());
                 connection.commit();
                 return purchase.value();
             } catch (Exception exception) {
@@ -36,25 +32,20 @@ final class CatalogPurchaseTransaction {
         }
     }
 
-    private static void chargeCredits(Connection connection, int userId, int credits) throws SQLException {
+    private static void chargeCredits(Connection connection, String operationId, int userId, int credits)
+            throws SQLException {
         if (credits == 0) return;
-        try (PreparedStatement statement = connection.prepareStatement(CHARGE_CREDITS)) {
-            statement.setInt(1, credits);
-            statement.setInt(2, userId);
-            statement.setInt(3, credits);
-            if (statement.executeUpdate() != 1) throw new SQLException("Insufficient credits for catalog purchase");
-        }
+        EconomyLedger.apply(connection, new EconomyOperation(
+                operationId + ":credits", userId, userId, "catalog_purchase", "catalog.purchase",
+                EconomyLedger.CREDITS, -credits, null, operationId));
     }
 
-    private static void chargePoints(Connection connection, int userId, int pointsType, int points) throws SQLException {
+    private static void chargePoints(Connection connection, String operationId, int userId, int pointsType, int points)
+            throws SQLException {
         if (points == 0) return;
-        try (PreparedStatement statement = connection.prepareStatement(CHARGE_POINTS)) {
-            statement.setInt(1, points);
-            statement.setInt(2, userId);
-            statement.setInt(3, pointsType);
-            statement.setInt(4, points);
-            if (statement.executeUpdate() != 1) throw new SQLException("Insufficient points for catalog purchase");
-        }
+        EconomyLedger.apply(connection, new EconomyOperation(
+                operationId + ":points", userId, userId, "catalog_purchase", "catalog.purchase",
+                pointsType, -points, null, operationId));
     }
 
     @FunctionalInterface

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogValueValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogValueValidator.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class CatalogValueValidator {
+    private CatalogValueValidator() {
+    }
+
+    public static List<String> validate(Values values) {
+        List<String> findings = new ArrayList<>();
+        if (values.id() <= 0) add(findings, values.id(), "id must be positive");
+        if (values.credits() < 0) add(findings, values.id(), "cost_credits must not be negative");
+        if (values.points() < 0) add(findings, values.id(), "cost_points must not be negative");
+        if (values.pointsType() < 0) add(findings, values.id(), "points_type must not be negative");
+        if (values.amount() <= 0) add(findings, values.id(), "amount must be positive");
+        if (values.limitedStack() < 0) add(findings, values.id(), "limited_stack must not be negative");
+        if (values.limitedSells() < 0 || values.limitedSells() > values.limitedStack()) {
+            add(findings, values.id(), "limited_sells must be between zero and limited_stack");
+        }
+        return List.copyOf(findings);
+    }
+
+    private static void add(List<String> findings, int id, String message) {
+        findings.add("catalog item " + id + ": " + message);
+    }
+
+    public record Values(int id, int credits, int points, int pointsType, int amount,
+                         int limitedStack, int limitedSells) {
+        public static Values from(ResultSet result) throws SQLException {
+            return new Values(
+                    result.getInt("id"),
+                    result.getInt("cost_credits"),
+                    result.getInt("cost_points"),
+                    result.getInt("points_type"),
+                    result.getInt("amount"),
+                    result.getInt("limited_stack"),
+                    result.getInt("limited_sells"));
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlacePurchaseTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/marketplace/MarketPlacePurchaseTransaction.java
@@ -1,6 +1,8 @@
 package com.eu.habbo.habbohotel.catalog.marketplace;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,8 +14,6 @@ final class MarketPlacePurchaseTransaction {
     private static final Logger LOGGER = LoggerFactory.getLogger(MarketPlacePurchaseTransaction.class);
     private static final String SELL_OFFER = "UPDATE marketplace_items SET state = 2, sold_timestamp = ? WHERE id = ? AND state = 1";
     private static final String TRANSFER_ITEM = "UPDATE items SET user_id = ? WHERE id = ?";
-    private static final String CHARGE_CREDITS = "UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?";
-    private static final String CHARGE_CURRENCY = "UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?";
 
     private MarketPlacePurchaseTransaction() {
     }
@@ -27,11 +27,21 @@ final class MarketPlacePurchaseTransaction {
             connection.setAutoCommit(false);
 
             if (!executeOfferSale(connection, offerId, soldTimestamp)
-                    || !executeItemTransfer(connection, itemId, buyerId)
-                    || !executeCharge(connection, buyerId, currencyType, charge)) {
+                    || !executeItemTransfer(connection, itemId, buyerId)) {
                 connection.rollback();
                 return false;
             }
+
+            EconomyLedger.apply(connection, new EconomyOperation(
+                    "marketplace:offer:" + offerId + ":buyer",
+                    buyerId,
+                    buyerId,
+                    "marketplace_purchase",
+                    "catalog.marketplace.buy",
+                    currencyType < 0 ? EconomyLedger.CREDITS : currencyType,
+                    -charge,
+                    itemId,
+                    "offerId=" + offerId));
 
             connection.commit();
             return true;
@@ -65,22 +75,4 @@ final class MarketPlacePurchaseTransaction {
         }
     }
 
-    private static boolean executeCharge(Connection connection, int buyerId, int currencyType, int charge) throws SQLException {
-        if (currencyType < 0) {
-            try (PreparedStatement statement = connection.prepareStatement(CHARGE_CREDITS)) {
-                statement.setInt(1, charge);
-                statement.setInt(2, buyerId);
-                statement.setInt(3, charge);
-                return statement.executeUpdate() == 1;
-            }
-        }
-
-        try (PreparedStatement statement = connection.prepareStatement(CHARGE_CURRENCY)) {
-            statement.setInt(1, charge);
-            statement.setInt(2, buyerId);
-            statement.setInt(3, currencyType);
-            statement.setInt(4, charge);
-            return statement.executeUpdate() == 1;
-        }
-    }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyAuditEntry.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyAuditEntry.java
@@ -3,7 +3,9 @@ package com.eu.habbo.habbohotel.economy;
 public record EconomyAuditEntry(
         String operationId,
         int userId,
+        Integer actorId,
         String operation,
+        String reason,
         int currencyType,
         int amount,
         int balanceBefore,
@@ -20,12 +22,29 @@ public record EconomyAuditEntry(
         return new EconomyAuditEntry(
                 "furniture-redeem:" + itemId,
                 userId,
+                userId,
                 "furniture_redeem",
+                "furniture.redeem",
                 currencyType,
                 amount,
                 balanceBefore,
                 balanceAfter,
                 itemId,
                 itemName == null ? "" : itemName);
+    }
+
+    public static EconomyAuditEntry from(EconomyOperation operation, int balanceBefore, int balanceAfter) {
+        return new EconomyAuditEntry(
+                operation.operationId(),
+                operation.userId(),
+                operation.actorId(),
+                operation.operation(),
+                operation.reason(),
+                operation.currencyType(),
+                operation.delta(),
+                balanceBefore,
+                balanceAfter,
+                operation.itemId(),
+                operation.context());
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyAuditLogger.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyAuditLogger.java
@@ -11,31 +11,40 @@ import java.sql.SQLException;
 public final class EconomyAuditLogger {
     private static final Logger LOGGER = LoggerFactory.getLogger(EconomyAuditLogger.class);
     private static final String INSERT = """
-            INSERT IGNORE INTO logs_economy
-                (operation_id, user_id, operation, currency_type, amount, balance_before, balance_after, item_id, context)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO logs_economy
+                (operation_id, user_id, actor_id, operation, reason, currency_type, amount,
+                 balance_before, balance_after, item_id, context)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
 
     private EconomyAuditLogger() {
     }
 
     public static boolean record(EconomyAuditEntry entry) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement(INSERT)) {
-            statement.setString(1, entry.operationId());
-            statement.setInt(2, entry.userId());
-            statement.setString(3, entry.operation());
-            statement.setInt(4, entry.currencyType());
-            statement.setInt(5, entry.amount());
-            statement.setInt(6, entry.balanceBefore());
-            statement.setInt(7, entry.balanceAfter());
-            if (entry.itemId() == null) statement.setNull(8, java.sql.Types.INTEGER);
-            else statement.setInt(8, entry.itemId());
-            statement.setString(9, truncate(entry.context(), 255));
-            return statement.executeUpdate() == 1;
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            return record(connection, entry);
         } catch (SQLException e) {
             LOGGER.error("Failed to write economy audit operation {}", entry.operationId(), e);
             return false;
+        }
+    }
+
+    public static boolean record(Connection connection, EconomyAuditEntry entry) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(INSERT)) {
+            statement.setString(1, entry.operationId());
+            statement.setInt(2, entry.userId());
+            if (entry.actorId() == null) statement.setNull(3, java.sql.Types.INTEGER);
+            else statement.setInt(3, entry.actorId());
+            statement.setString(4, entry.operation());
+            statement.setString(5, entry.reason());
+            statement.setInt(6, entry.currencyType());
+            statement.setInt(7, entry.amount());
+            statement.setInt(8, entry.balanceBefore());
+            statement.setInt(9, entry.balanceAfter());
+            if (entry.itemId() == null) statement.setNull(10, java.sql.Types.INTEGER);
+            else statement.setInt(10, entry.itemId());
+            statement.setString(11, truncate(entry.context(), 255));
+            return statement.executeUpdate() == 1;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyLedger.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyLedger.java
@@ -1,0 +1,120 @@
+package com.eu.habbo.habbohotel.economy;
+
+import com.eu.habbo.Emulator;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public final class EconomyLedger {
+    public static final int CREDITS = -1;
+    private static final String LOCK_USER = "SELECT credits FROM users WHERE id = ? FOR UPDATE";
+    private static final String READ_CURRENCY = "SELECT amount FROM users_currency WHERE user_id = ? AND type = ? FOR UPDATE";
+    private static final String UPDATE_CREDITS = "UPDATE users SET credits = ? WHERE id = ?";
+    private static final String UPSERT_CURRENCY = """
+            INSERT INTO users_currency (user_id, type, amount) VALUES (?, ?, ?)
+            ON DUPLICATE KEY UPDATE amount = VALUES(amount)
+            """;
+    private static final String READ_OPERATION = """
+            SELECT user_id, currency_type, amount, balance_before, balance_after
+            FROM logs_economy WHERE operation_id = ?
+            """;
+
+    private EconomyLedger() {
+    }
+
+    public static EconomyMutationResult execute(EconomyOperation operation) throws SQLException {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                EconomyMutationResult result = apply(connection, operation);
+                connection.commit();
+                return result;
+            } catch (SQLException | RuntimeException exception) {
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackException) {
+                    exception.addSuppressed(rollbackException);
+                }
+                throw exception;
+            }
+        }
+    }
+
+    public static EconomyMutationResult apply(Connection connection, EconomyOperation operation) throws SQLException {
+        int balanceBefore = lockBalance(connection, operation.userId(), operation.currencyType());
+        EconomyMutationResult existing = existingResult(connection, operation);
+        if (existing != null) return existing;
+
+        int balanceAfter = checkedBalance(balanceBefore, operation.delta());
+        persistBalance(connection, operation.userId(), operation.currencyType(), balanceAfter);
+        EconomyAuditLogger.record(connection, EconomyAuditEntry.from(operation, balanceBefore, balanceAfter));
+        return new EconomyMutationResult(balanceBefore, balanceAfter, true);
+    }
+
+    public static int checkedBalance(int balanceBefore, int delta) {
+        long balanceAfter = (long) balanceBefore + delta;
+        if (balanceBefore < 0 || balanceAfter < 0 || balanceAfter > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("economy mutation would produce an invalid balance");
+        }
+        return (int) balanceAfter;
+    }
+
+    private static int lockBalance(Connection connection, int userId, int currencyType) throws SQLException {
+        int credits;
+        try (PreparedStatement statement = connection.prepareStatement(LOCK_USER)) {
+            statement.setInt(1, userId);
+            try (ResultSet result = statement.executeQuery()) {
+                if (!result.next()) throw new SQLException("Unknown economy user " + userId);
+                credits = result.getInt("credits");
+            }
+        }
+        if (currencyType == CREDITS) return credits;
+
+        try (PreparedStatement statement = connection.prepareStatement(READ_CURRENCY)) {
+            statement.setInt(1, userId);
+            statement.setInt(2, currencyType);
+            try (ResultSet result = statement.executeQuery()) {
+                return result.next() ? result.getInt("amount") : 0;
+            }
+        }
+    }
+
+    private static EconomyMutationResult existingResult(Connection connection, EconomyOperation operation)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(READ_OPERATION)) {
+            statement.setString(1, operation.operationId());
+            try (ResultSet result = statement.executeQuery()) {
+                if (!result.next()) return null;
+                if (result.getInt("user_id") != operation.userId()
+                        || result.getInt("currency_type") != operation.currencyType()
+                        || result.getInt("amount") != operation.delta()) {
+                    throw new SQLException("Economy operation id reused with different payload: "
+                            + operation.operationId());
+                }
+                return new EconomyMutationResult(
+                        result.getInt("balance_before"), result.getInt("balance_after"), false);
+            }
+        }
+    }
+
+    private static void persistBalance(Connection connection, int userId, int currencyType, int balance)
+            throws SQLException {
+        if (currencyType == CREDITS) {
+            try (PreparedStatement statement = connection.prepareStatement(UPDATE_CREDITS)) {
+                statement.setInt(1, balance);
+                statement.setInt(2, userId);
+                if (statement.executeUpdate() != 1) throw new SQLException("Unable to update credits for " + userId);
+            }
+            return;
+        }
+
+        try (PreparedStatement statement = connection.prepareStatement(UPSERT_CURRENCY)) {
+            statement.setInt(1, userId);
+            statement.setInt(2, currencyType);
+            statement.setInt(3, balance);
+            statement.executeUpdate();
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyMutationResult.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyMutationResult.java
@@ -1,0 +1,4 @@
+package com.eu.habbo.habbohotel.economy;
+
+public record EconomyMutationResult(int balanceBefore, int balanceAfter, boolean applied) {
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyOperation.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyOperation.java
@@ -1,0 +1,32 @@
+package com.eu.habbo.habbohotel.economy;
+
+public record EconomyOperation(
+        String operationId,
+        int userId,
+        Integer actorId,
+        String operation,
+        String reason,
+        int currencyType,
+        int delta,
+        Integer itemId,
+        String context) {
+
+    public EconomyOperation {
+        operationId = requireText(operationId, 96, "operationId");
+        if (userId <= 0) throw new IllegalArgumentException("userId must be positive");
+        if (actorId != null && actorId <= 0) throw new IllegalArgumentException("actorId must be positive");
+        operation = requireText(operation, 64, "operation");
+        reason = requireText(reason, 96, "reason");
+        if (currencyType < EconomyLedger.CREDITS) throw new IllegalArgumentException("currencyType is invalid");
+        if (delta == 0) throw new IllegalArgumentException("delta must not be zero");
+        if (itemId != null && itemId <= 0) throw new IllegalArgumentException("itemId must be positive");
+        context = context == null ? "" : context;
+    }
+
+    private static String requireText(String value, int maxLength, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+        String normalized = value.strip();
+        if (normalized.length() > maxLength) throw new IllegalArgumentException(field + " is too long");
+        return normalized;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyOperationId.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/economy/EconomyOperationId.java
@@ -1,0 +1,18 @@
+package com.eu.habbo.habbohotel.economy;
+
+import java.util.UUID;
+
+public final class EconomyOperationId {
+    private EconomyOperationId() {
+    }
+
+    public static String create(String namespace) {
+        if (namespace == null || namespace.isBlank()) {
+            throw new IllegalArgumentException("economy operation namespace must not be blank");
+        }
+        String prefix = namespace.strip().replaceAll("[^a-zA-Z0-9:._-]", "-");
+        String operationId = prefix + ":" + UUID.randomUUID();
+        if (operationId.length() > 80) operationId = operationId.substring(operationId.length() - 80);
+        return operationId;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java
@@ -1,6 +1,9 @@
 package com.eu.habbo.habbohotel.rooms;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 
@@ -14,7 +17,6 @@ import java.util.Collection;
 final class RoomTradeTransaction {
     private static final String TRANSFER_ITEM = "UPDATE items SET user_id = ? WHERE id = ? AND user_id = ? LIMIT 1";
     private static final String REDEEM_ITEM = "DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1";
-    private static final String CREDIT_USER = "UPDATE users SET credits = credits + ? WHERE id = ?";
 
     private RoomTradeTransaction() {
     }
@@ -25,6 +27,7 @@ final class RoomTradeTransaction {
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
             connection.setAutoCommit(false);
             try {
+                String operationId = EconomyOperationId.create("room-trade");
                 int tradeId = logTrades
                         ? insertTradeLog(connection, userOne, userTwo, userOneItems.size(), userTwoItems.size())
                         : 0;
@@ -33,8 +36,10 @@ final class RoomTradeTransaction {
                         userOneItems, logTrades);
                 persistItems(connection, tradeId, userTwo.getHabboInfo().getId(), userOne.getHabboInfo().getId(),
                         userTwoItems, logTrades);
-                creditUser(connection, userOne.getHabboInfo().getId(), creditsForUserOne);
-                creditUser(connection, userTwo.getHabboInfo().getId(), creditsForUserTwo);
+                creditUser(connection, operationId, userOne.getHabboInfo().getId(), creditsForUserOne,
+                        userTwo.getHabboInfo().getId(), tradeId);
+                creditUser(connection, operationId, userTwo.getHabboInfo().getId(), creditsForUserTwo,
+                        userOne.getHabboInfo().getId(), tradeId);
 
                 connection.commit();
                 return true;
@@ -99,12 +104,18 @@ final class RoomTradeTransaction {
         }
     }
 
-    private static void creditUser(Connection connection, int userId, int credits) throws SQLException {
+    private static void creditUser(Connection connection, String operationId, int userId, int credits,
+                                   int actorId, int tradeId) throws SQLException {
         if (credits <= 0) return;
-        try (PreparedStatement statement = connection.prepareStatement(CREDIT_USER)) {
-            statement.setInt(1, credits);
-            statement.setInt(2, userId);
-            if (statement.executeUpdate() != 1) throw new SQLException("Unable to credit trade recipient " + userId);
-        }
+        EconomyLedger.apply(connection, new EconomyOperation(
+                operationId + ":recipient:" + userId,
+                userId,
+                actorId,
+                "trade_credit_conversion",
+                "room.trade.credit_furni",
+                EconomyLedger.CREDITS,
+                credits,
+                null,
+                "tradeId=" + tradeId));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -4,6 +4,10 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.bots.Bot;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.messenger.Messenger;
 import com.eu.habbo.habbohotel.pets.Pet;
 import com.eu.habbo.habbohotel.rooms.*;
@@ -240,6 +244,16 @@ public class Habbo implements Runnable {
 
 
     public void giveCredits(int credits) {
+        this.giveCredits(credits, "economy.api.credits");
+    }
+
+    public void giveCredits(int credits, String reason) {
+        this.giveCredits(credits, reason,
+                EconomyOperationId.create("credits:" + this.getHabboInfo().getId()),
+                this.getHabboInfo().getId());
+    }
+
+    public void giveCredits(int credits, String reason, String operationId, Integer actorId) {
         if (credits == 0)
             return;
 
@@ -247,23 +261,33 @@ public class Habbo implements Runnable {
         if (Emulator.getPluginManager().fireEvent(event).isCancelled())
             return;
 
-        this.getHabboInfo().addCredits(event.credits);
+        try {
+            EconomyMutationResult result = EconomyLedger.execute(new EconomyOperation(
+                    operationId,
+                    this.getHabboInfo().getId(),
+                    actorId,
+                    event.credits > 0 ? "credit_grant" : "credit_debit",
+                    reason,
+                    EconomyLedger.CREDITS,
+                    event.credits,
+                    null,
+                    ""));
+            this.getHabboInfo().setCredits(result.balanceAfter());
+        } catch (Exception exception) {
+            LOGGER.error("Unable to apply audited credit mutation for user {}", this.getHabboInfo().getId(), exception);
+            return;
+        }
 
         if (this.client != null) this.client.sendResponse(new UserCreditsComposer(this));
     }
 
 
     public void givePixels(int pixels) {
-        if (pixels == 0)
-            return;
+        this.givePoints(0, pixels, "economy.api.pixels");
+    }
 
-
-        UserPointsEvent event = new UserPointsEvent(this, pixels, 0);
-        if (Emulator.getPluginManager().fireEvent(event).isCancelled())
-            return;
-
-        this.getHabboInfo().addPixels(event.points);
-        if (this.client != null) this.client.sendResponse(new UserCurrencyComposer(this));
+    public void givePixels(int pixels, String reason) {
+        this.givePoints(0, pixels, reason);
     }
 
 
@@ -273,6 +297,16 @@ public class Habbo implements Runnable {
 
 
     public void givePoints(int type, int points) {
+        this.givePoints(type, points, "economy.api.currency");
+    }
+
+    public void givePoints(int type, int points, String reason) {
+        this.givePoints(type, points, reason,
+                EconomyOperationId.create("currency:" + this.getHabboInfo().getId() + ":" + type),
+                this.getHabboInfo().getId());
+    }
+
+    public void givePoints(int type, int points, String reason, String operationId, Integer actorId) {
         if (points == 0)
             return;
 
@@ -280,9 +314,27 @@ public class Habbo implements Runnable {
         if (Emulator.getPluginManager().fireEvent(event).isCancelled())
             return;
 
-        this.getHabboInfo().addCurrencyAmount(event.type, event.points);
-        if (this.client != null)
-            this.client.sendResponse(new UserPointsComposer(this.getHabboInfo().getCurrencyAmount(type), event.points, event.type));
+        try {
+            EconomyMutationResult result = EconomyLedger.execute(new EconomyOperation(
+                    operationId,
+                    this.getHabboInfo().getId(),
+                    actorId,
+                    event.points > 0 ? "currency_grant" : "currency_debit",
+                    reason,
+                    event.type,
+                    event.points,
+                    null,
+                    ""));
+            this.getHabboInfo().setCurrencyAmount(event.type, result.balanceAfter());
+        } catch (Exception exception) {
+            LOGGER.error("Unable to apply audited currency mutation for user {}", this.getHabboInfo().getId(), exception);
+            return;
+        }
+        if (this.client != null) {
+            if (event.type == 0) this.client.sendResponse(new UserCurrencyComposer(this));
+            else this.client.sendResponse(new UserPointsComposer(
+                    this.getHabboInfo().getCurrencyAmount(event.type), event.points, event.type));
+        }
     }
 
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboManager.java
@@ -1,6 +1,9 @@
 package com.eu.habbo.habbohotel.users;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.database.SqlQueries;
 import com.eu.habbo.habbohotel.modtool.ModToolBan;
 import com.eu.habbo.habbohotel.permissions.Permission;
@@ -289,11 +292,14 @@ public class HabboManager {
     public void giveCredits(int userId, int credits) {
         Habbo habbo = this.getHabbo(userId);
         if (habbo != null) {
-            habbo.giveCredits(credits);
+            habbo.giveCredits(credits, "system.habbo_manager");
         } else {
             try {
-                SqlQueries.update("UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1", credits, userId);
-            } catch (SqlQueries.DataAccessException e) {
+                EconomyLedger.execute(new EconomyOperation(
+                        EconomyOperationId.create("habbo-manager:credits:" + userId),
+                        userId, null, credits > 0 ? "credit_grant" : "credit_debit",
+                        "system.habbo_manager", EconomyLedger.CREDITS, credits, null, ""));
+            } catch (Exception e) {
                 LOGGER.error("Caught SQL exception", e);
             }
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCreditsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCreditsEvent.java
@@ -1,14 +1,13 @@
 package com.eu.habbo.messages.incoming.housekeeping;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.housekeeping.HousekeepingActionResultComposer;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 public class HousekeepingGiveCreditsEvent extends MessageHandler {
     private static final String ACTION_KEY = "user.give_credits";
@@ -38,27 +37,23 @@ public class HousekeepingGiveCreditsEvent extends MessageHandler {
         }
 
         Habbo online = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
+        int actorId = this.client.getHabbo().getHabboInfo().getId();
+        String operationId = EconomyOperationId.create("housekeeping:credits:" + userId);
 
         if (online != null) {
             // giveCredits already pushes UserCreditsComposer and persists via the
             // standard HabboInfo write path; nothing extra needed for the online branch.
-            online.giveCredits(amount);
+            online.giveCredits(amount, "housekeeping.user.give_credits", operationId, actorId);
             this.audit(userId, amount);
             this.client.sendResponse(new HousekeepingActionResultComposer(ACTION_KEY, true, userId, ""));
             return;
         }
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement("UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1")) {
-            statement.setInt(1, amount);
-            statement.setInt(2, userId);
-            int rows = statement.executeUpdate();
-
-            if (rows == 0) {
-                this.client.sendResponse(new HousekeepingActionResultComposer(ACTION_KEY, false, 0, "housekeeping.error.user_not_found"));
-                return;
-            }
-        } catch (SQLException e) {
+        try {
+            EconomyLedger.execute(new EconomyOperation(
+                    operationId, userId, actorId, "credit_grant", "housekeeping.user.give_credits",
+                    EconomyLedger.CREDITS, amount, null, ACTION_KEY));
+        } catch (Exception e) {
             this.client.sendResponse(new HousekeepingActionResultComposer(ACTION_KEY, false, 0, "housekeeping.error.db_failed"));
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCurrencyEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCurrencyEvent.java
@@ -1,14 +1,13 @@
 package com.eu.habbo.messages.incoming.housekeeping;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.housekeeping.HousekeepingActionResultComposer;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 /**
  * Generic non-credits currency grant. Wire field `currencyType`:
@@ -52,14 +51,16 @@ public class HousekeepingGiveCurrencyEvent extends MessageHandler {
         }
 
         Habbo online = Emulator.getGameEnvironment().getHabboManager().getHabbo(userId);
+        int actorId = this.client.getHabbo().getHabboInfo().getId();
+        String operationId = EconomyOperationId.create("housekeeping:currency:" + userId + ":" + currencyType);
 
         if (online != null) {
             // givePixels writes users_currency type=0 and ships UserCurrency;
             // givePoints(type, amount) is the generalised path for everything else.
             if (currencyType == CURRENCY_DUCKETS) {
-                online.givePixels(amount);
+                online.givePoints(currencyType, amount, "housekeeping.user.give_currency", operationId, actorId);
             } else {
-                online.givePoints(currencyType, amount);
+                online.givePoints(currencyType, amount, "housekeeping.user.give_currency", operationId, actorId);
             }
 
             this.audit(actionKey, userId, currencyType, amount);
@@ -67,15 +68,11 @@ public class HousekeepingGiveCurrencyEvent extends MessageHandler {
             return;
         }
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
-             PreparedStatement statement = connection.prepareStatement(
-                     "INSERT INTO users_currency (user_id, type, amount) VALUES (?, ?, ?) " +
-                     "ON DUPLICATE KEY UPDATE amount = amount + VALUES(amount)")) {
-            statement.setInt(1, userId);
-            statement.setInt(2, currencyType);
-            statement.setInt(3, amount);
-            statement.executeUpdate();
-        } catch (SQLException e) {
+        try {
+            EconomyLedger.execute(new EconomyOperation(
+                    operationId, userId, actorId, "currency_grant", "housekeeping.user.give_currency",
+                    currencyType, amount, null, actionKey));
+        } catch (Exception e) {
             this.client.sendResponse(new HousekeepingActionResultComposer(actionKey, false, 0, "housekeeping.error.db_failed"));
             return;
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemEvent.java
@@ -1,8 +1,6 @@
 package com.eu.habbo.messages.incoming.rooms.items;
 
 import com.eu.habbo.Emulator;
-import com.eu.habbo.habbohotel.economy.EconomyAuditEntry;
-import com.eu.habbo.habbohotel.economy.EconomyAuditLogger;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.users.HabboItem;
@@ -113,7 +111,8 @@ public class RedeemItemEvent extends MessageHandler {
                             item.getId(),
                             this.client.getHabbo().getHabboInfo().getId(),
                             currencyGrant.currencyType(),
-                            currencyGrant.amount()))
+                            currencyGrant.amount(),
+                            item.getBaseItem().getName()))
                         return;
 
                     room.removeHabboItem(item);
@@ -125,28 +124,10 @@ public class RedeemItemEvent extends MessageHandler {
                     t.setStackHeight(room.getStackHeight(item.getX(), item.getY(), false));
                     room.updateTile(t);
                     room.sendComposer(new UpdateStackHeightComposer(item.getX(), item.getY(), t.z, t.relativeHeight()).compose());
-                    int balanceBefore = getCurrencyBalance(currencyGrant.currencyType());
                     applyCurrencyGrant(currencyGrant);
-                    int balanceAfter = getCurrencyBalance(currencyGrant.currencyType());
-                    EconomyAuditLogger.record(EconomyAuditEntry.redemption(
-                            this.client.getHabbo().getHabboInfo().getId(),
-                            item.getId(),
-                            currencyGrant.currencyType(),
-                            currencyGrant.amount(),
-                            balanceBefore,
-                            balanceAfter,
-                            item.getBaseItem().getName()));
                 }
             }
         }
-    }
-
-    private int getCurrencyBalance(int currencyType) {
-        return switch (currencyType) {
-            case FurnitureRedeemedEvent.CREDITS -> this.client.getHabbo().getHabboInfo().getCredits();
-            case FurnitureRedeemedEvent.PIXELS -> this.client.getHabbo().getHabboInfo().getPixels();
-            default -> this.client.getHabbo().getHabboInfo().getCurrencyAmount(currencyType);
-        };
     }
 
     private PreparedCurrencyGrant prepareCurrencyGrant(int currencyType, int amount) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemTransaction.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RedeemItemTransaction.java
@@ -1,7 +1,8 @@
 package com.eu.habbo.messages.incoming.rooms.items;
 
 import com.eu.habbo.Emulator;
-import com.eu.habbo.plugin.events.furniture.FurnitureRedeemedEvent;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,16 +13,11 @@ import java.sql.SQLException;
 final class RedeemItemTransaction {
     private static final Logger LOGGER = LoggerFactory.getLogger(RedeemItemTransaction.class);
     private static final String DELETE_ITEM = "DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1";
-    private static final String ADD_CREDITS = "UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1";
-    private static final String ADD_CURRENCY = """
-            INSERT INTO users_currency (user_id, type, amount) VALUES (?, ?, ?)
-            ON DUPLICATE KEY UPDATE amount = amount + ?
-            """;
 
     private RedeemItemTransaction() {
     }
 
-    static boolean commit(int itemId, int userId, int currencyType, int amount) {
+    static boolean commit(int itemId, int userId, int currencyType, int amount, String itemName) {
         if (itemId <= 0 || userId <= 0 || amount <= 0) return false;
 
         Connection connection = null;
@@ -38,24 +34,16 @@ final class RedeemItemTransaction {
                 }
             }
 
-            if (currencyType == FurnitureRedeemedEvent.CREDITS) {
-                try (PreparedStatement update = connection.prepareStatement(ADD_CREDITS)) {
-                    update.setInt(1, amount);
-                    update.setInt(2, userId);
-                    if (update.executeUpdate() != 1) {
-                        connection.rollback();
-                        return false;
-                    }
-                }
-            } else {
-                try (PreparedStatement update = connection.prepareStatement(ADD_CURRENCY)) {
-                    update.setInt(1, userId);
-                    update.setInt(2, currencyType);
-                    update.setInt(3, amount);
-                    update.setInt(4, amount);
-                    update.executeUpdate();
-                }
-            }
+            EconomyLedger.apply(connection, new EconomyOperation(
+                    "furniture-redeem:" + itemId,
+                    userId,
+                    userId,
+                    "furniture_redeem",
+                    "furniture.redeem",
+                    currencyType,
+                    amount,
+                    itemId,
+                    itemName));
 
             connection.commit();
             return true;

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveCredits.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/GiveCredits.java
@@ -1,15 +1,14 @@
 package com.eu.habbo.messages.rcon;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.google.gson.Gson;
 import jakarta.validation.constraints.Positive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 public class GiveCredits extends RCONMessage<GiveCredits.JSONGiveCredits> {
     private static final Logger LOGGER = LoggerFactory.getLogger(GiveCredits.class);
@@ -34,18 +33,21 @@ public class GiveCredits extends RCONMessage<GiveCredits.JSONGiveCredits> {
         }
 
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(object.user_id);
+        String operationId = EconomyOperationId.create("rcon:credits:" + object.user_id);
 
         if (habbo != null) {
-            habbo.giveCredits(object.credits);
+            habbo.giveCredits(object.credits, "rcon.givecredits", operationId, null);
         } else {
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1")) {
-                statement.setInt(1, object.credits);
-                statement.setInt(2, object.user_id);
-                if (statement.executeUpdate() == 0) {
-                    this.status = RCONMessage.HABBO_NOT_FOUND;
-                    return;
-                }
-            } catch (SQLException e) {
+            if (!RconUserLookup.userExists(object.user_id)) {
+                this.status = RCONMessage.HABBO_NOT_FOUND;
+                this.message = "user not found";
+                return;
+            }
+            try {
+                EconomyLedger.execute(new EconomyOperation(
+                        operationId, object.user_id, null, "credit_grant", "rcon.givecredits",
+                        EconomyLedger.CREDITS, object.credits, null, ""));
+            } catch (Exception e) {
                 this.status = RCONMessage.SYSTEM_ERROR;
                 LOGGER.error("Caught SQL exception", e);
                 return;

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/GivePixels.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/GivePixels.java
@@ -1,15 +1,14 @@
 package com.eu.habbo.messages.rcon;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.google.gson.Gson;
 import jakarta.validation.constraints.Positive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 public class GivePixels extends RCONMessage<GivePixels.JSONGivePixels> {
     private static final Logger LOGGER = LoggerFactory.getLogger(GivePixels.class);
@@ -34,9 +33,10 @@ public class GivePixels extends RCONMessage<GivePixels.JSONGivePixels> {
         }
 
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(object.user_id);
+        String operationId = EconomyOperationId.create("rcon:pixels:" + object.user_id);
 
         if (habbo != null) {
-            habbo.givePixels(object.pixels);
+            habbo.givePoints(0, object.pixels, "rcon.givepixels", operationId, null);
         } else {
             if (!RconUserLookup.userExists(object.user_id)) {
                 this.status = RCONMessage.HABBO_NOT_FOUND;
@@ -44,12 +44,11 @@ public class GivePixels extends RCONMessage<GivePixels.JSONGivePixels> {
                 return;
             }
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_currency (`user_id`, `type`, `amount`) VALUES (?, 0, ?) ON DUPLICATE KEY UPDATE amount = amount + ?")) {
-                statement.setInt(1, object.user_id);
-                statement.setInt(2, object.pixels);
-                statement.setInt(3, object.pixels);
-                statement.executeUpdate();
-            } catch (SQLException e) {
+            try {
+                EconomyLedger.execute(new EconomyOperation(
+                        operationId, object.user_id, null, "currency_grant", "rcon.givepixels",
+                        0, object.pixels, null, ""));
+            } catch (Exception e) {
                 this.status = RCONMessage.SYSTEM_ERROR;
                 LOGGER.error("Caught SQL exception", e);
             }

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/GivePoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/GivePoints.java
@@ -1,16 +1,15 @@
 package com.eu.habbo.messages.rcon;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.economy.EconomyOperationId;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.google.gson.Gson;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 
 public class GivePoints extends RCONMessage<GivePoints.JSONGivePoints> {
     private static final Logger LOGGER = LoggerFactory.getLogger(GivePoints.class);
@@ -38,9 +37,10 @@ public class GivePoints extends RCONMessage<GivePoints.JSONGivePoints> {
         }
 
         Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(object.user_id);
+        String operationId = EconomyOperationId.create("rcon:currency:" + object.user_id + ":" + object.type);
 
         if (habbo != null) {
-            habbo.givePoints(object.type, object.points);
+            habbo.givePoints(object.type, object.points, "rcon.givepoints", operationId, null);
         } else {
             if (!RconUserLookup.userExists(object.user_id)) {
                 this.status = RCONMessage.HABBO_NOT_FOUND;
@@ -48,13 +48,11 @@ public class GivePoints extends RCONMessage<GivePoints.JSONGivePoints> {
                 return;
             }
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("INSERT INTO users_currency (`user_id`, `type`, `amount`) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE amount = amount + ?")) {
-                statement.setInt(1, object.user_id);
-                statement.setInt(2, object.type);
-                statement.setInt(3, object.points);
-                statement.setInt(4, object.points);
-                statement.execute();
-            } catch (SQLException e) {
+            try {
+                EconomyLedger.execute(new EconomyOperation(
+                        operationId, object.user_id, null, "currency_grant", "rcon.givepoints",
+                        object.type, object.points, null, ""));
+            } catch (Exception e) {
                 this.status = RCONMessage.SYSTEM_ERROR;
                 LOGGER.error("Caught SQL exception", e);
             }

--- a/Emulator/src/test/java/com/eu/habbo/database/ImmutableEconomyLedgerSchemaTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/ImmutableEconomyLedgerSchemaTest.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.database;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImmutableEconomyLedgerSchemaTest {
+    @Test
+    void migrationMakesEconomyAuditAppendOnlyAndSelfDescribing() throws Exception {
+        String sql = Files.readString(Path.of("../Database/Database Updates/028_immutable_economy_ledger.sql"));
+
+        assertTrue(sql.contains("`actor_id` INT UNSIGNED NULL"));
+        assertTrue(sql.contains("`reason` VARCHAR(96) NOT NULL"));
+        assertTrue(sql.contains("BEFORE UPDATE ON `logs_economy`"));
+        assertTrue(sql.contains("BEFORE DELETE ON `logs_economy`"));
+        assertTrue(sql.contains("SIGNAL SQLSTATE '45000'"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/compat/MariaDbSqlCompatibilityAuditTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/compat/MariaDbSqlCompatibilityAuditTest.java
@@ -1,0 +1,41 @@
+package com.eu.habbo.database.compat;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MariaDbSqlCompatibilityAuditTest {
+    @Test
+    void detectsKnownCrossDialectConstructsWithLocations() {
+        String sql = "SELECT * FROM users WHERE name ILIKE ? ORDER BY id NULLS LAST; "
+                + "INSERT OR IGNORE INTO users(id) VALUES (1); "
+                + "SELECT ROW_NUMBER() OVER (ORDER BY id) AS row_number FROM users;";
+
+        var findings = MariaDbSqlCompatibilityAudit.scan("fixture.sql", sql);
+
+        assertEquals(4, findings.size());
+        assertTrue(findings.stream().allMatch(finding -> finding.location().startsWith("fixture.sql:")));
+    }
+
+    @Test
+    void acceptsMariaDbFormsUsedByPolaris() {
+        String sql = "INSERT IGNORE INTO users(id) VALUES (1); "
+                + "INSERT INTO users_currency(user_id, type, amount) VALUES (?, ?, ?) "
+                + "ON DUPLICATE KEY UPDATE amount = amount + VALUES(amount); "
+                + "SELECT ROW_NUMBER() OVER (ORDER BY id) AS `row_number` FROM users;";
+
+        assertTrue(MariaDbSqlCompatibilityAudit.scan("fixture.sql", sql).isEmpty());
+    }
+
+    @Test
+    void productionQueriesAndManagedMigrationsPassTheMariaDbAudit() throws Exception {
+        var findings = MariaDbSqlCompatibilityAudit.scanRepository(Path.of(".."));
+
+        assertTrue(findings.isEmpty(), () -> "MariaDB-incompatible SQL found:\n" + String.join("\n", findings.stream()
+                .map(Object::toString)
+                .toList()));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/migrations/MariaDbMigrationIntegrationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/migrations/MariaDbMigrationIntegrationTest.java
@@ -9,6 +9,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -19,6 +21,60 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MariaDbMigrationIntegrationTest {
+    @Test
+    void immutableEconomyLedgerMigrationRunsOnMariaDbAndRejectsChanges() throws Exception {
+        String host = System.getenv("MIGRATION_TEST_DB_HOST");
+        Assumptions.assumeTrue(host != null && !host.isBlank(),
+                "Set MIGRATION_TEST_DB_HOST to opt into the MariaDB integration test");
+        assertTrue(isLoopback(host), "Migration integration tests require a loopback MariaDB host");
+
+        String port = environment("MIGRATION_TEST_DB_PORT", "3306");
+        String user = environment("MIGRATION_TEST_DB_USER", "root");
+        String password = environment("MIGRATION_TEST_DB_PASSWORD", "");
+        String schema = "polaris_economy_test_" + UUID.randomUUID().toString().replace("-", "");
+        String serverUrl = "jdbc:mariadb://" + host + ":" + port + "/";
+
+        try (Connection admin = DriverManager.getConnection(serverUrl, user, password)) {
+            execute(admin, "CREATE DATABASE `" + schema + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        }
+
+        try (Connection connection = DriverManager.getConnection(serverUrl + schema, user, password)) {
+            execute(connection, """
+                    CREATE TABLE logs_economy (
+                      id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                      operation_id VARCHAR(96) NOT NULL UNIQUE,
+                      user_id INT UNSIGNED NOT NULL,
+                      operation VARCHAR(64) NOT NULL,
+                      currency_type INT NOT NULL,
+                      amount INT NOT NULL,
+                      balance_before INT NOT NULL,
+                      balance_after INT NOT NULL,
+                      item_id INT UNSIGNED NULL,
+                      context VARCHAR(255) NOT NULL DEFAULT '',
+                      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                    ) ENGINE=InnoDB
+                    """);
+            String migration = Files.readString(Path.of(
+                    "../Database/Database Updates/028_immutable_economy_ledger.sql"));
+            for (String statement : SqlScriptSplitter.split(migration)) execute(connection, statement);
+
+            execute(connection, """
+                    INSERT INTO logs_economy
+                      (operation_id, user_id, actor_id, operation, reason, currency_type, amount,
+                       balance_before, balance_after, context)
+                    VALUES ('integration:1', 1, 2, 'grant', 'integration.test', -1, 5, 0, 5, '')
+                    """);
+            assertThrows(SQLException.class,
+                    () -> execute(connection, "UPDATE logs_economy SET amount = 6 WHERE operation_id = 'integration:1'"));
+            assertThrows(SQLException.class,
+                    () -> execute(connection, "DELETE FROM logs_economy WHERE operation_id = 'integration:1'"));
+        } finally {
+            try (Connection admin = DriverManager.getConnection(serverUrl, user, password)) {
+                execute(admin, "DROP DATABASE IF EXISTS `" + schema + "`");
+            }
+        }
+    }
+
     @Test
     void verifiesBaselineApplyIdempotencyDriftFailureAndLockingOnDisposableSchema()
             throws Exception {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/AtomicCatalogPurchaseContractTest.java
@@ -24,8 +24,10 @@ class AtomicCatalogPurchaseContractTest {
         assertTrue(credit > persist);
         assertTrue(points > credit);
         assertTrue(commit > points);
-        assertTrue(source.contains("UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?"));
-        assertTrue(source.contains("UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?"));
+        assertTrue(source.contains("EconomyLedger.apply(connection"));
+        assertTrue(source.contains("\"catalog.purchase\""));
+        assertTrue(source.contains("operationId + \":credits\""));
+        assertTrue(source.contains("operationId + \":points\""));
         assertTrue(source.contains("connection.rollback()"));
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogValueValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogValueValidatorTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CatalogValueValidatorTest {
+    @Test
+    void acceptsValidFreeCreditAndCurrencyOffers() {
+        assertTrue(CatalogValueValidator.validate(new CatalogValueValidator.Values(1, 0, 0, 0, 1, 0, 0)).isEmpty());
+        assertTrue(CatalogValueValidator.validate(new CatalogValueValidator.Values(2, 100, 0, 0, 1, 0, 0)).isEmpty());
+        assertTrue(CatalogValueValidator.validate(new CatalogValueValidator.Values(3, 0, 25, 5, 1, 100, 4)).isEmpty());
+    }
+
+    @Test
+    void reportsEveryUnsafeEconomicValueWithTheCatalogId() {
+        var findings = CatalogValueValidator.validate(
+                new CatalogValueValidator.Values(77, -1, -2, -1, 0, -4, 5));
+
+        assertEquals(6, findings.size());
+        assertTrue(findings.stream().allMatch(finding -> finding.startsWith("catalog item 77:")));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/marketplace/AtomicMarketPlacePurchaseContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/marketplace/AtomicMarketPlacePurchaseContractTest.java
@@ -19,8 +19,9 @@ class AtomicMarketPlacePurchaseContractTest {
         assertTrue(source.contains("setAutoCommit(false)"));
         assertTrue(source.contains("UPDATE marketplace_items SET state = 2, sold_timestamp = ? WHERE id = ? AND state = 1"));
         assertTrue(source.contains("UPDATE items SET user_id = ? WHERE id = ?"));
-        assertTrue(source.contains("UPDATE users SET credits = credits - ? WHERE id = ? AND credits >= ?"));
-        assertTrue(source.contains("UPDATE users_currency SET amount = amount - ? WHERE user_id = ? AND type = ? AND amount >= ?"));
+        assertTrue(source.contains("EconomyLedger.apply(connection"));
+        assertTrue(source.contains("\"marketplace:offer:\" + offerId + \":buyer\""));
+        assertTrue(source.contains("\"catalog.marketplace.buy\""));
         assertTrue(source.contains("connection.commit()"));
         assertTrue(source.contains("connection.rollback()"));
     }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -1,0 +1,58 @@
+package com.eu.habbo.habbohotel.economy;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EconomyAuditCoverageContractTest {
+    private static final Path SOURCES = Path.of("src/main/java");
+
+    @Test
+    void durableWalletSqlIsCentralizedInLedgerSnapshotAndAccountBootstrap() throws Exception {
+        Set<String> owners = new HashSet<>();
+        try (var paths = Files.walk(SOURCES)) {
+            for (Path path : paths.filter(file -> file.toString().endsWith(".java")).toList()) {
+                String source = Files.readString(path);
+                if (source.contains("UPDATE users SET credits")
+                        || source.contains("INSERT INTO users_currency")
+                        || source.contains("UPDATE users_currency SET amount")) {
+                    owners.add(path.getFileName().toString());
+                }
+            }
+        }
+
+        assertEquals(Set.of("EconomyLedger.java", "HabboInfo.java", "RegistrationSupport.java"), owners,
+                "new durable wallet mutations must use EconomyLedger; only snapshot persistence and account bootstrap bypass it");
+    }
+
+    @Test
+    void primaryEconomicFlowsUseTheLedgerInsideTheirTransaction() throws Exception {
+        for (String relative : Set.of(
+                "com/eu/habbo/habbohotel/catalog/CatalogPurchaseTransaction.java",
+                "com/eu/habbo/habbohotel/catalog/marketplace/MarketPlacePurchaseTransaction.java",
+                "com/eu/habbo/habbohotel/rooms/RoomTradeTransaction.java",
+                "com/eu/habbo/messages/incoming/rooms/items/RedeemItemTransaction.java")) {
+            String source = Files.readString(SOURCES.resolve(relative));
+            assertTrue(source.contains("EconomyLedger.apply(connection"), relative);
+        }
+    }
+
+    @Test
+    void genericOnlineAndAdministrativeGrantsUseExplicitAuditedReasons() throws Exception {
+        String habbo = Files.readString(SOURCES.resolve("com/eu/habbo/habbohotel/users/Habbo.java"));
+        String housekeepingCredits = Files.readString(SOURCES.resolve(
+                "com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCreditsEvent.java"));
+        String housekeepingCurrency = Files.readString(SOURCES.resolve(
+                "com/eu/habbo/messages/incoming/housekeeping/HousekeepingGiveCurrencyEvent.java"));
+
+        assertTrue(habbo.contains("EconomyLedger.execute(new EconomyOperation("));
+        assertTrue(housekeepingCredits.contains("\"housekeeping.user.give_credits\""));
+        assertTrue(housekeepingCurrency.contains("\"housekeeping.user.give_currency\""));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditEntryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditEntryTest.java
@@ -13,7 +13,9 @@ class EconomyAuditEntryTest {
 
         assertEquals("furniture-redeem:9001", entry.operationId());
         assertEquals(42, entry.userId());
+        assertEquals(42, entry.actorId());
         assertEquals("furniture_redeem", entry.operation());
+        assertEquals("furniture.redeem", entry.reason());
         assertEquals(-1, entry.currencyType());
         assertEquals(50, entry.amount());
         assertEquals(100, entry.balanceBefore());

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyLedgerContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyLedgerContractTest.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.habbohotel.economy;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EconomyLedgerContractTest {
+    @Test
+    void locksWalletChecksIdempotencyMutatesAndAuditsOnOneConnection() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/economy/EconomyLedger.java"));
+
+        int lock = source.indexOf("lockBalance(connection");
+        int existing = source.indexOf("existingResult(connection", lock);
+        int persist = source.indexOf("persistBalance(connection", existing);
+        int audit = source.indexOf("EconomyAuditLogger.record(connection", persist);
+
+        assertTrue(lock > -1);
+        assertTrue(lock < existing, "wallet lock must serialize duplicate operation checks");
+        assertTrue(existing < persist, "idempotent retry must return before another mutation");
+        assertTrue(persist < audit, "the ledger row must describe the balance actually persisted");
+        assertTrue(source.contains("FOR UPDATE"));
+        assertTrue(source.contains("operation id reused with different payload"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyOperationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyOperationTest.java
@@ -1,0 +1,49 @@
+package com.eu.habbo.habbohotel.economy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EconomyOperationTest {
+    @Test
+    void operationCarriesStableIdentityReasonActorAndSignedDelta() {
+        EconomyOperation operation = new EconomyOperation(
+                "marketplace:offer:77:buyer",
+                42,
+                9,
+                "marketplace_purchase",
+                "catalog.marketplace.buy",
+                -1,
+                -250,
+                8001,
+                "{\"offerId\":77}");
+
+        assertEquals("marketplace:offer:77:buyer", operation.operationId());
+        assertEquals(9, operation.actorId());
+        assertEquals("catalog.marketplace.buy", operation.reason());
+        assertEquals(-250, operation.delta());
+    }
+
+    @Test
+    void rejectsAmbiguousOrUnsafeOperations() {
+        assertThrows(IllegalArgumentException.class, () -> new EconomyOperation(
+                "", 42, null, "grant", "admin.grant", -1, 5, null, ""));
+        assertThrows(IllegalArgumentException.class, () -> new EconomyOperation(
+                "grant:1", 0, null, "grant", "admin.grant", -1, 5, null, ""));
+        assertThrows(IllegalArgumentException.class, () -> new EconomyOperation(
+                "grant:1", 42, null, "grant", "", -1, 5, null, ""));
+        assertThrows(IllegalArgumentException.class, () -> new EconomyOperation(
+                "grant:1", 42, null, "grant", "admin.grant", -1, 0, null, ""));
+        assertThrows(IllegalArgumentException.class, () -> new EconomyOperation(
+                "grant:1", 42, null, "grant", "admin.grant", -2, 5, null, ""));
+    }
+
+    @Test
+    void checkedBalanceRejectsOverdraftAndOverflow() {
+        assertEquals(125, EconomyLedger.checkedBalance(100, 25));
+        assertThrows(IllegalArgumentException.class, () -> EconomyLedger.checkedBalance(10, -11));
+        assertThrows(IllegalArgumentException.class,
+                () -> EconomyLedger.checkedBalance(Integer.MAX_VALUE, 1));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/AtomicRoomTradeContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/AtomicRoomTradeContractTest.java
@@ -23,7 +23,8 @@ class AtomicRoomTradeContractTest {
         assertTrue(begin > -1, "trade persistence must disable autocommit");
         assertTrue(source.contains("UPDATE items SET user_id = ? WHERE id = ? AND user_id = ? LIMIT 1"));
         assertTrue(source.contains("DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1"));
-        assertTrue(source.contains("UPDATE users SET credits = credits + ? WHERE id = ?"));
+        assertTrue(source.contains("EconomyLedger.apply(connection"));
+        assertTrue(source.contains("\"room.trade.credit_furni\""));
         assertTrue(persist > begin, "furni must be persisted inside the transaction");
         assertTrue(credit > persist, "trade credits must be granted after item persistence");
         assertTrue(commit > credit, "the transaction must commit only after every economy mutation");

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/AtomicRedeemItemContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/items/AtomicRedeemItemContractTest.java
@@ -19,12 +19,12 @@ class AtomicRedeemItemContractTest {
         int commit = source.indexOf("RedeemItemTransaction.commit(");
         int roomRemoval = source.indexOf("room.removeHabboItem(item)");
         int apply = source.indexOf("applyCurrencyGrant(");
-        int audit = source.indexOf("EconomyAuditLogger.record(");
 
         assertTrue(prepare > -1 && prepare < commit, "plugin currency events must resolve before the transaction");
         assertTrue(commit < roomRemoval, "database commit must precede room removal");
         assertTrue(roomRemoval < apply, "memory balance must be synchronized only after commit");
-        assertTrue(apply < audit, "economy audit must record the committed and synchronized balance");
+        assertTrue(!source.contains("EconomyAuditLogger.record("),
+                "redemption audit must be committed inside the database transaction, not afterwards");
         assertTrue(source.contains("currencyGrant.currencyType()"),
                 "audit and balance updates must use the plugin-resolved currency type");
     }
@@ -35,8 +35,9 @@ class AtomicRedeemItemContractTest {
 
         assertTrue(source.contains("setAutoCommit(false)"));
         assertTrue(source.contains("DELETE FROM items WHERE id = ? AND user_id = ? LIMIT 1"));
-        assertTrue(source.contains("UPDATE users SET credits = credits + ? WHERE id = ? LIMIT 1"));
-        assertTrue(source.contains("ON DUPLICATE KEY UPDATE amount = amount + ?"));
+        assertTrue(source.contains("EconomyLedger.apply(connection"));
+        assertTrue(source.contains("\"furniture-redeem:\" + itemId"));
+        assertTrue(source.contains("\"furniture.redeem\""));
         assertTrue(source.contains("connection.commit()"));
         assertTrue(source.contains("connection.rollback()"));
     }

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/GiveCreditsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/GiveCreditsContractTest.java
@@ -16,10 +16,12 @@ class GiveCreditsContractTest {
     void offlineCreditGrantReportsMissingUsersWhenNoRowsChange() throws Exception {
         String source = giveCreditsSource();
 
-        assertTrue(source.contains("executeUpdate()"),
-                "Offline RCON credit grants must inspect the affected row count");
+        assertTrue(source.contains("RconUserLookup.userExists"),
+                "Offline RCON credit grants must verify the target user");
         assertTrue(source.contains("HABBO_NOT_FOUND"),
-                "Offline RCON credit grants must report missing users when the UPDATE changes no rows");
+                "Offline RCON credit grants must report missing users");
+        assertTrue(source.contains("EconomyLedger.execute"),
+                "Offline RCON grants must use the immutable transactional ledger");
         assertTrue(source.contains("RconGrantGuard.validatePositiveAmount"),
                 "RCON credit grants must reject zero, negative, and oversized grants");
     }

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/GivePixelsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/GivePixelsContractTest.java
@@ -16,10 +16,8 @@ class GivePixelsContractTest {
     void offlinePixelGrantCreatesMissingCurrencyRow() throws Exception {
         String source = givePixelsSource();
 
-        assertTrue(source.contains("INSERT INTO users_currency"),
-                "Offline RCON pixel grants must create the users_currency type 0 row when it is missing");
-        assertTrue(source.contains("ON DUPLICATE KEY UPDATE"),
-                "Offline RCON pixel grants should increment existing rows with an upsert");
+        assertTrue(source.contains("EconomyLedger.execute"),
+                "Offline RCON pixel grants must use the immutable transactional ledger");
         assertTrue(source.contains("RconGrantGuard.validatePositiveAmount"),
                 "RCON pixel grants must reject zero, negative, and oversized grants");
         assertTrue(source.contains("RconUserLookup.userExists"),

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/GivePointsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/GivePointsContractTest.java
@@ -22,7 +22,7 @@ class GivePointsContractTest {
                 "RCON point grants must reject zero, negative, and oversized grants");
         assertTrue(source.contains("RconUserLookup.userExists"),
                 "Offline RCON point grants must not create orphan currency rows for missing users");
-        assertTrue(source.contains("ON DUPLICATE KEY UPDATE"),
-                "Offline RCON point grants should increment existing rows with an upsert");
+        assertTrue(source.contains("EconomyLedger.execute"),
+                "Offline RCON point grants must use the immutable transactional ledger");
     }
 }


### PR DESCRIPTION
## Summary

- audit production SQL and managed migrations for MariaDB-incompatible constructs
- make the economy ledger append-only with actor, reason, unique operation ID, signed delta, and before/after balances
- apply wallet mutations and ledger rows in the same transaction for catalog, marketplace, trade credit conversion, and furniture redemption
- route online, offline, RCON, and housekeeping grants through the audited ledger
- validate catalog economic values globally while loading the catalog

## Verification

- mvn -B test: 597 tests, 0 failures, 0 errors, 1 skipped
- mvn -B verify: BUILD SUCCESS
- git diff --check

## Roadmap

Completes P1 items 30-31, 34-38, 41, and 42.