### PR TITLE
Add structured slow-query observability

### DIFF
--- a/Database/Slow Query Monitoring.md
+++ b/Database/Slow Query Monitoring.md
@@ -1,0 +1,34 @@
+# Slow query monitoring
+
+Polaris logs every JDBC execution that reaches `db.slow_query.threshold_ms` as a
+single `event=database_slow_query` record. The record contains the elapsed time,
+operation, stable SQL fingerprint, sanitized SQL shape, thread name, SQL state,
+vendor code, and a Hikari pool snapshot. Literal strings, numeric values, bound
+parameters, and SQL comments are not written to the log.
+
+The application signal explains which Polaris thread and pool state produced a
+slow call. MariaDB remains the authoritative source for server execution details.
+For production diagnosis, enable the MariaDB slow log temporarily and use the
+Polaris fingerprint and timestamp to correlate both views:
+
+```ini
+[mariadb]
+slow_query_log=ON
+long_query_time=0.250
+log_slow_admin_statements=ON
+```
+
+Keep the MariaDB slow log outside the web root, restrict file permissions, and
+disable it again after collecting the diagnostic window. Do not enable
+`general_log`: it records every statement and can expose parameter values.
+
+Polaris defaults:
+
+```ini
+db.slow_query.enabled=true
+db.slow_query.threshold_ms=250
+db.slow_query.max_sql_length=1024
+```
+
+The maximum SQL length must be between 128 and 8192 characters. Invalid values
+fail database-pool initialization instead of silently disabling diagnostics.

--- a/Emulator/src/main/java/com/eu/habbo/database/DatabasePool.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/DatabasePool.java
@@ -3,6 +3,7 @@ package com.eu.habbo.database;
 import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.database.compat.LegacyBridgeDataSource;
 import com.eu.habbo.database.compat.LegacySqlBridge;
