### PR TITLE
Complete RCON and plugin boundary validation

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/ChangeRoomOwner.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/ChangeRoomOwner.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.Positive;
 
 public class ChangeRoomOwner extends RCONMessage<ChangeRoomOwner.JSON> {
     public ChangeRoomOwner() {
@@ -43,9 +44,11 @@ public class ChangeRoomOwner extends RCONMessage<ChangeRoomOwner.JSON> {
 
     static class JSON {
 
+        @Positive(message = "invalid room")
         public int room_id;
 
 
+        @Positive(message = "invalid user")
         public int user_id;
 
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/ChangeUsername.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/ChangeUsername.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.outgoing.users.UserDataComposer;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.Positive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +63,7 @@ public class ChangeUsername extends RCONMessage<ChangeUsername.JSON> {
     }
 
     static class JSON {
+        @Positive(message = "invalid user")
         public int user_id;
 
         public boolean canChange;

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/ModifyUserSubscription.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/ModifyUserSubscription.java
@@ -4,6 +4,10 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,10 +109,17 @@ public class ModifyUserSubscription extends RCONMessage<ModifyUserSubscription.J
 
     static class JSON {
 
+        @Positive(message = "invalid user")
         public int user_id;
 
+        @NotBlank(message = "invalid subscription type")
+        @Size(max = 64, message = "invalid subscription type")
+        @Pattern(regexp = "[A-Za-z0-9_]+", message = "invalid subscription type")
         public String type = ""; // Subscription type e.g. HABBO_CLUB
 
+        @NotBlank(message = "invalid action")
+        @Size(max = 16, message = "invalid action")
+        @Pattern(regexp = "(?i)^(add|remove|a|r|\\+|-)$", message = "invalid action")
         public String action = ""; // Can be add or remove
 
         public int duration = -1; // Time to add/remove in seconds. -1 means remove subscription entirely

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendGift.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/SendGift.java
@@ -8,6 +8,7 @@ import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.Positive;
 
 public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
     private static final int DEFAULT_MAX_MESSAGE_LENGTH = 300;
@@ -107,9 +108,11 @@ public class SendGift extends RCONMessage<SendGift.SendGiftJSON> {
 
     static class SendGiftJSON {
 
+        @Positive(message = "invalid user")
         public int user_id = -1;
 
 
+        @Positive(message = "invalid item")
         public int itemid = -1;
 
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/StaffAlert.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/StaffAlert.java
@@ -2,6 +2,8 @@ package com.eu.habbo.messages.rcon;
 
 import com.eu.habbo.Emulator;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public class StaffAlert extends RCONMessage<StaffAlert.JSON> {
     public StaffAlert() {
@@ -15,6 +17,8 @@ public class StaffAlert extends RCONMessage<StaffAlert.JSON> {
 
     static class JSON {
 
+        @NotBlank(message = "invalid message")
+        @Size(max = 4096, message = "invalid message")
         public String message;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/UpdateUser.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/UpdateUser.java
@@ -6,6 +6,11 @@ import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDataComposer;
 import com.eu.habbo.messages.outgoing.users.MeMenuSettingsComposer;
 import com.eu.habbo.messages.outgoing.users.UpdateUserLookComposer;
 import com.google.gson.Gson;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -166,27 +171,41 @@ public class UpdateUser extends RCONMessage<UpdateUser.JSON> {
 
     static class JSON {
 
+        @Positive(message = "invalid user")
         public int user_id;
 
 
+        @PositiveOrZero(message = "invalid achievement score")
         public int achievement_score = 0;
 
 
+        @Min(value = -1, message = "invalid block_following")
+        @Max(value = 1, message = "invalid block_following")
         public int block_following = -1;
 
 
+        @Min(value = -1, message = "invalid block_friendrequests")
+        @Max(value = 1, message = "invalid block_friendrequests")
         public int block_friendrequests = -1;
 
 
+        @Min(value = -1, message = "invalid block_roominvites")
+        @Max(value = 1, message = "invalid block_roominvites")
         public int block_roominvites = -1;
 
 
+        @Min(value = -1, message = "invalid old_chat")
+        @Max(value = 1, message = "invalid old_chat")
         public int old_chat = -1;
 
 
+        @Min(value = -1, message = "invalid block_camera_follow")
+        @Max(value = 1, message = "invalid block_camera_follow")
         public int block_camera_follow = -1;
 
 
+        @Size(max = MAX_LOOK_LENGTH, message = "invalid look")
+        @jakarta.validation.constraints.Pattern(regexp = "^$|[A-Za-z0-9.-]+", message = "invalid look")
         public String look = "";
 
         public boolean strip_unredeemed_clothing = false;

--- a/Emulator/src/main/java/com/eu/habbo/plugin/PluginRuntimeValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/plugin/PluginRuntimeValidator.java
@@ -3,6 +3,10 @@ package com.eu.habbo.plugin;
 import com.eu.habbo.messages.RuntimeValidationReport;
 
 public final class PluginRuntimeValidator {
+    private static final int MAX_PLUGIN_NAME_LENGTH = 100;
+    private static final int MAX_PLUGIN_AUTHOR_LENGTH = 100;
+    private static final int MAX_MAIN_CLASS_LENGTH = 255;
+    private static final String JAVA_CLASS_NAME_PATTERN = "(?:[A-Za-z_$][A-Za-z0-9_$]*\\.)*[A-Za-z_$][A-Za-z0-9_$]*";
 
     private PluginRuntimeValidator() {
     }
@@ -17,10 +21,18 @@ public final class PluginRuntimeValidator {
 
         if (isBlank(configuration.name)) {
             report.addError("Plugin " + jarName + " is missing required plugin.json field name");
+        } else if (!isSafeMetadata(configuration.name, MAX_PLUGIN_NAME_LENGTH)) {
+            report.addError("Plugin " + jarName + " has an invalid name");
         }
 
         if (isBlank(configuration.main)) {
             report.addError("Plugin " + jarName + " is missing required plugin.json field main");
+        } else if (configuration.main.length() > MAX_MAIN_CLASS_LENGTH || !configuration.main.matches(JAVA_CLASS_NAME_PATTERN)) {
+            report.addError("Plugin " + jarName + " has an invalid main class name");
+        }
+
+        if (!isBlank(configuration.author) && !isSafeMetadata(configuration.author, MAX_PLUGIN_AUTHOR_LENGTH)) {
+            report.addError("Plugin " + jarName + " has an invalid author");
         }
 
         return report;
@@ -65,5 +77,13 @@ public final class PluginRuntimeValidator {
 
     private static boolean isBlank(String value) {
         return value == null || value.trim().isEmpty();
+    }
+
+    private static boolean isSafeMetadata(String value, int maxLength) {
+        if (value.length() > maxLength) {
+            return false;
+        }
+
+        return value.codePoints().noneMatch(Character::isISOControl);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/RconPayloadValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/RconPayloadValidatorTest.java
@@ -41,4 +41,41 @@ class RconPayloadValidatorTest {
 
         assertEquals("invalid badge", RconPayloadValidator.validate(payload));
     }
+
+    @Test
+    void rejectsInvalidRoomOwnerIdentifiersBeforeDispatch() {
+        ChangeRoomOwner.JSON payload = new ChangeRoomOwner.JSON();
+        payload.room_id = 0;
+        payload.user_id = 1;
+
+        assertEquals("invalid room", RconPayloadValidator.validate(payload));
+    }
+
+    @Test
+    void rejectsBlankStaffAlertsBeforeDispatch() {
+        StaffAlert.JSON payload = new StaffAlert.JSON();
+        payload.message = " \r\n ";
+
+        assertEquals("invalid message", RconPayloadValidator.validate(payload));
+    }
+
+    @Test
+    void rejectsInvalidSubscriptionMetadataBeforeDispatch() {
+        ModifyUserSubscription.JSON payload = new ModifyUserSubscription.JSON();
+        payload.user_id = 1;
+        payload.type = "HABBO\nCLUB";
+        payload.action = "add";
+        payload.duration = 60;
+
+        assertEquals("invalid subscription type", RconPayloadValidator.validate(payload));
+    }
+
+    @Test
+    void rejectsInvalidUpdateUserToggleBeforeDispatch() {
+        UpdateUser.JSON payload = new UpdateUser.JSON();
+        payload.user_id = 1;
+        payload.block_following = 2;
+
+        assertEquals("invalid block_following", RconPayloadValidator.validate(payload));
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/plugin/PluginRuntimeValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/plugin/PluginRuntimeValidatorTest.java
@@ -57,6 +57,35 @@ class PluginRuntimeValidatorTest {
         assertFalse(report.hasErrors());
     }
 
+    @Test
+    void rejectsPluginMetadataContainingControlCharacters() {
+        HabboPluginConfiguration configuration = configuration("Unsafe\nPlugin", ValidPlugin.class.getName());
+
+        RuntimeValidationReport report = PluginRuntimeValidator.validateConfiguration("unsafe.jar", configuration);
+
+        assertTrue(report.hasErrors());
+        assertTrue(report.errors().stream().anyMatch(issue -> issue.message().contains("invalid name")));
+    }
+
+    @Test
+    void rejectsInvalidPluginMainClassName() {
+        HabboPluginConfiguration configuration = configuration("Unsafe", "../com.eu.habbo.BadPlugin");
+
+        RuntimeValidationReport report = PluginRuntimeValidator.validateConfiguration("unsafe.jar", configuration);
+
+        assertTrue(report.hasErrors());
+        assertTrue(report.errors().stream().anyMatch(issue -> issue.message().contains("invalid main")));
+    }
+
+    @Test
+    void keepsLegacyPluginNamespaceCompatible() {
+        HabboPluginConfiguration configuration = configuration("Legacy", ValidPlugin.class.getName());
+
+        RuntimeValidationReport report = PluginRuntimeValidator.validateConfiguration("legacy.jar", configuration);
+
+        assertFalse(report.hasErrors());
+    }
+
     private static HabboPluginConfiguration configuration(String name, String main) {
         HabboPluginConfiguration configuration = new HabboPluginConfiguration();
         configuration.name = name;


### PR DESCRIPTION
## Summary
- reject invalid RCON identifiers, staff alerts, subscription metadata, user toggles, and gift identifiers before handler execution
- validate plugin names, authors, and Java main-class names while preserving legacy `com.eu.habbo` plugin compatibility
- add focused boundary-validation regression coverage

## Verification
- `mvn -q -Dtest=RconPayloadValidatorTest,PluginRuntimeValidatorTest test`
- `mvn -q clean test` (591 tests, 0 failures, 0 errors, 1 skipped)

## Roadmap
Completes item 76: common validation at the remaining RCON and plugin boundaries.