### PR TITLE
Make emulator shutdown graceful and bounded

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -467,11 +467,10 @@ public final class Emulator {
         if (Emulator.pluginManager != null) tryShutdown(() -> Emulator.pluginManager.dispose());
         if (Emulator.config != null) tryShutdown(() -> Emulator.config.saveToDatabase());
         if (Emulator.gameServer != null) tryShutdown(() -> Emulator.gameServer.stop());
+        if (Emulator.threading != null) tryShutdown(() -> Emulator.threading.shutDown());
+        if (Emulator.database != null) tryShutdown(() -> Emulator.database.dispose());
 
         LOGGER.info("Stopped Polaris {}", version);
-
-        if (Emulator.database != null) tryShutdown(() -> Emulator.database.dispose());
-        if (Emulator.threading != null) tryShutdown(() -> Emulator.threading.shutDown());
 
         Emulator.stopped = true;
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java
@@ -133,6 +133,7 @@ public class GameEnvironment {
         this.pixelScheduler.setDisposed(true);
         this.creditsScheduler.setDisposed(true);
         this.gotwPointsScheduler.setDisposed(true);
+        this.subscriptionScheduler.setDisposed(true);
         this.craftingManager.dispose();
         this.habboManager.dispose();
         this.commandHandler.dispose();

--- a/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class ThreadPooling {
@@ -59,10 +60,81 @@ public class ThreadPooling {
     }
 
     public void shutDown() {
-        this.canAdd = false;
-        this.scheduledPool.shutdownNow();
+        this.shutDown(5, TimeUnit.SECONDS);
+    }
 
-        LOGGER.info("Threading -> Disposed!");
+    ShutdownResult shutDown(long timeout, TimeUnit unit) {
+        this.canAdd = false;
+        this.scheduledPool.shutdown();
+
+        boolean terminatedGracefully = false;
+        boolean terminated = false;
+        boolean interrupted = false;
+        int cancelledTasks = 0;
+
+        try {
+            terminatedGracefully = this.scheduledPool.awaitTermination(Math.max(0L, timeout), unit);
+        } catch (InterruptedException exception) {
+            interrupted = true;
+        }
+
+        if (!terminatedGracefully) {
+            cancelledTasks = this.scheduledPool.shutdownNow().size();
+
+            if (!interrupted) {
+                try {
+                    terminated = this.scheduledPool.awaitTermination(Math.max(0L, timeout), unit);
+                } catch (InterruptedException exception) {
+                    interrupted = true;
+                }
+            }
+        } else {
+            terminated = true;
+        }
+
+        long completedTasks = this.scheduledPool instanceof ScheduledThreadPoolExecutor executor
+                ? executor.getCompletedTaskCount()
+                : 0L;
+
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+
+        ShutdownResult result = new ShutdownResult(
+                terminatedGracefully,
+                terminated,
+                cancelledTasks,
+                completedTasks,
+                interrupted
+        );
+
+        if (terminatedGracefully) {
+            LOGGER.info("Threading -> Disposed gracefully (completed tasks: {})", completedTasks);
+        } else if (terminated) {
+            LOGGER.warn(
+                    "Threading -> Disposed after forced shutdown (completed tasks: {}, cancelled queued tasks: {})",
+                    completedTasks,
+                    cancelledTasks
+            );
+        } else {
+            LOGGER.error(
+                    "Threading -> Workers still active after forced shutdown (completed tasks: {}, cancelled queued tasks: {}, interrupted: {})",
+                    completedTasks,
+                    cancelledTasks,
+                    interrupted
+            );
+        }
+
+        return result;
+    }
+
+    record ShutdownResult(
+            boolean terminatedGracefully,
+            boolean terminated,
+            int cancelledTasks,
+            long completedTasks,
+            boolean interrupted
+    ) {
     }
 
     public void setCanAdd(boolean canAdd) {

--- a/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingGracefulShutdownTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingGracefulShutdownTest.java
@@ -1,0 +1,118 @@
+package com.eu.habbo.threading;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ThreadPoolingGracefulShutdownTest {
+
+    @Test
+    void waitsForRunningTasksBeforeForcingShutdown() throws Exception {
+        ThreadPooling pooling = new ThreadPooling(1);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        CountDownLatch interrupted = new CountDownLatch(1);
+        ExecutorService shutdownCaller = Executors.newSingleThreadExecutor();
+
+        try {
+            pooling.run(() -> {
+                started.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException exception) {
+                    interrupted.countDown();
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertTrue(started.await(1, TimeUnit.SECONDS));
+
+            Future<ThreadPooling.ShutdownResult> shutdown = shutdownCaller.submit(
+                    () -> pooling.shutDown(2, TimeUnit.SECONDS)
+            );
+
+            assertThrows(TimeoutException.class, () -> shutdown.get(100, TimeUnit.MILLISECONDS));
+            release.countDown();
+
+            ThreadPooling.ShutdownResult result = shutdown.get(2, TimeUnit.SECONDS);
+            assertTrue(result.terminatedGracefully());
+            assertEquals(0, result.cancelledTasks());
+            assertFalse(interrupted.await(50, TimeUnit.MILLISECONDS));
+            assertTrue(pooling.getService().isTerminated());
+        } finally {
+            release.countDown();
+            pooling.getService().shutdownNow();
+            shutdownCaller.shutdownNow();
+        }
+    }
+
+    @Test
+    void forcesShutdownAfterBoundedTimeoutAndReportsQueuedTasks() throws Exception {
+        ThreadPooling pooling = new ThreadPooling(1);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch interrupted = new CountDownLatch(1);
+
+        try {
+            pooling.run(() -> {
+                started.countDown();
+                try {
+                    new CountDownLatch(1).await();
+                } catch (InterruptedException exception) {
+                    interrupted.countDown();
+                    Thread.currentThread().interrupt();
+                }
+            });
+            pooling.run(() -> { }, TimeUnit.MINUTES.toMillis(1));
+            assertTrue(started.await(1, TimeUnit.SECONDS));
+
+            ThreadPooling.ShutdownResult result = pooling.shutDown(50, TimeUnit.MILLISECONDS);
+
+            assertFalse(result.terminatedGracefully());
+            assertTrue(result.terminated());
+            assertTrue(result.cancelledTasks() >= 1);
+            assertTrue(interrupted.await(1, TimeUnit.SECONDS));
+            assertTrue(pooling.getService().isShutdown());
+        } finally {
+            pooling.getService().shutdownNow();
+        }
+    }
+
+    @Test
+    void gameEnvironmentDisposesEveryCoreScheduler() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/eu/habbo/habbohotel/GameEnvironment.java"
+        ));
+
+        assertTrue(source.contains("this.pointsScheduler.setDisposed(true);"));
+        assertTrue(source.contains("this.pixelScheduler.setDisposed(true);"));
+        assertTrue(source.contains("this.creditsScheduler.setDisposed(true);"));
+        assertTrue(source.contains("this.gotwPointsScheduler.setDisposed(true);"));
+        assertTrue(source.contains("this.subscriptionScheduler.setDisposed(true);"));
+    }
+
+    @Test
+    void executorDrainsBeforeDatabaseIsClosed() throws Exception {
+        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/Emulator.java"));
+        String shutdownMethod = source.substring(source.indexOf("private static void dispose()"));
+        int threadingShutdown = shutdownMethod.indexOf("Emulator.threading.shutDown()");
+        int databaseShutdown = shutdownMethod.indexOf("Emulator.database.dispose()");
+        int stoppedLog = shutdownMethod.indexOf("LOGGER.info(\"Stopped Polaris {}\", version)");
+
+        assertTrue(threadingShutdown >= 0);
+        assertTrue(databaseShutdown > threadingShutdown,
+                "tasks must finish before their database dependency is closed");
+        assertTrue(stoppedLog > databaseShutdown,
+                "the emulator must only report stopped after dependencies are closed");
+    }
+}


### PR DESCRIPTION
## Summary
- drain scheduled work for a bounded period before forcing cancellation
- wait again after forced cancellation and report whether workers actually terminated
- stop every core scheduler, including the subscription scheduler
- close the database only after executor shutdown completes

## Why
The previous shutdown path called `shutdownNow()` immediately and closed the database before the executor. That could interrupt safe in-flight work or let a still-running task access an already disposed dependency.

## Safety behavior
- no new asynchronous work is accepted once shutdown begins
- running tasks receive up to 5 seconds to finish normally
- queued and running work is interrupted only after the graceful deadline
- forced shutdown receives a second bounded termination window
- thread interruption is preserved
- completion, cancellation, and incomplete termination are logged

## Validation
- `mvn -q clean test`
- 588 tests, 0 failures, 0 errors, 1 skipped
- `git diff --cached --check`