### PR TITLE
Offload TCP packet handling from Netty I/O threads

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GamePacketExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GamePacketExecutionGroup.java
@@ -1,0 +1,42 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.Emulator;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.EventExecutorGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+final class GamePacketExecutionGroup {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GamePacketExecutionGroup.class);
+    private static final EventExecutorGroup GROUP = new DefaultEventExecutorGroup(
+            configuredThreads(),
+            new DefaultThreadFactory("GamePacketHandler", true));
+
+    private GamePacketExecutionGroup() {
+    }
+
+    static EventExecutorGroup get() {
+        return GROUP;
+    }
+
+    static void shutdown() {
+        try {
+            GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).syncUninterruptibly();
+        } catch (Exception e) {
+            LOGGER.warn("Packet handler group shutdown interrupted", e);
+        }
+    }
+
+    static int configuredThreads() {
+        int fallback = Math.max(16, Runtime.getRuntime().availableProcessors() * 2);
+        if (Emulator.getConfig() == null) {
+            return fallback;
+        }
+
+        int configured = Emulator.getConfig().getInt("io.packet.handler.threads", fallback);
+        return configured > 0 ? configured : fallback;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -55,7 +55,7 @@ public class GameServer extends Server {
                 }
                 ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
                 ch.pipeline().addLast(new GameMessageRateLimit());
-                ch.pipeline().addLast(new GameMessageHandler());
+                ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());
 
                 // Encoders.
                 ch.pipeline().addLast(new GameServerMessageEncoder());
@@ -126,9 +126,7 @@ public class GameServer extends Server {
             this.gameClientManager.forceDisposeClient(client);
         }
 
-        if (Emulator.getConfig().getBoolean("ws.enabled", false)) {
-            WebSocketChannelInitializer.shutdownPacketHandlers();
-        }
+        GamePacketExecutionGroup.shutdown();
 
         super.stop();
     }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -26,40 +26,14 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
-import io.netty.util.concurrent.EventExecutorGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
-import java.util.concurrent.TimeUnit;
 
 public class WebSocketChannelInitializer extends ChannelInitializer<SocketChannel> {
     private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketChannelInitializer.class);
     private static final int MAX_FRAME_SIZE = 500000;
-
-    // Runs the game packet handler OFF the Netty I/O event loop, so a blocking
-    // handler (login/friends/catalog/guild JDBC, A* pathfinding, etc.) can no
-    // longer stall socket I/O for every other client sharing that I/O thread.
-    // A DefaultEventExecutorGroup pins each channel to one executor, so a single
-    // client's packets stay strictly ordered (no new intra-client races); the
-    // cross-client concurrency degree is the same the multi-threaded I/O group
-    // already had. Daemon threads so they don't block JVM shutdown.
-    private static final EventExecutorGroup PACKET_HANDLER_GROUP = new DefaultEventExecutorGroup(
-            packetHandlerThreads(),
-            new DefaultThreadFactory("GamePacketHandler", true));
-
-    // Size of the packet-handler pool. Defaults to max(16, 2x CPU cores); set
-    // the optional `io.packet.handler.threads` config key to override.
-    private static int packetHandlerThreads() {
-        int fallback = Math.max(16, Runtime.getRuntime().availableProcessors() * 2);
-        if (Emulator.getConfig() == null) {
-            return fallback;
-        }
-        int configured = Emulator.getConfig().getInt("io.packet.handler.threads", fallback);
-        return configured > 0 ? configured : fallback;
-    }
 
     private final SslContext sslContext;
     private final boolean sslEnabled;
@@ -111,7 +85,7 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
 
         ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
         ch.pipeline().addLast(new GameMessageRateLimit());
-        ch.pipeline().addLast(PACKET_HANDLER_GROUP, "gameMessageHandler", new GameMessageHandler());
+        ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());
         ch.pipeline().addLast("messageEncoder", new GameServerMessageEncoder());
 
         if (PacketManager.DEBUG_SHOW_PACKETS) {
@@ -123,12 +97,4 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         return this.sslEnabled;
     }
 
-    /** Gracefully stop the off-I/O packet handler pool (call before worker/boss shutdown). */
-    public static void shutdownPacketHandlers() {
-        try {
-            PACKET_HANDLER_GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).syncUninterruptibly();
-        } catch (Exception e) {
-            LOGGER.warn("Packet handler group shutdown interrupted", e);
-        }
-    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/GamePacketExecutionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/GamePacketExecutionContractTest.java
@@ -1,0 +1,34 @@
+package com.eu.habbo.networking.gameserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GamePacketExecutionContractTest {
+
+    @Test
+    void tcpAndWebSocketPipelinesUseTheSameOffIoExecutionGroup() throws Exception {
+        String tcp = source("GameServer.java");
+        String webSocket = source("WebSocketChannelInitializer.java");
+
+        assertTrue(tcp.contains("GamePacketExecutionGroup.get()"), "TCP packet handlers must be off the Netty I/O loop");
+        assertTrue(webSocket.contains("GamePacketExecutionGroup.get()"), "WebSocket packet handlers must use the shared execution group");
+    }
+
+    @Test
+    void gameServerAlwaysShutsDownTheSharedPacketExecutionGroup() throws Exception {
+        String tcp = source("GameServer.java");
+        int stopMethod = tcp.indexOf("public void stop()");
+        int shutdown = tcp.indexOf("GamePacketExecutionGroup.shutdown()", stopMethod);
+
+        assertTrue(stopMethod >= 0);
+        assertTrue(shutdown > stopMethod, "the packet executor must stop for TCP-only and WebSocket servers");
+    }
+
+    private static String source(String file) throws Exception {
+        return Files.readString(Path.of("src/main/java/com/eu/habbo/networking/gameserver/" + file));
+    }
+}


### PR DESCRIPTION
## Summary
- run TCP and WebSocket game packet handlers on one dedicated Netty executor group instead of TCP worker I/O threads
- preserve per-channel packet ordering while allowing cross-client concurrency
- shut down the shared packet execution group for both TCP-only and WebSocket deployments

## Verification
- `mvn -q -Dtest=GamePacketExecutionContractTest test`
- `mvn -q clean test` (586 tests, 0 failures, 0 errors, 1 skipped)

## Roadmap
Completes item 79: heavy packet work no longer runs on network I/O threads.