### PR TITLE
feat: add canonical furni consistency pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,14 @@ jobs:
       - name: Build and test
         run: mvn -B verify
 
+      - name: Upload furni consistency fixture report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: furni-consistency-fixture-report
+          path: Emulator/target/furni-consistency-fixture.json
+          if-no-files-found: error
+
   migration-integration:
     runs-on: ubuntu-latest
     services:

--- a/Emulator/src/main/java/com/eu/habbo/tools/furni/FurniConsistencyCli.java
+++ b/Emulator/src/main/java/com/eu/habbo/tools/furni/FurniConsistencyCli.java
@@ -1,0 +1,140 @@
+package com.eu.habbo.tools.furni;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.DriverManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class FurniConsistencyCli {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private FurniConsistencyCli() {
+    }
+
+    public static void main(String[] arguments) {
+        System.exit(run(arguments, System.out, System.err));
+    }
+
+    static int run(String[] arguments, PrintStream out, PrintStream error) {
+        try {
+            Map<String, String> options = options(arguments);
+            if (options.containsKey("help")) {
+                usage(out);
+                return 0;
+            }
+            require(options, "furniture-data", "bundles", "icons", "report");
+            if (!options.containsKey("items") && !options.containsKey("items-sql-dump")
+                    && !options.containsKey("jdbc-url")) {
+                throw new IllegalArgumentException("provide --items, --items-sql-dump, or --jdbc-url");
+            }
+
+            List<FurniConsistencyValidator.ItemBase> items;
+            if (options.containsKey("items")) {
+                items = readItems(Path.of(options.get("items")));
+            } else if (options.containsKey("items-sql-dump")) {
+                items = ItemsBaseSqlDumpReader.read(Files.readString(Path.of(options.get("items-sql-dump"))));
+            } else {
+                items = readItemsFromDatabase(options);
+            }
+            JsonObject furnitureData = JsonParser.parseString(
+                    Files.readString(Path.of(options.get("furniture-data")))).getAsJsonObject();
+            Path swf = options.containsKey("swf") ? Path.of(options.get("swf")) : null;
+            FurniConsistencyValidator.Report report = FurniConsistencyValidator.validate(
+                    items,
+                    furnitureData,
+                    Path.of(options.get("bundles")),
+                    Path.of(options.get("icons")),
+                    swf);
+
+            Path reportPath = Path.of(options.get("report"));
+            if (reportPath.getParent() != null) Files.createDirectories(reportPath.getParent());
+            Files.writeString(reportPath, GSON.toJson(report));
+            out.printf("Furni audit: %d items, %d FurnitureData entries, %d bundles, %d findings%n",
+                    report.summary().itemsChecked(), report.summary().furnitureDataEntries(),
+                    report.summary().bundlesChecked(), report.findings().size());
+            if (!options.containsKey("quiet")) {
+                report.findings().forEach(finding -> out.printf("[%s] item=%s classname=%s %s%n",
+                        finding.code(), finding.itemId(), finding.classname(), finding.message()));
+            }
+            out.println("Report: " + reportPath.toAbsolutePath());
+            return report.valid() ? 0 : 1;
+        } catch (Exception exception) {
+            error.println("Furni audit failed: " + exception.getMessage());
+            usage(error);
+            return 2;
+        }
+    }
+
+    private static List<FurniConsistencyValidator.ItemBase> readItems(Path path) throws Exception {
+        JsonElement root = JsonParser.parseString(Files.readString(path));
+        JsonArray array = root.isJsonArray() ? root.getAsJsonArray() : root.getAsJsonObject().getAsJsonArray("items");
+        if (array == null) throw new IllegalArgumentException("items JSON must be an array or contain an items array");
+        List<FurniConsistencyValidator.ItemBase> items = new ArrayList<>();
+        for (JsonElement element : array) {
+            items.add(GSON.fromJson(element, FurniConsistencyValidator.ItemBase.class));
+        }
+        return List.copyOf(items);
+    }
+
+    private static List<FurniConsistencyValidator.ItemBase> readItemsFromDatabase(Map<String, String> options)
+            throws Exception {
+        String user = options.getOrDefault("db-user", "root");
+        String passwordEnvironment = options.getOrDefault("db-password-env", "POLARIS_DB_PASSWORD");
+        String password = System.getenv(passwordEnvironment);
+        if (password == null) throw new IllegalArgumentException("missing database password environment: " + passwordEnvironment);
+
+        List<FurniConsistencyValidator.ItemBase> items = new ArrayList<>();
+        try (var connection = DriverManager.getConnection(options.get("jdbc-url"), user, password);
+             var statement = connection.prepareStatement(
+                     "SELECT id, sprite_id, item_name, type, interaction_type FROM items_base ORDER BY id");
+             var result = statement.executeQuery()) {
+            while (result.next()) {
+                items.add(new FurniConsistencyValidator.ItemBase(
+                        result.getInt("id"), result.getInt("sprite_id"), result.getString("item_name"),
+                        result.getString("type"), result.getString("interaction_type")));
+            }
+        }
+        return List.copyOf(items);
+    }
+
+    private static Map<String, String> options(String[] arguments) {
+        Map<String, String> result = new HashMap<>();
+        for (int index = 0; index < arguments.length; index++) {
+            String argument = arguments[index];
+            if (!argument.startsWith("--")) throw new IllegalArgumentException("unexpected argument: " + argument);
+            String key = argument.substring(2);
+            if (key.equals("help") || key.equals("quiet")) {
+                result.put(key, "true");
+                continue;
+            }
+            if (++index >= arguments.length) throw new IllegalArgumentException("missing value for --" + key);
+            result.put(key, arguments[index]);
+        }
+        return result;
+    }
+
+    private static void require(Map<String, String> options, String... names) {
+        for (String name : names) {
+            if (!options.containsKey(name) || options.get(name).isBlank()) {
+                throw new IllegalArgumentException("missing --" + name);
+            }
+        }
+    }
+
+    private static void usage(PrintStream out) {
+        out.println("Usage: FurniConsistencyCli --items items-base.json OR --items-sql-dump database.sql OR --jdbc-url jdbc:mariadb://... ");
+        out.println("       --furniture-data FurnitureData.json --bundles DIR --icons DIR [--swf DIR] --report report.json [--quiet]");
+        out.println("Database mode also accepts --db-user USER --db-password-env ENV_NAME.");
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/tools/furni/FurniConsistencyValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/tools/furni/FurniConsistencyValidator.java
@@ -1,0 +1,238 @@
+package com.eu.habbo.tools.furni;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
+
+public final class FurniConsistencyValidator {
+    private static final Pattern SIMPLE_REDEEM = Pattern.compile("^(?:CF|CFC|PF)_(\\d+)(?:_|$)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern DIAMOND_REDEEM = Pattern.compile("^CF_DIAMOND_(\\d+)(?:_|$)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern TYPED_REDEEM = Pattern.compile("^DF_\\d+_(\\d+)(?:_|$)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern INVALID_ASSET_PATH = Pattern.compile("[<>:\"/\\\\|?*\\x00-\\x1f]");
+    private static final Pattern RESERVED_WINDOWS_NAME = Pattern.compile(
+            "^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\\..*)?$", Pattern.CASE_INSENSITIVE);
+
+    private FurniConsistencyValidator() {
+    }
+
+    public static Report validate(List<ItemBase> items, JsonObject furnitureData, Path bundlesDirectory,
+                                  Path iconsDirectory, Path swfDirectory) {
+        List<Finding> findings = new ArrayList<>();
+        Map<String, List<FurnitureEntry>> byClassname = indexFurnitureData(furnitureData, findings);
+        int bundlesChecked = 0;
+        int itemsChecked = 0;
+
+        for (ItemBase item : items) {
+            if (!requiresFurnitureAssets(item)) continue;
+            itemsChecked++;
+            String key = normalize(item.itemName());
+            List<FurnitureEntry> entries = byClassname.getOrDefault(key, List.of());
+            if (entries.isEmpty()) {
+                findings.add(finding("missing_furniture_data", item,
+                        "classname is absent from FurnitureData.json"));
+            } else {
+                boolean expectsWall = "i".equalsIgnoreCase(item.type());
+                boolean mapped = entries.stream().anyMatch(entry -> entry.id() == item.spriteId()
+                        && entry.wall() == expectsWall);
+                if (!mapped) {
+                    findings.add(finding("id_classname_mismatch", item,
+                            "sprite_id/type does not match the FurnitureData classname entry"));
+                }
+            }
+
+            String assetName = assetName(item.itemName());
+            if (!isPortableAssetName(assetName)) {
+                findings.add(finding("invalid_asset_path", item,
+                        "classname cannot be represented as a portable Windows/Linux asset filename"));
+                continue;
+            }
+
+            Path bundle = bundlesDirectory.resolve(assetName + ".nitro");
+            if (!Files.isRegularFile(bundle)) {
+                findings.add(finding("missing_bundle", item, "missing .nitro furniture bundle"));
+            } else {
+                bundlesChecked++;
+                validateBundle(item, assetName, bundle, findings);
+            }
+
+            Path icon = iconsDirectory.resolve(assetName + "_icon.png");
+            if (!Files.isRegularFile(icon)) {
+                findings.add(finding("missing_icon", item, "missing legacy/catalog icon"));
+            }
+
+            if (swfDirectory != null && !Files.isRegularFile(swfDirectory.resolve(assetName + ".swf"))) {
+                findings.add(finding("missing_swf", item, "missing optional legacy SWF asset"));
+            }
+        }
+
+        return new Report(List.copyOf(findings),
+                new Summary(itemsChecked, byClassname.values().stream().mapToInt(List::size).sum(), bundlesChecked));
+    }
+
+    private static Map<String, List<FurnitureEntry>> indexFurnitureData(JsonObject root, List<Finding> findings) {
+        Map<String, List<FurnitureEntry>> indexed = new HashMap<>();
+        addFurnitureSection(root, "roomitemtypes", false, indexed);
+        addFurnitureSection(root, "wallitemtypes", true, indexed);
+        indexed.forEach((classname, entries) -> {
+            if (entries.size() > 1) {
+                findings.add(new Finding("duplicate_classname", null, classname,
+                        "FurnitureData contains " + entries.size() + " entries for the same classname"));
+            }
+        });
+        return indexed;
+    }
+
+    private static void addFurnitureSection(JsonObject root, String section, boolean wall,
+                                            Map<String, List<FurnitureEntry>> target) {
+        if (!root.has(section) || !root.get(section).isJsonObject()) return;
+        JsonObject wrapper = root.getAsJsonObject(section);
+        if (!wrapper.has("furnitype") || !wrapper.get("furnitype").isJsonArray()) return;
+        for (JsonElement element : wrapper.getAsJsonArray("furnitype")) {
+            if (!element.isJsonObject()) continue;
+            JsonObject entry = element.getAsJsonObject();
+            if (!entry.has("id") || !entry.has("classname")) continue;
+            String classname = entry.get("classname").getAsString();
+            target.computeIfAbsent(normalize(classname), ignored -> new ArrayList<>())
+                    .add(new FurnitureEntry(entry.get("id").getAsInt(), classname, wall));
+        }
+    }
+
+    private static void validateBundle(ItemBase item, String assetName, Path bundle, List<Finding> findings) {
+        try {
+            JsonObject json = readFurnitureJson(bundle, assetName);
+            if (!json.has("name") || !assetName.equalsIgnoreCase(json.get("name").getAsString())) {
+                findings.add(finding("bundle_classname_mismatch", item,
+                        "bundle metadata name does not match items_base.item_name"));
+            }
+
+            OptionalInt expectedCredits = expectedCredits(item.itemName());
+            if (expectedCredits.isPresent()) {
+                String logicType = json.has("logicType") ? json.get("logicType").getAsString() : "";
+                JsonObject logic = json.has("logic") && json.get("logic").isJsonObject()
+                        ? json.getAsJsonObject("logic") : new JsonObject();
+                int actualCredits = logic.has("credits") ? logic.get("credits").getAsInt() : -1;
+                if (!"furniture_credit".equals(logicType) || actualCredits != expectedCredits.getAsInt()) {
+                    findings.add(finding("credit_logic_mismatch", item,
+                            "bundle logic.credits must equal redeemable classname value "
+                                    + expectedCredits.getAsInt()));
+                }
+            }
+        } catch (Exception exception) {
+            findings.add(finding("invalid_bundle", item, exception.getMessage()));
+        }
+    }
+
+    static JsonObject readFurnitureJson(Path bundle, String classname) throws IOException {
+        try (DataInputStream input = new DataInputStream(Files.newInputStream(bundle))) {
+            int count = input.readUnsignedShort();
+            for (int index = 0; index < count; index++) {
+                int nameLength = input.readUnsignedShort();
+                String name = new String(input.readNBytes(nameLength), StandardCharsets.UTF_8);
+                int compressedLength = input.readInt();
+                if (compressedLength < 0 || compressedLength > 64 * 1024 * 1024) {
+                    throw new IOException("invalid compressed entry length");
+                }
+                byte[] compressed = input.readNBytes(compressedLength);
+                if (compressed.length != compressedLength) throw new EOFException("truncated bundle entry");
+                if (name.equalsIgnoreCase(classname + ".json")) {
+                    try (var decompressed = compressed.length > 2
+                            && (compressed[0] & 0xff) == 0x1f && (compressed[1] & 0xff) == 0x8b
+                            ? new GZIPInputStream(new ByteArrayInputStream(compressed))
+                            : new InflaterInputStream(new ByteArrayInputStream(compressed))) {
+                        return JsonParser.parseString(new String(decompressed.readAllBytes(), StandardCharsets.UTF_8))
+                                .getAsJsonObject();
+                    }
+                }
+            }
+        }
+        throw new IOException("bundle is missing " + classname + ".json");
+    }
+
+    private static OptionalInt expectedCredits(String classname) {
+        for (Pattern pattern : List.of(DIAMOND_REDEEM, TYPED_REDEEM, SIMPLE_REDEEM)) {
+            Matcher matcher = pattern.matcher(classname);
+            if (matcher.find()) {
+                try {
+                    int value = Integer.parseInt(matcher.group(1));
+                    return value > 0 ? OptionalInt.of(value) : OptionalInt.empty();
+                } catch (NumberFormatException ignored) {
+                    return OptionalInt.empty();
+                }
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    private static Finding finding(String code, ItemBase item, String message) {
+        return new Finding(code, item.id(), item.itemName(), message);
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.strip().toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isPortableAssetName(String value) {
+        return value != null && !value.isBlank()
+                && !value.endsWith(".") && !value.endsWith(" ")
+                && !INVALID_ASSET_PATH.matcher(value).find()
+                && !RESERVED_WINDOWS_NAME.matcher(value).matches();
+    }
+
+    private static String assetName(String classname) {
+        if (classname == null) return "";
+        int variant = classname.indexOf('*');
+        return variant > 0 ? classname.substring(0, variant) : classname;
+    }
+
+    private static boolean requiresFurnitureAssets(ItemBase item) {
+        if (!("s".equalsIgnoreCase(item.type()) || "i".equalsIgnoreCase(item.type()))) return false;
+        String name = normalize(item.itemName());
+        return !name.startsWith("a0 pet");
+    }
+
+    public record ItemBase(
+            int id,
+            @SerializedName("sprite_id") int spriteId,
+            @SerializedName("item_name") String itemName,
+            String type,
+            @SerializedName("interaction_type") String interactionType) {
+    }
+
+    private record FurnitureEntry(int id, String classname, boolean wall) {
+    }
+
+    public record Finding(String code, Integer itemId, String classname, String message) {
+    }
+
+    public record Summary(int itemsChecked, int furnitureDataEntries, int bundlesChecked) {
+    }
+
+    public record Report(List<Finding> findings, Summary summary) {
+        public boolean valid() {
+            return findings.isEmpty();
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/tools/furni/ItemsBaseSqlDumpReader.java
+++ b/Emulator/src/main/java/com/eu/habbo/tools/furni/ItemsBaseSqlDumpReader.java
@@ -1,0 +1,128 @@
+package com.eu.habbo.tools.furni;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class ItemsBaseSqlDumpReader {
+    private static final String INSERT = "insert into `items_base`";
+
+    private ItemsBaseSqlDumpReader() {
+    }
+
+    public static List<FurniConsistencyValidator.ItemBase> read(String sql) {
+        Map<Integer, FurniConsistencyValidator.ItemBase> items = new LinkedHashMap<>();
+        String lower = sql.toLowerCase(Locale.ROOT);
+        int searchFrom = 0;
+        while (true) {
+            int insert = lower.indexOf(INSERT, searchFrom);
+            if (insert < 0) break;
+            int columnsStart = sql.indexOf('(', insert + INSERT.length());
+            int columnsEnd = columnsStart < 0 ? -1 : sql.indexOf(')', columnsStart + 1);
+            if (columnsEnd < 0) break;
+            int values = lower.indexOf("values", columnsEnd);
+            if (values < 0) break;
+
+            List<String> columns = splitColumns(sql.substring(columnsStart + 1, columnsEnd));
+            Map<String, Integer> indexes = new HashMap<>();
+            for (int index = 0; index < columns.size(); index++) indexes.put(columns.get(index), index);
+            requireColumns(indexes);
+
+            int cursor = values + "values".length();
+            while (cursor < sql.length()) {
+                cursor = skipWhitespaceAndCommas(sql, cursor);
+                if (cursor >= sql.length() || sql.charAt(cursor) == ';') {
+                    cursor++;
+                    break;
+                }
+                if (sql.charAt(cursor) != '(') {
+                    throw new IllegalArgumentException("invalid items_base VALUES tuple near offset " + cursor);
+                }
+                ParsedTuple tuple = parseTuple(sql, cursor + 1);
+                List<String> fields = tuple.fields();
+                FurniConsistencyValidator.ItemBase item = new FurniConsistencyValidator.ItemBase(
+                        integer(fields, indexes, "id"),
+                        integer(fields, indexes, "sprite_id"),
+                        string(fields, indexes, "item_name"),
+                        string(fields, indexes, "type"),
+                        string(fields, indexes, "interaction_type"));
+                items.put(item.id(), item);
+                cursor = tuple.nextIndex();
+            }
+            searchFrom = Math.max(cursor, columnsEnd + 1);
+        }
+        return List.copyOf(items.values());
+    }
+
+    private static List<String> splitColumns(String value) {
+        List<String> columns = new ArrayList<>();
+        for (String column : value.split(",")) {
+            columns.add(column.strip().replace("`", "").toLowerCase(Locale.ROOT));
+        }
+        return columns;
+    }
+
+    private static ParsedTuple parseTuple(String sql, int cursor) {
+        List<String> fields = new ArrayList<>();
+        StringBuilder field = new StringBuilder();
+        boolean quoted = false;
+        while (cursor < sql.length()) {
+            char value = sql.charAt(cursor++);
+            if (quoted) {
+                if (value == '\\' && cursor < sql.length()) {
+                    field.append(sql.charAt(cursor++));
+                } else if (value == '\'' && cursor < sql.length() && sql.charAt(cursor) == '\'') {
+                    field.append('\'');
+                    cursor++;
+                } else if (value == '\'') {
+                    quoted = false;
+                } else {
+                    field.append(value);
+                }
+                continue;
+            }
+            if (value == '\'') {
+                quoted = true;
+            } else if (value == ',') {
+                fields.add(field.toString().strip());
+                field.setLength(0);
+            } else if (value == ')') {
+                fields.add(field.toString().strip());
+                return new ParsedTuple(List.copyOf(fields), cursor);
+            } else {
+                field.append(value);
+            }
+        }
+        throw new IllegalArgumentException("unterminated items_base VALUES tuple");
+    }
+
+    private static int skipWhitespaceAndCommas(String sql, int cursor) {
+        while (cursor < sql.length()) {
+            char value = sql.charAt(cursor);
+            if (!Character.isWhitespace(value) && value != ',') break;
+            cursor++;
+        }
+        return cursor;
+    }
+
+    private static int integer(List<String> fields, Map<String, Integer> indexes, String column) {
+        return Integer.parseInt(fields.get(indexes.get(column)));
+    }
+
+    private static String string(List<String> fields, Map<String, Integer> indexes, String column) {
+        String value = fields.get(indexes.get(column));
+        return value.equalsIgnoreCase("NULL") ? "" : value;
+    }
+
+    private static void requireColumns(Map<String, Integer> indexes) {
+        for (String column : List.of("id", "sprite_id", "item_name", "type", "interaction_type")) {
+            if (!indexes.containsKey(column)) throw new IllegalArgumentException("items_base dump is missing " + column);
+        }
+    }
+
+    private record ParsedTuple(List<String> fields, int nextIndex) {
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/tools/furni/FurniConsistencyCliTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/tools/furni/FurniConsistencyCliTest.java
@@ -1,0 +1,23 @@
+package com.eu.habbo.tools.furni;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FurniConsistencyCliTest {
+    @Test
+    void helpDocumentsFileAndDatabaseModes() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        int result = FurniConsistencyCli.run(new String[]{"--help"}, new PrintStream(output), System.err);
+
+        assertEquals(0, result);
+        assertTrue(output.toString().contains("--items"));
+        assertTrue(output.toString().contains("--jdbc-url"));
+        assertTrue(output.toString().contains("--report"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/tools/furni/FurniConsistencyReportArtifactTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/tools/furni/FurniConsistencyReportArtifactTest.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.tools.furni;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FurniConsistencyReportArtifactTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void writesMachineReadableFixtureReportForCiArtifactUpload() throws Exception {
+        var item = new FurniConsistencyValidator.ItemBase(7, 7, "missing_fixture", "s", "default");
+        var furnitureData = JsonParser.parseString("""
+                {"roomitemtypes":{"furnitype":[{"id":7,"classname":"missing_fixture"}]},
+                 "wallitemtypes":{"furnitype":[]}}
+                """).getAsJsonObject();
+        var report = FurniConsistencyValidator.validate(
+                List.of(item), furnitureData,
+                Files.createDirectories(temp.resolve("bundles")),
+                Files.createDirectories(temp.resolve("icons")), null);
+
+        Path artifact = Path.of("target/furni-consistency-fixture.json");
+        Files.createDirectories(artifact.getParent());
+        Files.writeString(artifact, new GsonBuilder().setPrettyPrinting().create().toJson(report));
+
+        assertTrue(Files.size(artifact) > 0);
+        assertTrue(JsonParser.parseString(Files.readString(artifact)).getAsJsonObject().has("findings"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/tools/furni/FurniConsistencyValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/tools/furni/FurniConsistencyValidatorTest.java
@@ -1,0 +1,146 @@
+package com.eu.habbo.tools.furni;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.DataOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.DeflaterOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FurniConsistencyValidatorTest {
+    @TempDir
+    Path temp;
+
+    @Test
+    void validatesDatabaseFurnitureDataBundleIconAndCreditLogicTogether() throws Exception {
+        Path bundles = Files.createDirectories(temp.resolve("bundles"));
+        Path icons = Files.createDirectories(temp.resolve("icons"));
+        writeBundle(bundles.resolve("CF_50_goldbar.nitro"), "CF_50_goldbar", "50");
+        Files.write(icons.resolve("CF_50_goldbar_icon.png"), new byte[]{1});
+
+        var item = new FurniConsistencyValidator.ItemBase(2066, 2066, "CF_50_goldbar", "s", "default");
+        JsonObject furnitureData = furnitureData("CF_50_goldbar", 2066, false);
+        var report = FurniConsistencyValidator.validate(
+                List.of(item), furnitureData, bundles, icons, null);
+
+        assertTrue(report.findings().isEmpty());
+        assertEquals(1, report.summary().itemsChecked());
+        assertEquals(1, report.summary().bundlesChecked());
+    }
+
+    @Test
+    void reportsDuplicatesMappingAssetsAndCreditLogicWithStableCodes() throws Exception {
+        Path bundles = Files.createDirectories(temp.resolve("broken-bundles"));
+        Path icons = Files.createDirectories(temp.resolve("broken-icons"));
+        writeBundle(bundles.resolve("CF_50_goldbar.nitro"), "CF_50_goldbar", "5");
+
+        var items = List.of(
+                new FurniConsistencyValidator.ItemBase(1, 2066, "CF_50_goldbar", "s", "default"),
+                new FurniConsistencyValidator.ItemBase(2, 9999, "missing_asset", "i", "default"));
+        JsonObject furnitureData = JsonParser.parseString("""
+                {"roomitemtypes":{"furnitype":[
+                  {"id":2066,"classname":"CF_50_goldbar"},
+                  {"id":999,"classname":"CF_50_goldbar"}
+                ]},"wallitemtypes":{"furnitype":[]}}
+                """).getAsJsonObject();
+
+        var report = FurniConsistencyValidator.validate(items, furnitureData, bundles, icons, null);
+        var codes = report.findings().stream().map(FurniConsistencyValidator.Finding::code).toList();
+
+        assertTrue(codes.contains("duplicate_classname"));
+        assertTrue(codes.contains("missing_furniture_data"));
+        assertTrue(codes.contains("missing_bundle"));
+        assertTrue(codes.contains("missing_icon"));
+        assertTrue(codes.contains("credit_logic_mismatch"));
+    }
+
+    @Test
+    void legacyVariantSuffixUsesTheSharedPortableAssetName() throws Exception {
+        Path bundles = Files.createDirectories(temp.resolve("path-bundles"));
+        Path icons = Files.createDirectories(temp.resolve("path-icons"));
+        writeBundle(bundles.resolve("table_plasto_4leg.nitro"), "table_plasto_4leg", "0");
+        Files.write(icons.resolve("table_plasto_4leg_icon.png"), new byte[]{1});
+        var item = new FurniConsistencyValidator.ItemBase(9, 9, "table_plasto_4leg*1", "s", "default");
+
+        var report = FurniConsistencyValidator.validate(
+                List.of(item), furnitureData("table_plasto_4leg*1", 9, false), bundles, icons, null);
+
+        assertTrue(report.findings().stream()
+                .noneMatch(finding -> finding.code().equals("invalid_asset_path")));
+        assertTrue(report.findings().stream()
+                .noneMatch(finding -> finding.code().equals("missing_bundle")));
+    }
+
+    @Test
+    void acceptsZlibCompressedNitroJsonEntries() throws Exception {
+        Path bundles = Files.createDirectories(temp.resolve("zlib-bundles"));
+        Path icons = Files.createDirectories(temp.resolve("zlib-icons"));
+        writeBundle(bundles.resolve("chair_basic.nitro"), "chair_basic", "0", false);
+        Files.write(icons.resolve("chair_basic_icon.png"), new byte[]{1});
+
+        var report = FurniConsistencyValidator.validate(
+                List.of(new FurniConsistencyValidator.ItemBase(11, 11, "chair_basic", "s", "default")),
+                furnitureData("chair_basic", 11, false), bundles, icons, null);
+
+        assertTrue(report.findings().stream().noneMatch(finding -> finding.code().equals("invalid_bundle")));
+    }
+
+    @Test
+    void skipsNonFurnitureAndVirtualPetRows() throws Exception {
+        Path bundles = Files.createDirectories(temp.resolve("virtual-bundles"));
+        Path icons = Files.createDirectories(temp.resolve("virtual-icons"));
+        var items = List.of(
+                new FurniConsistencyValidator.ItemBase(1, 0, "bot_generic", "r", "default"),
+                new FurniConsistencyValidator.ItemBase(2, 50000, "a0 pet0", "s", "default"));
+
+        var report = FurniConsistencyValidator.validate(items,
+                JsonParser.parseString("{\"roomitemtypes\":{\"furnitype\":[]},\"wallitemtypes\":{\"furnitype\":[]}}")
+                        .getAsJsonObject(), bundles, icons, null);
+
+        assertEquals(0, report.summary().itemsChecked());
+        assertTrue(report.findings().isEmpty());
+    }
+
+    private static JsonObject furnitureData(String classname, int id, boolean wall) {
+        String room = wall ? "[]" : "[{\"id\":" + id + ",\"classname\":\"" + classname + "\"}]";
+        String walls = wall ? "[{\"id\":" + id + ",\"classname\":\"" + classname + "\"}]" : "[]";
+        return JsonParser.parseString("{\"roomitemtypes\":{\"furnitype\":" + room
+                + "},\"wallitemtypes\":{\"furnitype\":" + walls + "}}").getAsJsonObject();
+    }
+
+    private static void writeBundle(Path target, String classname, String credits) throws Exception {
+        writeBundle(target, classname, credits, true);
+    }
+
+    private static void writeBundle(Path target, String classname, String credits, boolean gzipCompression)
+            throws Exception {
+        byte[] json = ("{\"type\":\"furniture\",\"name\":\"" + classname
+                + "\",\"logicType\":\"furniture_credit\",\"logic\":{\"credits\":\""
+                + credits + "\"}}").getBytes(StandardCharsets.UTF_8);
+        byte[] compressed;
+        try (var bytes = new java.io.ByteArrayOutputStream();
+             var compressedOutput = gzipCompression ? new GZIPOutputStream(bytes) : new DeflaterOutputStream(bytes)) {
+            compressedOutput.write(json);
+            compressedOutput.finish();
+            compressed = bytes.toByteArray();
+        }
+        byte[] name = (classname + ".json").getBytes(StandardCharsets.UTF_8);
+        try (OutputStream output = Files.newOutputStream(target); DataOutputStream data = new DataOutputStream(output)) {
+            data.writeShort(1);
+            data.writeShort(name.length);
+            data.write(name);
+            data.writeInt(compressed.length);
+            data.write(compressed);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/tools/furni/FurniImportPipelineContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/tools/furni/FurniImportPipelineContractTest.java
@@ -1,0 +1,27 @@
+package com.eu.habbo.tools.furni;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FurniImportPipelineContractTest {
+    @Test
+    void canonicalProcedureCoversEveryDatabaseAndAssetLayer() throws Exception {
+        String documentation = Files.readString(Path.of("../docs/FURNI_IMPORT_PIPELINE.md"));
+        String wrapper = Files.readString(Path.of("../scripts/verify-furni-import.ps1"));
+
+        for (String required : new String[]{
+                "items_base", "catalog_items", "FurnitureData.json", ".nitro", "_icon.png",
+                "logic.credits", "MariaDB transaction", "JSON report"}) {
+            assertTrue(documentation.contains(required), required);
+        }
+        assertTrue(wrapper.contains("FurniConsistencyCli"));
+        assertTrue(wrapper.contains("--items-sql-dump"));
+        assertTrue(wrapper.contains("--furniture-data"));
+        assertTrue(wrapper.contains("--bundles"));
+        assertTrue(wrapper.contains("--icons"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/tools/furni/ItemsBaseSqlDumpReaderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/tools/furni/ItemsBaseSqlDumpReaderTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.tools.furni;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ItemsBaseSqlDumpReaderTest {
+    @Test
+    void readsMultipleItemsBaseInsertBlocksAndQuotedValues() {
+        String sql = """
+                INSERT INTO `items_base` (`id`, `sprite_id`, `public_name`, `item_name`, `type`, `interaction_type`) VALUES
+                  (1, 2066, 'Gold Bar', 'CF_50_goldbar', 's', 'default'),
+                  (2, 4608, 'Manager''s Portrait', 'diamond_painting14', 'i', 'default');
+                INSERT INTO `other` (`id`) VALUES (9);
+                INSERT INTO `items_base` (`interaction_type`, `type`, `item_name`, `sprite_id`, `id`) VALUES
+                  ('default', 's', 'escaped\\_name', 99, 3);
+                """;
+
+        var items = ItemsBaseSqlDumpReader.read(sql);
+
+        assertEquals(3, items.size());
+        assertEquals("CF_50_goldbar", items.get(0).itemName());
+        assertEquals(4608, items.get(1).spriteId());
+        assertEquals("escaped_name", items.get(2).itemName());
+    }
+}

--- a/docs/FURNI_IMPORT_PIPELINE.md
+++ b/docs/FURNI_IMPORT_PIPELINE.md
@@ -1,0 +1,58 @@
+# Canonical Furni Import and Verification Pipeline
+
+This is the single acceptance procedure for furni changes shared by Polaris, Nitro Render, UI, and the live `Nitro-Files` tree. An import is not complete when only the database row exists.
+
+## Required import package
+
+Every imported furni must provide, as one reviewed package:
+
+- the `items_base` row and every intended `catalog_items` row;
+- one `FurnitureData.json` entry whose `classname`, numeric `id`, and floor/wall section match `item_name`, `sprite_id`, and `type`;
+- `<classname>.nitro` in `nitro-assets/bundled/furniture`;
+- `<classname>_icon.png` in `swf/dcr/hof_furni/icons`;
+- `<classname>.swf` when the target deployment still serves legacy SWF assets;
+- for redeemable names (`CF_`, `CFC_`, `PF_`, `DF_`, and `CF_diamond_`), bundle `logicType=furniture_credit` and `logic.credits` equal to the value encoded in the classname.
+
+## Procedure
+
+1. Stage the SQL rows, `FurnitureData.json`, bundle, icon, and optional SWF together. Do not write only one layer to production.
+2. Apply the SQL in one MariaDB transaction on a disposable or staging schema first.
+3. Point the validator at the staged/exported `items_base` and the exact `Nitro-Files` tree that the client will read.
+4. Promote the package only when the validator exits with code `0`.
+5. Archive the generated JSON report with the import. Exit code `1` means inconsistencies were found; exit code `2` means the audit itself could not run.
+6. If promotion fails after files were copied, restore the prior `FurnitureData.json` and asset files, then roll back or reverse the database transaction. Never accept a database-only or files-only import.
+
+## Windows command
+
+From the emulator repository:
+
+```powershell
+.\scripts\verify-furni-import.ps1 `
+  -ItemsSource '.\Database\Default Database\FullDatabase.sql' `
+  -FurnitureData '..\Nitro-Files\nitro-assets\gamedata\FurnitureData.json' `
+  -NitroRoot '..\Nitro-Files' `
+  -Report '.\reports\furni-consistency.json'
+```
+
+Pass `-ItemsJson` when `ItemsSource` is a JSON array/export instead of a MariaDB dump. Pass `-RequireSwf` only for deployments that require legacy SWFs.
+
+## Direct database command
+
+The Java CLI can audit the current database without exporting credentials to a file:
+
+```powershell
+$env:POLARIS_DB_PASSWORD = '<local secret>'
+$jar = Get-ChildItem '.\Emulator\target\*-jar-with-dependencies.jar' |
+  Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+java -cp $jar.FullName `
+  com.eu.habbo.tools.furni.FurniConsistencyCli `
+  --jdbc-url 'jdbc:mariadb://127.0.0.1:3306/habbo' `
+  --db-user 'root' `
+  --db-password-env 'POLARIS_DB_PASSWORD' `
+  --furniture-data '..\Nitro-Files\nitro-assets\gamedata\FurnitureData.json' `
+  --bundles '..\Nitro-Files\nitro-assets\bundled\furniture' `
+  --icons '..\Nitro-Files\swf\dcr\hof_furni\icons' `
+  --report '.\reports\furni-consistency-live.json'
+```
+
+The CLI never prints the password and performs no database or asset mutation.

--- a/scripts/verify-furni-import.ps1
+++ b/scripts/verify-furni-import.ps1
@@ -1,0 +1,47 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ItemsSource,
+    [Parameter(Mandatory = $true)]
+    [string]$FurnitureData,
+    [Parameter(Mandatory = $true)]
+    [string]$NitroRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$Report,
+    [switch]$ItemsJson,
+    [switch]$RequireSwf,
+    [switch]$Quiet
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$moduleRoot = Join-Path $repoRoot 'Emulator'
+$jar = Get-ChildItem -LiteralPath (Join-Path $moduleRoot 'target') -Filter '*-jar-with-dependencies.jar' -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTimeUtc -Descending |
+    Select-Object -First 1
+$latestSource = Get-ChildItem -LiteralPath (Join-Path $moduleRoot 'src') -Recurse -File |
+    Sort-Object LastWriteTimeUtc -Descending |
+    Select-Object -First 1
+
+if ($null -eq $jar -or ($null -ne $latestSource -and $latestSource.LastWriteTimeUtc -gt $jar.LastWriteTimeUtc)) {
+    & mvn -B -f (Join-Path $moduleRoot 'pom.xml') -DskipTests package
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    $jar = Get-ChildItem -LiteralPath (Join-Path $moduleRoot 'target') -Filter '*-jar-with-dependencies.jar' |
+        Sort-Object LastWriteTimeUtc -Descending |
+        Select-Object -First 1
+}
+
+$sourceOption = if ($ItemsJson) { '--items' } else { '--items-sql-dump' }
+$arguments = @(
+    '-cp', $jar.FullName,
+    'com.eu.habbo.tools.furni.FurniConsistencyCli',
+    $sourceOption, (Resolve-Path -LiteralPath $ItemsSource).Path,
+    '--furniture-data', (Resolve-Path -LiteralPath $FurnitureData).Path,
+    '--bundles', (Join-Path $NitroRoot 'nitro-assets\bundled\furniture'),
+    '--icons', (Join-Path $NitroRoot 'swf\dcr\hof_furni\icons'),
+    '--report', $Report
+)
+if ($RequireSwf) { $arguments += @('--swf', (Join-Path $NitroRoot 'swf\dcr\hof_furni')) }
+if ($Quiet) { $arguments += '--quiet' }
+
+& java @arguments
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

- validate items_base against FurnitureData classnames, sprite IDs, and floor/wall sections
- detect duplicate classnames, missing bundles/icons/optional SWFs, and malformed Nitro bundles
- inspect both gzip and zlib Nitro containers and verify redeemable logic.credits
- support JSON exports, MariaDB dumps, and direct JDBC reads without printing credentials
- generate machine-readable reports and upload the CI fixture report
- document one canonical import acceptance procedure for emulator, renderer, UI, and Nitro-Files

## Verification

- mvn -B verify: 593 tests, 0 failures, 0 errors, 1 skipped
- live read-only audit: 10,423 items and 55,855 FurnitureData entries checked; report generated without modifying Nitro-Files
- git diff --check

## Roadmap

Completes P1 items 46-49, 51-52, 58, and 60.