+import com.eu.habbo.database.observability.SlowQuerySettings;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
@@ -98,7 +99,16 @@ class DatabasePool {
             log.info("HABBO DATABASE: " + config.getValue(DB_NAME_KEY));
             log.info("USING DRIVER: MariaDB Connector/J");
 
-            this.database = new LegacyBridgeDataSource(databaseConfiguration, legacySqlBridge);
+            SlowQuerySettings slowQuerySettings = SlowQuerySettings.from(config);
+            this.database = new LegacyBridgeDataSource(
+                    databaseConfiguration,
+                    legacySqlBridge,
+                    slowQuerySettings);
+            log.info(
+                    "SLOW QUERY LOGGING: {} (threshold={} ms, max_sql_length={})",
+                    slowQuerySettings.enabled() ? "enabled" : "disabled",
+                    slowQuerySettings.thresholdMs(),
+                    slowQuerySettings.maxSqlLength());
         } catch (Exception e) {
             log.error("Error initializing database connection pool: {}", e.getMessage());
             return false;

--- a/Emulator/src/main/java/com/eu/habbo/database/compat/LegacyBridgeDataSource.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/compat/LegacyBridgeDataSource.java
@@ -1,7 +1,12 @@
 package com.eu.habbo.database.compat;
 
+import com.eu.habbo.database.observability.PoolSnapshot;
+import com.eu.habbo.database.observability.Slf4jSlowQuerySink;
+import com.eu.habbo.database.observability.SlowQueryMonitor;
+import com.eu.habbo.database.observability.SlowQuerySettings;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -17,10 +22,28 @@ import java.sql.SQLException;
 public class LegacyBridgeDataSource extends HikariDataSource {
 
     private final LegacySqlBridge bridge;
+    private final SlowQueryMonitor slowQueryMonitor;
 
+    /**
+     * Preserves the existing public construction API for plugins, tests, and
+     * embedding code while enabling slow-query diagnostics with safe defaults.
+     */
     public LegacyBridgeDataSource(HikariConfig configuration, LegacySqlBridge bridge) {
+        this(configuration, bridge, SlowQuerySettings.defaults());
+    }
+
+    public LegacyBridgeDataSource(
+            HikariConfig configuration,
+            LegacySqlBridge bridge,
+            SlowQuerySettings slowQuerySettings) {
         super(configuration);
         this.bridge = bridge;
+        this.slowQueryMonitor = new SlowQueryMonitor(
+                slowQuerySettings,
+                new Slf4jSlowQuerySink(),
+                System::nanoTime,
+                this::poolSnapshot,
+                () -> Thread.currentThread().getName());
     }
 
     public LegacySqlBridge getBridge() {
@@ -29,11 +52,23 @@ public class LegacyBridgeDataSource extends HikariDataSource {
 
     @Override
     public Connection getConnection() throws SQLException {
-        return this.bridge.wrap(super.getConnection());
+        return this.bridge.wrap(this.slowQueryMonitor.wrap(super.getConnection()));
     }
 
     @Override
     public Connection getConnection(String username, String password) throws SQLException {
-        return this.bridge.wrap(super.getConnection(username, password));
+        return this.bridge.wrap(this.slowQueryMonitor.wrap(super.getConnection(username, password)));
+    }
+
+    private PoolSnapshot poolSnapshot() {
+        HikariPoolMXBean pool = this.getHikariPoolMXBean();
+        if (pool == null) {
+            return PoolSnapshot.UNAVAILABLE;
+        }
+        return new PoolSnapshot(
+                pool.getActiveConnections(),
+                pool.getIdleConnections(),
+                pool.getTotalConnections(),
+                pool.getThreadsAwaitingConnection());
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/database/observability/PoolSnapshot.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/observability/PoolSnapshot.java
@@ -1,0 +1,5 @@
+package com.eu.habbo.database.observability;
+
+public record PoolSnapshot(int active, int idle, int total, int awaiting) {
+    public static final PoolSnapshot UNAVAILABLE = new PoolSnapshot(-1, -1, -1, -1);
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/observability/Slf4jSlowQuerySink.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/observability/Slf4jSlowQuerySink.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.database.observability;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Slf4jSlowQuerySink implements SlowQuerySink {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("database.slow_query");
+
+    @Override
+    public void accept(SlowQueryEvent event) {
+        PoolSnapshot pool = event.pool();
+        LOGGER.warn(
+                "event=database_slow_query duration_ms={} operation={} success={} sql_state={} vendor_code={} "
+                        + "fingerprint={} thread={} pool_active={} pool_idle={} pool_total={} pool_awaiting={} sql=\"{}\"",
+                event.durationMs(),
+                event.operation(),
+                event.success(),
+                event.sqlState(),
+                event.vendorCode(),
+                event.fingerprint(),
+                event.threadName(),
+                pool.active(),
+                pool.idle(),
+                pool.total(),
+                pool.awaiting(),
+                event.sql());
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQueryEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQueryEvent.java
@@ -1,0 +1,13 @@
+package com.eu.habbo.database.observability;
+
+public record SlowQueryEvent(
+        long durationMs,
+        String operation,
+        boolean success,
+        String sqlState,
+        int vendorCode,
+        String fingerprint,
+        String sql,
+        String threadName,
+        PoolSnapshot pool) {
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQueryMonitor.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQueryMonitor.java
@@ -1,0 +1,214 @@
+package com.eu.habbo.database.observability;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+public final class SlowQueryMonitor {
+
+    private static final Set<String> EXECUTION_METHODS = Set.of(
+            "execute", "executeQuery", "executeUpdate", "executeLargeUpdate",
+            "executeBatch", "executeLargeBatch");
+
+    private final SlowQuerySettings settings;
+    private final SlowQuerySink sink;
+    private final LongSupplier nanoTime;
+    private final Supplier<PoolSnapshot> poolSnapshot;
+    private final Supplier<String> threadName;
+
+    public SlowQueryMonitor(
+            SlowQuerySettings settings,
+            SlowQuerySink sink,
+            LongSupplier nanoTime,
+            Supplier<PoolSnapshot> poolSnapshot,
+            Supplier<String> threadName) {
+        this.settings = settings;
+        this.sink = sink;
+        this.nanoTime = nanoTime;
+        this.poolSnapshot = poolSnapshot;
+        this.threadName = threadName;
+    }
+
+    public Connection wrap(Connection connection) {
+        if (!this.settings.enabled()) {
+            return connection;
+        }
+        return (Connection) Proxy.newProxyInstance(
+                SlowQueryMonitor.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                new ConnectionHandler(connection));
+    }
+
+    private final class ConnectionHandler implements InvocationHandler {
+        private final Connection delegate;
+
+        private ConnectionHandler(Connection delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            Object result = invokeDelegate(method, this.delegate, args);
+            if (!(result instanceof Statement statement)) {
+                return result;
+            }
+
+            String sql = null;
+            if (args != null && args.length > 0 && args[0] instanceof String value
+                    && ("prepareStatement".equals(method.getName()) || "prepareCall".equals(method.getName()))) {
+                sql = value;
+            }
+            return wrapStatement(statement, sql, (Connection) proxy);
+        }
+    }
+
+    private Statement wrapStatement(Statement statement, String preparedSql, Connection owner) {
+        Class<?> statementType = Statement.class;
+        if (statement instanceof CallableStatement) {
+            statementType = CallableStatement.class;
+        } else if (statement instanceof PreparedStatement) {
+            statementType = PreparedStatement.class;
+        }
+
+        return (Statement) Proxy.newProxyInstance(
+                SlowQueryMonitor.class.getClassLoader(),
+                new Class<?>[]{statementType},
+                new StatementHandler(statement, preparedSql, owner));
+    }
+
+    private final class StatementHandler implements InvocationHandler {
+        private final Statement delegate;
+        private final String preparedSql;
+        private final Connection owner;
+        private final List<String> batchSql = new ArrayList<>();
+
+        private StatementHandler(Statement delegate, String preparedSql, Connection owner) {
+            this.delegate = delegate;
+            this.preparedSql = preparedSql;
+            this.owner = owner;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            String methodName = method.getName();
+            if ("getConnection".equals(methodName)) {
+                return this.owner;
+            }
+            if ("addBatch".equals(methodName)) {
+                if (args != null && args.length > 0 && args[0] instanceof String value) {
+                    this.batchSql.add(value);
+                } else if (this.preparedSql != null) {
+                    this.batchSql.add(this.preparedSql);
+                }
+                return invokeDelegate(method, this.delegate, args);
+            }
+            if ("clearBatch".equals(methodName)) {
+                this.batchSql.clear();
+                return invokeDelegate(method, this.delegate, args);
+            }
+            if (!EXECUTION_METHODS.contains(methodName)) {
+                return invokeDelegate(method, this.delegate, args);
+            }
+
+            String sql = resolveSql(args, this.preparedSql, this.batchSql);
+            long startedAt = nanoTime.getAsLong();
+            Throwable failure = null;
+            try {
+                return invokeDelegate(method, this.delegate, args);
+            } catch (Throwable error) {
+                failure = error;
+                throw error;
+            } finally {
+                long elapsedNanos = Math.max(0, nanoTime.getAsLong() - startedAt);
+                emitIfSlow(methodName, sql, elapsedNanos, failure);
+                if ("executeBatch".equals(methodName) || "executeLargeBatch".equals(methodName)) {
+                    this.batchSql.clear();
+                }
+            }
+        }
+    }
+
+    private void emitIfSlow(String operation, String sql, long elapsedNanos, Throwable failure) {
+        if (elapsedNanos < TimeUnit.MILLISECONDS.toNanos(this.settings.thresholdMs())) {
+            return;
+        }
+
+        String sanitized = SlowQuerySql.sanitize(sql, this.settings.maxSqlLength());
+        SQLException sqlError = findSqlException(failure);
+        PoolSnapshot pool = safePoolSnapshot();
+        SlowQueryEvent event = new SlowQueryEvent(
+                TimeUnit.NANOSECONDS.toMillis(elapsedNanos),
+                operation,
+                failure == null,
+                sqlError == null || sqlError.getSQLState() == null ? "-" : sqlError.getSQLState(),
+                sqlError == null ? 0 : sqlError.getErrorCode(),
+                SlowQuerySql.fingerprint(sql),
+                sanitized,
+                safeThreadName(),
+                pool);
+        try {
+            this.sink.accept(event);
+        } catch (RuntimeException ignored) {
+            // Diagnostics must never alter database behavior.
+        }
+    }
+
+    private PoolSnapshot safePoolSnapshot() {
+        try {
+            PoolSnapshot snapshot = this.poolSnapshot.get();
+            return snapshot == null ? PoolSnapshot.UNAVAILABLE : snapshot;
+        } catch (RuntimeException ignored) {
+            return PoolSnapshot.UNAVAILABLE;
+        }
+    }
+
+    private String safeThreadName() {
+        try {
+            String name = this.threadName.get();
+            return name == null || name.isBlank() ? "unknown" : name;
+        } catch (RuntimeException ignored) {
+            return "unknown";
+        }
+    }
+
+    private static String resolveSql(Object[] args, String preparedSql, List<String> batchSql) {
+        if (args != null && args.length > 0 && args[0] instanceof String value) {
+            return value;
+        }
+        if (!batchSql.isEmpty()) {
+            return "BATCH size=" + batchSql.size() + " first=" + batchSql.getFirst();
+        }
+        return preparedSql;
+    }
+
+    private static SQLException findSqlException(Throwable error) {
+        Throwable current = error;
+        while (current != null) {
+            if (current instanceof SQLException sqlException) {
+                return sqlException;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private static Object invokeDelegate(Method method, Object delegate, Object[] args) throws Throwable {
+        try {
+            return method.invoke(delegate, args);
+        } catch (InvocationTargetException error) {
+            throw error.getCause() == null ? error : error.getCause();
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQuerySettings.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQuerySettings.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.database.observability;
+
+import com.eu.habbo.core.ConfigurationManager;
+
+public record SlowQuerySettings(boolean enabled, long thresholdMs, int maxSqlLength) {
+
+    public static final String ENABLED_KEY = "db.slow_query.enabled";
+    public static final String THRESHOLD_MS_KEY = "db.slow_query.threshold_ms";
+    public static final String MAX_SQL_LENGTH_KEY = "db.slow_query.max_sql_length";
+
+    public static final boolean DEFAULT_ENABLED = true;
+    public static final int DEFAULT_THRESHOLD_MS = 250;
+    public static final int DEFAULT_MAX_SQL_LENGTH = 1_024;
+
+    public SlowQuerySettings {
+        if (thresholdMs < 1) {
+            throw new IllegalArgumentException(THRESHOLD_MS_KEY + " must be at least 1");
+        }
+        if (maxSqlLength < 128 || maxSqlLength > 8_192) {
+            throw new IllegalArgumentException(MAX_SQL_LENGTH_KEY + " must be between 128 and 8192");
+        }
+    }
+
+    public static SlowQuerySettings from(ConfigurationManager config) {
+        return new SlowQuerySettings(
+                config.getBoolean(ENABLED_KEY, DEFAULT_ENABLED),
+                config.getInt(THRESHOLD_MS_KEY, DEFAULT_THRESHOLD_MS),
+                config.getInt(MAX_SQL_LENGTH_KEY, DEFAULT_MAX_SQL_LENGTH));
+    }
+
+    public static SlowQuerySettings defaults() {
+        return new SlowQuerySettings(
+                DEFAULT_ENABLED,
+                DEFAULT_THRESHOLD_MS,
+                DEFAULT_MAX_SQL_LENGTH);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQuerySink.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQuerySink.java
@@ -1,0 +1,6 @@
+package com.eu.habbo.database.observability;
+
+@FunctionalInterface
+public interface SlowQuerySink {
+    void accept(SlowQueryEvent event);
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQuerySql.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/observability/SlowQuerySql.java
@@ -1,0 +1,149 @@
+package com.eu.habbo.database.observability;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.regex.Pattern;
+
+public final class SlowQuerySql {
+
+    private static final Pattern NUMERIC_LITERAL = Pattern.compile(
+            "(?<![A-Za-z0-9_$])(?:0[xX][0-9A-Fa-f]+|[-+]?\\d+(?:\\.\\d+)?(?:[eE][-+]?\\d+)?)(?![A-Za-z0-9_$])");
+
+    private SlowQuerySql() {
+    }
+
+    public static String sanitize(String sql, int maxLength) {
+        if (sql == null || sql.isBlank()) {
+            return "<unknown>";
+        }
+
+        StringBuilder result = new StringBuilder(Math.min(sql.length(), maxLength));
+        boolean pendingSpace = false;
+
+        for (int index = 0; index < sql.length();) {
+            if (result.length() >= maxLength + 64) {
+                break;
+            }
+            char current = sql.charAt(index);
+
+            if (Character.isWhitespace(current)) {
+                pendingSpace = result.length() > 0;
+                index++;
+                continue;
+            }
+
+            if (current == '#') {
+                index = skipLineComment(sql, index + 1);
+                pendingSpace = result.length() > 0;
+                continue;
+            }
+
+            if (current == '-' && index + 1 < sql.length() && sql.charAt(index + 1) == '-') {
+                index = skipLineComment(sql, index + 2);
+                pendingSpace = result.length() > 0;
+                continue;
+            }
+
+            if (current == '/' && index + 1 < sql.length() && sql.charAt(index + 1) == '*') {
+                index = skipBlockComment(sql, index + 2);
+                pendingSpace = result.length() > 0;
+                continue;
+            }
+
+            if (pendingSpace) {
+                result.append(' ');
+                pendingSpace = false;
+            }
+
+            if (current == '\'' || current == '"') {
+                result.append('?');
+                index = skipQuotedLiteral(sql, index + 1, current);
+                continue;
+            }
+
+            if (current == '`') {
+                index = copyQuotedIdentifier(sql, index, result);
+                continue;
+            }
+
+            result.append(current);
+            index++;
+        }
+
+        String sanitized = NUMERIC_LITERAL.matcher(result.toString().strip()).replaceAll("?");
+        if (sanitized.length() <= maxLength) {
+            return sanitized;
+        }
+
+        return sanitized.substring(0, maxLength - 3).stripTrailing() + "...";
+    }
+
+    public static String fingerprint(String sql) {
+        return fingerprintSanitized(sanitize(sql, 8_192));
+    }
+
+    static String fingerprintSanitized(String sanitizedSql) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(sanitizedSql.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest, 0, 8);
+        } catch (NoSuchAlgorithmException error) {
+            throw new IllegalStateException("SHA-256 is unavailable", error);
+        }
+    }
+
+    private static int skipLineComment(String sql, int index) {
+        while (index < sql.length() && sql.charAt(index) != '\n' && sql.charAt(index) != '\r') {
+            index++;
+        }
+        return index;
+    }
+
+    private static int skipBlockComment(String sql, int index) {
+        while (index + 1 < sql.length()) {
+            if (sql.charAt(index) == '*' && sql.charAt(index + 1) == '/') {
+                return index + 2;
+            }
+            index++;
+        }
+        return sql.length();
+    }
+
+    private static int skipQuotedLiteral(String sql, int index, char quote) {
+        while (index < sql.length()) {
+            char current = sql.charAt(index++);
+            if (current == '\\' && index < sql.length()) {
+                index++;
+                continue;
+            }
+            if (current == quote) {
+                if (index < sql.length() && sql.charAt(index) == quote) {
+                    index++;
+                    continue;
+                }
+                return index;
+            }
+        }
+        return index;
+    }
+
+    private static int copyQuotedIdentifier(String sql, int index, StringBuilder result) {
+        result.append('`');
+        index++;
+        while (index < sql.length()) {
+            char current = sql.charAt(index++);
+            result.append(current);
+            if (current == '`') {
+                if (index < sql.length() && sql.charAt(index) == '`') {
+                    result.append('`');
+                    index++;
+                    continue;
+                }
+                break;
+            }
+        }
+        return index;
+    }
+}

--- a/Emulator/src/main/resources/logback.xml
+++ b/Emulator/src/main/resources/logback.xml
@@ -56,11 +56,28 @@
         </encoder>
     </appender>
 
+    <appender name="SlowQueries" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logging/database/slow-queries.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logging/database/slow-queries.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>25MB</maxFileSize>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <logger name="io.netty" level="INFO"/>
 
     <logger name="com.zaxxer.hikari" level="ERROR"/>
 	
 	<logger name="org.mariadb.jdbc" level="WARN"/>
+
+    <logger name="database.slow_query" level="WARN" additivity="true">
+        <appender-ref ref="SlowQueries" />
+    </logger>
 
     <root level="INFO">
         <appender-ref ref="Console" />

--- a/Emulator/src/test/java/com/eu/habbo/database/observability/SlowQueryLoggingConfigurationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/observability/SlowQueryLoggingConfigurationTest.java
@@ -1,0 +1,22 @@
+package com.eu.habbo.database.observability;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SlowQueryLoggingConfigurationTest {
+
+    @Test
+    void writesSlowQueriesToTheirOwnRotatingFile() throws Exception {
+        String logback = Files.readString(Path.of("src/main/resources/logback.xml"));
+
+        assertTrue(logback.contains("name=\"SlowQueries\""));
+        assertTrue(logback.contains("logging/database/slow-queries.log"));
+        assertTrue(logback.contains("slow-queries.%d{yyyy-MM-dd}.%i.gz"));
+        assertTrue(logback.contains("name=\"database.slow_query\""));
+        assertTrue(logback.contains("<appender-ref ref=\"SlowQueries\""));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/observability/SlowQueryMonitorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/observability/SlowQueryMonitorTest.java
@@ -1,0 +1,162 @@
+package com.eu.habbo.database.observability;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SlowQueryMonitorTest {
+
+    @Test
+    void emitsStructuredContextOnlyWhenTheThresholdIsReached() throws Exception {
+        List<SlowQueryEvent> events = new ArrayList<>();
+        SlowQueryMonitor monitor = monitor(events, clock(0, 300_000_000L), 250);
+        Connection connection = monitor.wrap(connectionReturning(statementReturning(false)));
+
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT * FROM users WHERE username = 'alice' AND id = 42")) {
+            statement.executeQuery();
+        }
+
+        assertEquals(1, events.size());
+        SlowQueryEvent event = events.getFirst();
+        assertEquals(300, event.durationMs());
+        assertEquals("executeQuery", event.operation());
+        assertTrue(event.success());
+        assertEquals("SELECT * FROM users WHERE username = ? AND id = ?", event.sql());
+        assertEquals(16, event.fingerprint().length());
+        assertEquals("test-worker", event.threadName());
+        assertEquals(new PoolSnapshot(3, 7, 10, 1), event.pool());
+    }
+
+    @Test
+    void ignoresFastQueries() throws Exception {
+        List<SlowQueryEvent> events = new ArrayList<>();
+        SlowQueryMonitor monitor = monitor(events, clock(0, 249_999_999L), 250);
+        Connection connection = monitor.wrap(connectionReturning(statementReturning(false)));
+
+        connection.createStatement().execute("SELECT 1");
+
+        assertTrue(events.isEmpty());
+    }
+
+    @Test
+    void recordsSafeFailureMetadataWithoutLoggingTheDriverMessage() throws Exception {
+        List<SlowQueryEvent> events = new ArrayList<>();
+        SlowQueryMonitor monitor = monitor(events, clock(0, 400_000_000L), 250);
+        Connection connection = monitor.wrap(connectionReturning(statementReturning(true)));
+
+        SQLException error = assertThrows(SQLException.class,
+                () -> connection.createStatement().executeUpdate(
+                        "UPDATE users SET auth_ticket = 'secret-ticket' WHERE id = 5"));
+
+        assertEquals("private driver message", error.getMessage());
+        SlowQueryEvent event = events.getFirst();
+        assertFalse(event.success());
+        assertEquals("42000", event.sqlState());
+        assertEquals(1064, event.vendorCode());
+        assertFalse(event.sql().contains("secret-ticket"));
+        assertFalse(event.toString().contains("private driver message"));
+    }
+
+    @Test
+    void loggingFailureNeverChangesTheQueryResult() throws Exception {
+        SlowQueryMonitor monitor = new SlowQueryMonitor(
+                new SlowQuerySettings(true, 1, 512),
+                event -> { throw new IllegalStateException("sink unavailable"); },
+                clock(0, 2_000_000L),
+                () -> PoolSnapshot.UNAVAILABLE,
+                () -> "test-worker");
+        Connection connection = monitor.wrap(connectionReturning(statementReturning(false)));
+
+        assertDoesNotThrow(() -> connection.createStatement().execute("SELECT 1"));
+    }
+
+    @Test
+    void summarizesStatementBatchesWithoutLoggingEveryValue() throws Exception {
+        List<SlowQueryEvent> events = new ArrayList<>();
+        SlowQueryMonitor monitor = monitor(events, clock(0, 300_000_000L), 250);
+        Connection connection = monitor.wrap(connectionReturning(statementReturning(false)));
+        Statement statement = connection.createStatement();
+
+        statement.addBatch("UPDATE users SET credits = 100 WHERE id = 1");
+        statement.addBatch("UPDATE users SET credits = 200 WHERE id = 2");
+        statement.executeBatch();
+
+        SlowQueryEvent event = events.getFirst();
+        assertEquals("executeBatch", event.operation());
+        assertTrue(event.sql().startsWith("BATCH size=? first=UPDATE users SET credits = ? WHERE id = ?"));
+        assertFalse(event.sql().contains("200"));
+    }
+
+    private static SlowQueryMonitor monitor(
+            List<SlowQueryEvent> events,
+            LongSupplier clock,
+            long thresholdMs) {
+        return new SlowQueryMonitor(
+                new SlowQuerySettings(true, thresholdMs, 512),
+                events::add,
+                clock,
+                () -> new PoolSnapshot(3, 7, 10, 1),
+                () -> "test-worker");
+    }
+
+    private static LongSupplier clock(long... values) {
+        AtomicInteger index = new AtomicInteger();
+        return () -> values[Math.min(index.getAndIncrement(), values.length - 1)];
+    }
+
+    private static Connection connectionReturning(Statement statement) {
+        return (Connection) Proxy.newProxyInstance(
+                SlowQueryMonitorTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "prepareStatement", "prepareCall", "createStatement" -> statement;
+                    case "close" -> null;
+                    case "isClosed" -> false;
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static PreparedStatement statementReturning(boolean fail) {
+        return (PreparedStatement) Proxy.newProxyInstance(
+                SlowQueryMonitorTest.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> {
+                    if (method.getName().startsWith("execute")) {
+                        if (fail) {
+                            throw new SQLException("private driver message", "42000", 1064);
+                        }
+                        return defaultValue(method.getReturnType());
+                    }
+                    if ("close".equals(method.getName())) return null;
+                    return defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        if (type == double.class) return 0D;
+        if (type == char.class) return '\0';
+        return null;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/observability/SlowQuerySqlTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/observability/SlowQuerySqlTest.java
@@ -1,0 +1,48 @@
+package com.eu.habbo.database.observability;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SlowQuerySqlTest {
+
+    @Test
+    void removesLiteralValuesAndCommentsBeforeLogging() {
+        String first = SlowQuerySql.sanitize(
+                "SELECT * /* operator note */ FROM users WHERE username = 'alice' "
+                        + "AND password = \"secret\" AND id = 42 -- private\nLIMIT 10",
+                512);
+        String second = SlowQuerySql.sanitize(
+                "SELECT * FROM users WHERE username = 'bob' AND password = \"other\" "
+                        + "AND id = 99 LIMIT 20",
+                512);
+
+        assertEquals("SELECT * FROM users WHERE username = ? AND password = ? AND id = ? LIMIT ?", first);
+        assertEquals(first, second);
+        assertFalse(first.contains("alice"));
+        assertFalse(first.contains("secret"));
+        assertFalse(first.contains("42"));
+    }
+
+    @Test
+    void keepsIdentifiersAndPlaceholdersWhileBoundingLogSize() {
+        String sanitized = SlowQuerySql.sanitize(
+                "SELECT `rank_42`, display_name FROM permission_ranks WHERE id = ?   AND enabled = 1",
+                64);
+
+        assertTrue(sanitized.startsWith("SELECT `rank_42`, display_name FROM permission_ranks"));
+        assertTrue(sanitized.endsWith("..."));
+        assertTrue(sanitized.length() <= 64);
+    }
+
+    @Test
+    void producesTheSameFingerprintForTheSameSanitizedShape() {
+        String first = SlowQuerySql.fingerprint("SELECT * FROM users WHERE id = 10");
+        String second = SlowQuerySql.fingerprint("SELECT * FROM users WHERE id = 20");
+
+        assertEquals(first, second);
+        assertEquals(16, first.length());
+    }
+}

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -65,3 +65,8 @@ login.news.limit=5
 ## io.packet.handler.threads=24 #Game packet-handler pool size; runs game handlers OFF the Netty I/O loop. Default max(16, 2 x CPU cores).
 ## auth.http.pool.size=16 #Dedicated worker pool for the /api/auth/* HTTP endpoints (BCrypt/JDBC/Turnstile/SMTP run off the event loop). Default 16.
 ## io.netty.allocator.pooled=false #Set true to opt into Netty's pooled ByteBuf allocator. Default false (unpooled-heap).
+
+#Structured slow-query diagnostics. SQL literals and bound values are never logged.
+db.slow_query.enabled=true
+db.slow_query.threshold_ms=250
+db.slow_query.max_sql_length=1024


### PR DESCRIPTION
## Dependency

This PR is intentionally based directly on `dev` and contains only the slow-query observability change. The current `dev` test baseline has six unrelated failures that are resolved by #386, so this PR should be reviewed and merged after #386.

The feature was also cherry-picked locally on top of #386 and verified there without conflicts.

## Summary

- wraps JDBC statements centrally while preserving the existing `HikariDataSource` and two-argument `LegacyBridgeDataSource` APIs;
- records slow executions with duration, operation, success state, SQL fingerprint, sanitized SQL shape, thread name, SQL state/vendor code, and Hikari pool pressure;
- never logs bound values, string/numeric literals, SQL comments, or driver error messages;
- writes events to a dedicated rotating `logging/database/slow-queries.log` file;
- adds safe defaults and configurable threshold/log length settings;
- documents optional correlation with the MariaDB slow query log.

## Configuration

```ini
db.slow_query.enabled=true
db.slow_query.threshold_ms=250
db.slow_query.max_sql_length=1024
```

## Validation

- `mvn -B clean '-Dtest=SlowQuerySqlTest,SlowQueryMonitorTest,SlowQueryLoggingConfigurationTest' test`: 9 tests, 0 failures.
- `mvn -B -DskipTests package`: Java 25 fat JAR built successfully (`Polaris-4.2.59-jar-with-dependencies.jar`).
- Migration-only bootstrap against local MariaDB: connected, validated the schema, logged the enabled slow-query settings, and shut down cleanly.
- On top of #386: `mvn -B verify`: 650 unit tests passed; 7 Testcontainers integration tests were skipped locally because Docker is unavailable.
- On current `dev`: the full suite still reports six pre-existing failures outside this 15-file diff.