### PR TITLE
Expose per-scheduler runtime status

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/core/Scheduler.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/Scheduler.java
@@ -2,9 +2,18 @@ package com.eu.habbo.core;
 
 import com.eu.habbo.Emulator;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class Scheduler implements Runnable {
     protected boolean disposed;
     protected int interval;
+    private volatile long lastStartedEpochMs;
+    private volatile long lastCompletedEpochMs;
+    private volatile long lastFailedEpochMs;
+    private volatile long nextRunEpochMs;
+    private final AtomicLong completedRuns = new AtomicLong();
+    private final AtomicLong failedRuns = new AtomicLong();
+    private volatile String lastError = "";
 
     public Scheduler(int interval) {
         this.interval = interval;
@@ -16,6 +25,9 @@ public class Scheduler implements Runnable {
 
     public void setDisposed(boolean disposed) {
         this.disposed = disposed;
+        if (disposed) {
+            this.nextRunEpochMs = 0L;
+        }
     }
 
     public int getInterval() {
@@ -28,9 +40,92 @@ public class Scheduler implements Runnable {
 
     @Override
     public void run() {
-        if (this.disposed)
+        if (this.disposed) {
+            this.nextRunEpochMs = 0L;
             return;
+        }
 
-        Emulator.getThreading().run(this, this.interval * 1000L);
+        long delayMs = Math.max(0L, this.interval * 1000L);
+        this.markScheduled(System.currentTimeMillis() + delayMs);
+        Emulator.getThreading().run(() -> {
+            if (this.disposed) {
+                this.nextRunEpochMs = 0L;
+                return;
+            }
+
+            this.markStarted(System.currentTimeMillis());
+            try {
+                Scheduler.this.run();
+                this.markCompleted(System.currentTimeMillis());
+            } catch (RuntimeException | Error exception) {
+                this.markFailed(System.currentTimeMillis(), exception);
+                throw exception;
+            }
+        }, delayMs);
+    }
+
+    void markScheduled(long epochMs) {
+        this.nextRunEpochMs = Math.max(0L, epochMs);
+    }
+
+    void markStarted(long epochMs) {
+        this.lastStartedEpochMs = Math.max(0L, epochMs);
+        this.nextRunEpochMs = 0L;
+    }
+
+    void markCompleted(long epochMs) {
+        this.lastCompletedEpochMs = Math.max(0L, epochMs);
+        this.completedRuns.incrementAndGet();
+        this.lastError = "";
+    }
+
+    void markFailed(long epochMs, Throwable error) {
+        this.lastFailedEpochMs = Math.max(0L, epochMs);
+        this.failedRuns.incrementAndGet();
+        String type = error == null ? "Unknown" : error.getClass().getSimpleName();
+        String message = error == null ? "" : error.getMessage();
+        String detail = message == null || message.isBlank() ? type : type + ": " + message;
+        this.lastError = detail.length() <= 256 ? detail : detail.substring(0, 256);
+    }
+
+    public Status snapshot() {
+        return new Status(
+                this.getClass().getSimpleName(),
+                !this.disposed,
+                this.interval,
+                this.lastStartedEpochMs,
+                this.lastCompletedEpochMs,
+                this.nextRunEpochMs,
+                this.completedRuns.get(),
+                this.failedRuns.get(),
+                this.lastFailedEpochMs,
+                this.lastError
+        );
+    }
+
+    public static final class Status {
+        public final String name;
+        public final boolean enabled;
+        public final int intervalSeconds;
+        public final long lastStartedEpochMs;
+        public final long lastCompletedEpochMs;
+        public final long nextRunEpochMs;
+        public final long completedRuns;
+        public final long failedRuns;
+        public final long lastFailedEpochMs;
+        public final String lastError;
+
+        public Status(String name, boolean enabled, int intervalSeconds, long lastStartedEpochMs, long lastCompletedEpochMs, long nextRunEpochMs, long completedRuns, long failedRuns, long lastFailedEpochMs, String lastError) {
+            this.name = name;
+            this.enabled = enabled;
+            this.intervalSeconds = intervalSeconds;
+            this.lastStartedEpochMs = lastStartedEpochMs;
+            this.lastCompletedEpochMs = lastCompletedEpochMs;
+            this.nextRunEpochMs = nextRunEpochMs;
+            this.completedRuns = completedRuns;
+            this.failedRuns = failedRuns;
+            this.lastFailedEpochMs = lastFailedEpochMs;
+            this.lastError = lastError;
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
@@ -1,6 +1,8 @@
 package com.eu.habbo.monitoring;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.core.Scheduler;
+import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
@@ -300,12 +302,14 @@ public final class EmulatorStatsService {
     }
 
     private static SchedulerMetrics collectSchedulerMetrics() {
+        List<Scheduler.Status> tasks = collectSchedulerStatuses();
+
         if (Emulator.getThreading() == null) {
-            return new SchedulerMetrics(0, 0, 0, 0, false);
+            return new SchedulerMetrics(0, 0, 0, 0, false, tasks);
         }
 
         if (!(Emulator.getThreading().getService() instanceof ScheduledThreadPoolExecutor executor)) {
-            return new SchedulerMetrics(0, 0, 0, 0, false);
+            return new SchedulerMetrics(0, 0, 0, 0, false, tasks);
         }
 
         return new SchedulerMetrics(
@@ -313,8 +317,24 @@ public final class EmulatorStatsService {
                 executor.getActiveCount(),
                 executor.getPoolSize(),
                 executor.getCompletedTaskCount(),
-                !executor.isShutdown()
+                !executor.isShutdown(),
+                tasks
         );
+    }
+
+    private static List<Scheduler.Status> collectSchedulerStatuses() {
+        GameEnvironment environment = Emulator.getGameEnvironment();
+        if (environment == null) {
+            return List.of();
+        }
+
+        List<Scheduler.Status> statuses = new ArrayList<>(5);
+        if (environment.getCreditsScheduler() != null) statuses.add(environment.getCreditsScheduler().snapshot());
+        if (environment.getPixelScheduler() != null) statuses.add(environment.getPixelScheduler().snapshot());
+        if (environment.getPointsScheduler() != null) statuses.add(environment.getPointsScheduler().snapshot());
+        if (environment.getGotwPointsScheduler() != null) statuses.add(environment.getGotwPointsScheduler().snapshot());
+        if (environment.subscriptionScheduler != null) statuses.add(environment.subscriptionScheduler.snapshot());
+        return List.copyOf(statuses);
     }
 
     private static NetworkMetrics collectNetworkMetrics(long now) {
@@ -581,13 +601,19 @@ public final class EmulatorStatsService {
         public final int poolSize;
         public final long completedTasks;
         public final boolean running;
+        public final List<Scheduler.Status> tasks;
 
         public SchedulerMetrics(int queuedTasks, int activeThreads, int poolSize, long completedTasks, boolean running) {
+            this(queuedTasks, activeThreads, poolSize, completedTasks, running, List.of());
+        }
+
+        public SchedulerMetrics(int queuedTasks, int activeThreads, int poolSize, long completedTasks, boolean running, List<Scheduler.Status> tasks) {
             this.queuedTasks = queuedTasks;
             this.activeThreads = activeThreads;
             this.poolSize = poolSize;
             this.completedTasks = completedTasks;
             this.running = running;
+            this.tasks = tasks == null ? List.of() : List.copyOf(tasks);
         }
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/core/SchedulerObservabilityTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/SchedulerObservabilityTest.java
@@ -1,0 +1,74 @@
+package com.eu.habbo.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SchedulerObservabilityTest {
+
+    @Test
+    void snapshotTracksSchedulingAndSuccessfulExecution() {
+        Scheduler scheduler = new Scheduler(10);
+
+        invoke(scheduler, "markScheduled", new Class<?>[]{long.class}, 1_000L);
+        invoke(scheduler, "markStarted", new Class<?>[]{long.class}, 1_000L);
+        invoke(scheduler, "markCompleted", new Class<?>[]{long.class}, 1_025L);
+
+        Object snapshot = snapshot(scheduler);
+        assertEquals("Scheduler", field(snapshot, "name"));
+        assertEquals(true, field(snapshot, "enabled"));
+        assertEquals(10, field(snapshot, "intervalSeconds"));
+        assertEquals(1_000L, field(snapshot, "lastStartedEpochMs"));
+        assertEquals(1_025L, field(snapshot, "lastCompletedEpochMs"));
+        assertEquals(1L, field(snapshot, "completedRuns"));
+        assertEquals(0L, field(snapshot, "failedRuns"));
+    }
+
+    @Test
+    void snapshotTracksFailuresWithoutCountingThemAsCompletions() {
+        Scheduler scheduler = new Scheduler(5);
+
+        invoke(scheduler, "markStarted", new Class<?>[]{long.class}, 2_000L);
+        invoke(scheduler, "markFailed", new Class<?>[]{long.class, Throwable.class}, 2_010L, new IllegalStateException("boom"));
+
+        Object snapshot = snapshot(scheduler);
+        assertEquals(0L, field(snapshot, "completedRuns"));
+        assertEquals(1L, field(snapshot, "failedRuns"));
+        assertEquals(2_010L, field(snapshot, "lastFailedEpochMs"));
+        assertTrue(String.valueOf(field(snapshot, "lastError")).contains("IllegalStateException"));
+    }
+
+    @Test
+    void emulatorStatsIncludesEveryCoreSchedulerSnapshot() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java"));
+
+        assertTrue(source.contains("getCreditsScheduler().snapshot()"));
+        assertTrue(source.contains("getPixelScheduler().snapshot()"));
+        assertTrue(source.contains("getPointsScheduler().snapshot()"));
+        assertTrue(source.contains("getGotwPointsScheduler().snapshot()"));
+        assertTrue(source.contains("subscriptionScheduler.snapshot()"));
+    }
+
+    private static Object snapshot(Scheduler scheduler) {
+        Method method = assertDoesNotThrow(() -> Scheduler.class.getMethod("snapshot"));
+        return assertDoesNotThrow(() -> method.invoke(scheduler));
+    }
+
+    private static void invoke(Scheduler scheduler, String name, Class<?>[] types, Object... values) {
+        Method method = assertDoesNotThrow(() -> Scheduler.class.getDeclaredMethod(name, types));
+        method.setAccessible(true);
+        assertDoesNotThrow(() -> method.invoke(scheduler, values));
+    }
+
+    private static Object field(Object target, String name) {
+        Field field = assertDoesNotThrow(() -> target.getClass().getField(name));
+        return assertDoesNotThrow(() -> field.get(target));
+    }
+}


### PR DESCRIPTION
## Summary
- expose immutable runtime snapshots for core schedulers
- track scheduling, completion, failure, next-run time, and the latest bounded error
- include per-scheduler status in emulator monitoring metrics while preserving the existing constructor API

## Why
Thread-pool totals do not identify a stalled or repeatedly failing scheduler. Per-task state makes the five core periodic jobs observable without changing their public scheduling contract.

## Validation
- `mvn -q clean test`
- 587 tests, 0 failures, 0 errors, 1 skipped
- `git diff --cached --check`