### PR TITLE
Enforce shared rate limits for operation groups

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/gameclients/GameClient.java
@@ -33,6 +33,7 @@ public class GameClient {
 
     public final ConcurrentHashMap<Integer, Integer> incomingPacketCounter = new ConcurrentHashMap<>(25);
     public final ConcurrentHashMap<Class<? extends MessageHandler>, Long> messageTimestamps = new ConcurrentHashMap<>();
+    public final ConcurrentHashMap<String, Long> groupedMessageRateLimitDeadlines = new ConcurrentHashMap<>();
     public long lastPacketCounterCleared = Emulator.getIntUnixTimestamp();
 
     public GameClient(Channel channel) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -90,6 +90,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class PacketManager {
 
@@ -206,14 +207,31 @@ public class PacketManager {
                 final MessageHandler handler = handlerClass.getDeclaredConstructor().newInstance();
 
                 if (handler.getRatelimit() > 0) {
-                    if (client.messageTimestamps.containsKey(handlerClass) && System.currentTimeMillis() - client.messageTimestamps.get(handlerClass) < handler.getRatelimit()) {
+                    long now = System.currentTimeMillis();
+                    String rateLimitGroup = handler.getRatelimitGroup();
+                    boolean rateLimited;
+
+                    if (rateLimitGroup != null && !rateLimitGroup.isBlank()) {
+                        rateLimited = !acquireGroupedRateLimit(
+                                client.groupedMessageRateLimitDeadlines,
+                                rateLimitGroup,
+                                handler.getRatelimit(),
+                                now);
+                    } else {
+                        rateLimited = client.messageTimestamps.containsKey(handlerClass)
+                                && now - client.messageTimestamps.get(handlerClass) < handler.getRatelimit();
+                    }
+
+                    if (rateLimited) {
                         if (PacketManager.DEBUG_SHOW_PACKETS) {
                             LOGGER.warn("Client packet {} was ratelimited.", packet.getMessageId());
                         }
 
                         return;
-                    } else {
-                        client.messageTimestamps.put(handlerClass, System.currentTimeMillis());
+                    }
+
+                    if (rateLimitGroup == null || rateLimitGroup.isBlank()) {
+                        client.messageTimestamps.put(handlerClass, now);
                     }
                 }
 
@@ -237,6 +255,23 @@ public class PacketManager {
         } catch (Exception e) {
             LOGGER.error("Caught exception", e);
         }
+    }
+
+    static boolean acquireGroupedRateLimit(Map<String, Long> deadlines, String group, long cooldownMs, long nowMs) {
+        if (deadlines == null || group == null || group.isBlank() || cooldownMs <= 0) {
+            return true;
+        }
+
+        AtomicBoolean acquired = new AtomicBoolean(false);
+        deadlines.compute(group, (key, deadline) -> {
+            if (deadline != null && deadline > nowMs) {
+                return deadline;
+            }
+
+            acquired.set(true);
+            return cooldownMs > Long.MAX_VALUE - nowMs ? Long.MAX_VALUE : nowMs + cooldownMs;
+        });
+        return acquired.get();
     }
 
     boolean isRegistered(int header) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/MessageHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/MessageHandler.java
@@ -15,6 +15,10 @@ public abstract class MessageHandler {
         return 0;
     }
 
+    public String getRatelimitGroup() {
+        return "";
+    }
+
     protected final Room currentRoom() {
         if (this.client == null || this.client.getHabbo() == null) return null;
         if (this.client.getHabbo().getHabboInfo() == null) return null;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemAsGiftEvent.java
@@ -45,6 +45,11 @@ public class CatalogBuyItemAsGiftEvent extends MessageHandler {
     }
 
     @Override
+    public String getRatelimitGroup() {
+        return "catalog.purchase";
+    }
+
+    @Override
     public void handle() throws Exception {
         if (Emulator.getIntUnixTimestamp() - this.client.getHabbo().getHabboStats().lastGiftTimestamp >= CatalogManager.PURCHASE_COOLDOWN) {
             if (ShutdownEmulator.timestamp > 0) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogBuyItemEvent.java
@@ -38,6 +38,11 @@ public class CatalogBuyItemEvent extends MessageHandler {
     }
 
     @Override
+    public String getRatelimitGroup() {
+        return "catalog.purchase";
+    }
+
+    @Override
     public void handle() throws Exception {
         if (Emulator.getIntUnixTimestamp() - this.client.getHabbo().getHabboStats().lastPurchaseTimestamp >= CatalogManager.PURCHASE_COOLDOWN) {
             this.client.getHabbo().getHabboStats().lastPurchaseTimestamp = Emulator.getIntUnixTimestamp();

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/PurchaseTargetOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/PurchaseTargetOfferEvent.java
@@ -15,6 +15,11 @@ public class PurchaseTargetOfferEvent extends MessageHandler {
     }
 
     @Override
+    public String getRatelimitGroup() {
+        return "catalog.purchase";
+    }
+
+    @Override
     public void handle() throws Exception {
         final int offerId = this.packet.readInt();
         int amount = this.packet.readInt();

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/marketplace/BuyItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/marketplace/BuyItemEvent.java
@@ -10,6 +10,11 @@ public class BuyItemEvent extends MessageHandler {
     }
 
     @Override
+    public String getRatelimitGroup() {
+        return "marketplace.mutation";
+    }
+
+    @Override
     public void handle() throws Exception {
         int offerId = this.packet.readInt();
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/marketplace/SellItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/marketplace/SellItemEvent.java
@@ -19,6 +19,11 @@ public class SellItemEvent extends MessageHandler {
     }
 
     @Override
+    public String getRatelimitGroup() {
+        return "marketplace.mutation";
+    }
+
+    @Override
     public void handle() throws Exception {
         if (!MarketPlace.MARKETPLACE_ENABLED) {
             this.client.sendResponse(new MarketplaceItemPostedComposer(MarketplaceItemPostedComposer.MARKETPLACE_DISABLED));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/marketplace/TakeBackItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/marketplace/TakeBackItemEvent.java
@@ -10,6 +10,11 @@ public class TakeBackItemEvent extends MessageHandler {
     }
 
     @Override
+    public String getRatelimitGroup() {
+        return "marketplace.mutation";
+    }
+
+    @Override
     public void handle() throws Exception {
         int offerId = this.packet.readInt();
 

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/earnings/ClaimAllEarningsRewardsEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/earnings/ClaimAllEarningsRewardsEvent.java
@@ -11,6 +11,11 @@ public class ClaimAllEarningsRewardsEvent extends MessageHandler {
     }
 
     @Override
+    public String getRatelimitGroup() {
+        return "earnings.claim";
+    }
+
+    @Override
     public void handle() {
         EarningsCenterManager manager = new EarningsCenterManager();
         this.client.sendResponse(new EarningsClaimResultComposer(manager.claimAll(this.client.getHabbo())));

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/earnings/ClaimEarningsRewardEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/earnings/ClaimEarningsRewardEvent.java
@@ -11,6 +11,11 @@ public class ClaimEarningsRewardEvent extends MessageHandler {
     }
 
     @Override
+    public String getRatelimitGroup() {
+        return "earnings.claim";
+    }
+
+    @Override
     public void handle() {
         String categoryKey = this.packet.readString();
         EarningsCenterManager manager = new EarningsCenterManager();

--- a/Emulator/src/test/java/com/eu/habbo/messages/PacketManagerGroupedRateLimitTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/PacketManagerGroupedRateLimitTest.java
@@ -1,0 +1,66 @@
+package com.eu.habbo.messages;
+
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.incoming.catalog.CatalogBuyItemAsGiftEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogBuyItemEvent;
+import com.eu.habbo.messages.incoming.catalog.PurchaseTargetOfferEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.BuyItemEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.SellItemEvent;
+import com.eu.habbo.messages.incoming.catalog.marketplace.TakeBackItemEvent;
+import com.eu.habbo.messages.incoming.earnings.ClaimAllEarningsRewardsEvent;
+import com.eu.habbo.messages.incoming.earnings.ClaimEarningsRewardEvent;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PacketManagerGroupedRateLimitTest {
+
+    @Test
+    void oneOperationBlocksOtherOperationsInTheSameGroupUntilItsOwnDeadline() {
+        Map<String, Long> deadlines = new ConcurrentHashMap<>();
+
+        assertTrue(acquire(deadlines, "catalog.purchase", 1_000, 10_000));
+        assertFalse(acquire(deadlines, "catalog.purchase", 250, 10_500));
+        assertTrue(acquire(deadlines, "catalog.purchase", 250, 11_000));
+    }
+
+    @Test
+    void independentOperationGroupsDoNotBlockEachOther() {
+        Map<String, Long> deadlines = new ConcurrentHashMap<>();
+
+        assertTrue(acquire(deadlines, "catalog.purchase", 1_000, 10_000));
+        assertTrue(acquire(deadlines, "earnings.claim", 1_000, 10_000));
+    }
+
+    @Test
+    void relatedEconomyHandlersDeclareSharedGroups() {
+        assertGroup("catalog.purchase", new CatalogBuyItemEvent(), new CatalogBuyItemAsGiftEvent(), new PurchaseTargetOfferEvent());
+        assertGroup("marketplace.mutation", new BuyItemEvent(), new SellItemEvent(), new TakeBackItemEvent());
+        assertGroup("earnings.claim", new ClaimAllEarningsRewardsEvent(), new ClaimEarningsRewardEvent());
+    }
+
+    private static boolean acquire(Map<String, Long> deadlines, String group, long cooldownMs, long nowMs) {
+        Method method = assertDoesNotThrow(
+                () -> PacketManager.class.getDeclaredMethod("acquireGroupedRateLimit", Map.class, String.class, long.class, long.class),
+                "PacketManager must expose the grouped rate-limit gate");
+        method.setAccessible(true);
+        return assertDoesNotThrow(() -> (boolean) method.invoke(null, deadlines, group, cooldownMs, nowMs));
+    }
+
+    private static void assertGroup(String expected, MessageHandler... handlers) {
+        Method method = assertDoesNotThrow(
+                () -> MessageHandler.class.getMethod("getRatelimitGroup"),
+                "MessageHandler must expose an optional shared rate-limit group");
+
+        for (MessageHandler handler : handlers) {
+            assertEquals(expected, assertDoesNotThrow(() -> method.invoke(handler)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add optional shared rate-limit groups without changing legacy per-handler cooldown behavior
- enforce atomic group deadlines so alternating related packet handlers cannot bypass the accepted operation cooldown
- group catalog purchases, marketplace mutations, and earnings claims

## Verification
- `mvn -q -Dtest=PacketManagerGroupedRateLimitTest test`
- `mvn -q clean test` (587 tests, 0 failures, 0 errors, 1 skipped)

## Roadmap
Completes item 77: consistent rate limiting across related operation groups.