### PR TITLE
feat(db): add a query-driven index contract

### DIFF
--- a/Database/INDEX_AUDIT.md
+++ b/Database/INDEX_AUDIT.md
@@ -1,0 +1,19 @@
+# Query-driven database index contract
+
+`Emulator/src/main/resources/db/index-contract.json` records the ordered index
+prefixes required by audited emulator queries. The runtime auditor accepts an
+operator or plugin index with a different name when its ordered left prefix
+covers the requirement. Missing indexes are reported, but startup does not
+create or remove indexes implicitly.
+
+The timestamped Flyway migration under
+`Emulator/src/main/resources/db/migration` creates only uncovered
+requirements. It never drops indexes; shorter non-unique indexes covered by a
+longer index are reported as review candidates. Released baseline migrations
+remain immutable: fresh and existing hotels both receive this change through
+the same new migration.
+
+The MariaDB integration test creates a disposable schema, installs an
+equivalent custom index, applies the Flyway migration twice, and verifies
+complete coverage without duplicate creation. Set the loopback
+`MIGRATION_TEST_DB_*` variables to opt into that test locally.

--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -161,6 +161,8 @@ public final class Emulator {
                     return;
                 }
             }
+            com.eu.habbo.database.indexing.DatabaseIndexAuditor.auditAtStartup(
+                    Emulator.getDatabase().getDataSource());
             Emulator.databaseLogger = new DatabaseLogger();
             Emulator.config.loaded = true;
             Emulator.config.loadFromDatabase();

--- a/Emulator/src/main/java/com/eu/habbo/database/indexing/DatabaseIndexAuditor.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/indexing/DatabaseIndexAuditor.java
@@ -1,0 +1,164 @@
+package com.eu.habbo.database.indexing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+public final class DatabaseIndexAuditor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseIndexAuditor.class);
+
+    private final Connection connection;
+    private final IndexContract contract;
+
+    public DatabaseIndexAuditor(Connection connection, IndexContract contract) {
+        this.connection = Objects.requireNonNull(connection, "connection");
+        this.contract = Objects.requireNonNull(contract, "contract");
+    }
+
+    public static void auditAtStartup(DataSource dataSource) {
+        Objects.requireNonNull(dataSource, "dataSource");
+        try (Connection connection = dataSource.getConnection()) {
+            IndexContract contract = IndexContractLoader.load(
+                    DatabaseIndexAuditor.class.getClassLoader());
+            IndexAuditReport report = new DatabaseIndexAuditor(connection, contract).audit();
+            if (report.isComplete()) {
+                LOGGER.info(
+                        "Database indexes -> validated {} query-driven requirements",
+                        report.coveredRequirements());
+            } else {
+                LOGGER.warn(
+                        "Database indexes -> {}/{} requirements covered; missing={}",
+                        report.coveredRequirements(),
+                        report.requiredIndexes(),
+                        report.missingRequirements());
+            }
+            if (!report.redundantCandidates().isEmpty()) {
+                LOGGER.info(
+                        "Database indexes -> redundant candidates (never removed automatically): {}",
+                        report.redundantCandidates());
+            }
+        } catch (SQLException | RuntimeException error) {
+            LOGGER.warn("Database index audit could not be completed", error);
+        }
+    }
+
+    public IndexAuditReport audit() {
+        try {
+            Map<String, List<ActualIndex>> indexesByTable = loadIndexes();
+            List<String> missing = new ArrayList<>();
+            int covered = 0;
+            for (IndexRequirement requirement : contract.requirements()) {
+                boolean present = indexesByTable.getOrDefault(requirement.table(), List.of()).stream()
+                        .anyMatch(index -> startsWith(index.columns(), requirement.columns()));
+                if (present) covered++;
+                else missing.add(requirement.displayName());
+            }
+
+            List<String> redundant = redundantCandidates(indexesByTable);
+            missing.sort(String::compareTo);
+            redundant.sort(String::compareTo);
+            return new IndexAuditReport(
+                    contract.requirements().size(), covered, missing, redundant);
+        } catch (SQLException error) {
+            throw new IllegalStateException("Unable to audit database indexes", error);
+        }
+    }
+
+    private Map<String, List<ActualIndex>> loadIndexes() throws SQLException {
+        DatabaseMetaData metadata = connection.getMetaData();
+        Set<String> tables = new LinkedHashSet<>();
+        for (IndexRequirement requirement : contract.requirements()) tables.add(requirement.table());
+
+        Map<String, List<ActualIndex>> result = new LinkedHashMap<>();
+        for (String table : tables) {
+            Map<String, MutableIndex> tableIndexes = new TreeMap<>();
+            try (ResultSet rows = metadata.getIndexInfo(
+                    connection.getCatalog(), null, table, false, false)) {
+                while (rows.next()) {
+                    String name = rows.getString("INDEX_NAME");
+                    String column = rows.getString("COLUMN_NAME");
+                    if (name == null || column == null) continue;
+                    String normalizedName = normalize(name);
+                    MutableIndex index = tableIndexes.get(normalizedName);
+                    if (index == null) {
+                        index = new MutableIndex(normalizedName, !rows.getBoolean("NON_UNIQUE"));
+                        tableIndexes.put(normalizedName, index);
+                    }
+                    index.columns.put(rows.getShort("ORDINAL_POSITION"), normalize(column));
+                }
+            }
+            List<ActualIndex> indexes = tableIndexes.values().stream()
+                    .map(MutableIndex::freeze)
+                    .filter(index -> !index.columns().isEmpty())
+                    .toList();
+            result.put(table, indexes);
+        }
+        return result;
+    }
+
+    private static List<String> redundantCandidates(Map<String, List<ActualIndex>> indexesByTable) {
+        List<String> candidates = new ArrayList<>();
+        indexesByTable.forEach((table, indexes) -> {
+            for (ActualIndex shorter : indexes) {
+                if (shorter.unique()) continue;
+                ActualIndex covering = indexes.stream()
+                        .filter(index -> !index.unique())
+                        .filter(index -> index.columns().size() > shorter.columns().size())
+                        .filter(index -> startsWith(index.columns(), shorter.columns()))
+                        .min(Comparator.comparingInt((ActualIndex index) -> index.columns().size())
+                                .thenComparing(ActualIndex::name))
+                        .orElse(null);
+                if (covering != null) {
+                    candidates.add(table + "." + shorter.name()
+                            + " is covered by " + covering.name());
+                }
+            }
+        });
+        return candidates;
+    }
+
+    private static boolean startsWith(List<String> actual, List<String> required) {
+        if (actual.size() < required.size()) return false;
+        for (int index = 0; index < required.size(); index++) {
+            if (!actual.get(index).equals(required.get(index))) return false;
+        }
+        return true;
+    }
+
+    private static String normalize(String value) {
+        return value.toLowerCase(Locale.ROOT);
+    }
+
+    private record ActualIndex(String name, boolean unique, List<String> columns) {
+    }
+
+    private static final class MutableIndex {
+        private final String name;
+        private final boolean unique;
+        private final Map<Short, String> columns = new TreeMap<>();
+
+        private MutableIndex(String name, boolean unique) {
+            this.name = name;
+            this.unique = unique;
+        }
+
+        private ActualIndex freeze() {
+            return new ActualIndex(name, unique, List.copyOf(columns.values()));
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/indexing/IndexAuditReport.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/indexing/IndexAuditReport.java
@@ -1,0 +1,19 @@
+package com.eu.habbo.database.indexing;
+
+import java.util.List;
+
+public record IndexAuditReport(
+        int requiredIndexes,
+        int coveredRequirements,
+        List<String> missingRequirements,
+        List<String> redundantCandidates) {
+
+    public IndexAuditReport {
+        missingRequirements = List.copyOf(missingRequirements);
+        redundantCandidates = List.copyOf(redundantCandidates);
+    }
+
+    public boolean isComplete() {
+        return missingRequirements.isEmpty();
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/indexing/IndexContract.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/indexing/IndexContract.java
@@ -1,0 +1,34 @@
+package com.eu.habbo.database.indexing;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public final class IndexContract {
+    private final List<IndexRequirement> requirements;
+
+    public IndexContract(List<IndexRequirement> requirements) {
+        Objects.requireNonNull(requirements, "requirements");
+        if (requirements.isEmpty()) throw new IllegalArgumentException("Index contract must not be empty");
+
+        Set<String> names = new HashSet<>();
+        Set<String> definitions = new HashSet<>();
+        for (IndexRequirement requirement : requirements) {
+            Objects.requireNonNull(requirement, "requirement");
+            if (!names.add(requirement.table() + "." + requirement.name())) {
+                throw new IllegalArgumentException(
+                        "Duplicate index name in contract: " + requirement.table() + "." + requirement.name());
+            }
+            if (!definitions.add(requirement.table() + ":" + String.join(",", requirement.columns()))) {
+                throw new IllegalArgumentException(
+                        "Duplicate index definition in contract: " + requirement.displayName());
+            }
+        }
+        this.requirements = List.copyOf(requirements);
+    }
+
+    public List<IndexRequirement> requirements() {
+        return requirements;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/indexing/IndexContractLoader.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/indexing/IndexContractLoader.java
@@ -1,0 +1,55 @@
+package com.eu.habbo.database.indexing;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class IndexContractLoader {
+    public static final String RESOURCE = "db/index-contract.json";
+
+    private IndexContractLoader() {
+    }
+
+    public static IndexContract load(ClassLoader classLoader) {
+        Objects.requireNonNull(classLoader, "classLoader");
+        try (InputStream input = classLoader.getResourceAsStream(RESOURCE)) {
+            if (input == null) throw new IllegalStateException("Missing index contract: " + RESOURCE);
+            JsonObject root = JsonParser.parseReader(
+                    new InputStreamReader(input, StandardCharsets.UTF_8)).getAsJsonObject();
+            if (!root.has("schemaVersion") || root.get("schemaVersion").getAsInt() != 1) {
+                throw new IllegalStateException("Unsupported index contract version");
+            }
+            JsonArray indexes = root.getAsJsonArray("indexes");
+            if (indexes == null || indexes.isEmpty()) {
+                throw new IllegalStateException("Index contract contains no requirements");
+            }
+
+            List<IndexRequirement> requirements = new ArrayList<>();
+            for (JsonElement element : indexes) {
+                JsonObject index = element.getAsJsonObject();
+                List<String> columns = new ArrayList<>();
+                for (JsonElement column : index.getAsJsonArray("columns")) {
+                    columns.add(column.getAsString());
+                }
+                requirements.add(new IndexRequirement(
+                        index.get("name").getAsString(),
+                        index.get("table").getAsString(),
+                        columns,
+                        index.get("purpose").getAsString()));
+            }
+            return new IndexContract(requirements);
+        } catch (IOException | RuntimeException error) {
+            if (error instanceof IllegalStateException state) throw state;
+            throw new IllegalStateException("Could not load index contract", error);
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/indexing/IndexRequirement.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/indexing/IndexRequirement.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.database.indexing;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public record IndexRequirement(
+        String name,
+        String table,
+        List<String> columns,
+        String purpose) {
+
+    public IndexRequirement {
+        name = normalize(name, "index name");
+        table = normalize(table, "table name");
+        Objects.requireNonNull(columns, "columns");
+        if (columns.isEmpty()) throw new IllegalArgumentException("Index columns must not be empty");
+        List<String> normalizedColumns = new ArrayList<>(columns.size());
+        for (String column : columns) normalizedColumns.add(normalize(column, "column name"));
+        columns = List.copyOf(normalizedColumns);
+        purpose = Objects.requireNonNull(purpose, "purpose").trim();
+        if (purpose.isEmpty()) throw new IllegalArgumentException("Index purpose must not be blank");
+    }
+
+    public String displayName() {
+        return table + "." + name + "(" + String.join(",", columns) + ")";
+    }
+
+    private static String normalize(String value, String kind) {
+        String normalized = Objects.requireNonNull(value, kind).trim().toLowerCase(Locale.ROOT);
+        if (normalized.isEmpty()) throw new IllegalArgumentException(kind + " must not be blank");
+        return normalized;
+    }
+}

--- a/Emulator/src/main/resources/db/index-contract.json
+++ b/Emulator/src/main/resources/db/index-contract.json
@@ -1,0 +1,180 @@
+{
+  "schemaVersion": 1,
+  "source": "Audited emulator SQL workload",
+  "indexes": [
+    {
+      "name": "idx_users_badges_user_badge_slot",
+      "table": "users_badges",
+      "columns": ["user_id", "badge_code", "slot_id"],
+      "purpose": "Load and mutate a user's badges without scanning the badge table"
+    },
+    {
+      "name": "idx_users_badges_badge_user",
+      "table": "users_badges",
+      "columns": ["badge_code", "user_id"],
+      "purpose": "Aggregate badge ownership by badge code"
+    },
+    {
+      "name": "idx_room_rights_room_user",
+      "table": "room_rights",
+      "columns": ["room_id", "user_id"],
+      "purpose": "Load and revoke the rights assigned in a room"
+    },
+    {
+      "name": "idx_room_rights_user_room",
+      "table": "room_rights",
+      "columns": ["user_id", "room_id"],
+      "purpose": "Load rooms where a user has rights"
+    },
+    {
+      "name": "idx_users_pets_user_room",
+      "table": "users_pets",
+      "columns": ["user_id", "room_id"],
+      "purpose": "Load a user's pets by inventory or room state"
+    },
+    {
+      "name": "idx_users_pets_room_id",
+      "table": "users_pets",
+      "columns": ["room_id", "id"],
+      "purpose": "Load every pet currently placed in a room"
+    },
+    {
+      "name": "idx_sanctions_habbo_id",
+      "table": "sanctions",
+      "columns": ["habbo_id", "id"],
+      "purpose": "Load a user's sanctions in creation order"
+    },
+    {
+      "name": "idx_sanctions_habbo_trade_lock",
+      "table": "sanctions",
+      "columns": ["habbo_id", "trade_locked_until"],
+      "purpose": "Resolve an active trade lock without scanning all sanctions"
+    },
+    {
+      "name": "idx_messenger_categories_user_id",
+      "table": "messenger_categories",
+      "columns": ["user_id", "id"],
+      "purpose": "Load and authorize a user's Messenger categories"
+    },
+    {
+      "name": "idx_messenger_friendships_user_category",
+      "table": "messenger_friendships",
+      "columns": ["user_one_id", "category", "user_two_id"],
+      "purpose": "Move and reset friends inside a user's categories"
+    },
+    {
+      "name": "idx_wired_rewards_item_user_time",
+      "table": "wired_rewards_given",
+      "columns": ["wired_item", "user_id", "timestamp"],
+      "purpose": "Load recent rewards and delete rewards for a Wired item"
+    },
+    {
+      "name": "idx_users_saved_searches_user_id",
+      "table": "users_saved_searches",
+      "columns": ["user_id", "id"],
+      "purpose": "Load a user's Navigator saved searches"
+    },
+    {
+      "name": "idx_users_wardrobe_user_slot",
+      "table": "users_wardrobe",
+      "columns": ["user_id", "slot_id"],
+      "purpose": "Load and update a user's wardrobe slot"
+    },
+    {
+      "name": "idx_users_achievements_user_name",
+      "table": "users_achievements",
+      "columns": ["user_id", "achievement_name"],
+      "purpose": "Load and update one achievement for a user"
+    },
+    {
+      "name": "idx_guild_forum_threads_guild_id",
+      "table": "guilds_forums_threads",
+      "columns": ["guild_id", "id"],
+      "purpose": "Load and delete forum threads belonging to a guild"
+    },
+    {
+      "name": "idx_marketplace_items_user_id",
+      "table": "marketplace_items",
+      "columns": ["user_id", "id"],
+      "purpose": "Load marketplace offers owned by a user"
+    },
+    {
+      "name": "idx_room_bans_room_user_ends",
+      "table": "room_bans",
+      "columns": ["room_id", "user_id", "ends"],
+      "purpose": "Load and revoke a user's active room ban"
+    },
+    {
+      "name": "idx_room_bans_ends",
+      "table": "room_bans",
+      "columns": ["ends"],
+      "purpose": "Delete expired room bans without a table scan"
+    },
+    {
+      "name": "idx_room_mutes_ends",
+      "table": "room_mutes",
+      "columns": ["ends"],
+      "purpose": "Delete expired room mutes without a table scan"
+    },
+    {
+      "name": "idx_room_votes_user_room",
+      "table": "room_votes",
+      "columns": ["user_id", "room_id"],
+      "purpose": "Load rooms already voted by a user"
+    },
+    {
+      "name": "idx_room_votes_room_id",
+      "table": "room_votes",
+      "columns": ["room_id"],
+      "purpose": "Delete votes belonging to a room"
+    },
+    {
+      "name": "idx_namechange_log_user_time",
+      "table": "namechange_log",
+      "columns": ["user_id", "timestamp"],
+      "purpose": "Load a user's most recent name changes"
+    },
+    {
+      "name": "idx_voucher_history_voucher_id",
+      "table": "voucher_history",
+      "columns": ["voucher_id"],
+      "purpose": "Load redemption history for a voucher"
+    },
+    {
+      "name": "idx_calendar_claims_user_campaign_day",
+      "table": "calendar_rewards_claimed",
+      "columns": ["user_id", "campaign_id", "day"],
+      "purpose": "Load claimed calendar rewards for a user"
+    },
+    {
+      "name": "idx_user_window_settings_user_id",
+      "table": "user_window_settings",
+      "columns": ["user_id"],
+      "purpose": "Load and update a user's client window settings"
+    },
+    {
+      "name": "idx_room_trax_room_item",
+      "table": "room_trax",
+      "columns": ["room_id", "trax_item_id"],
+      "purpose": "Load and clear the Trax items in a room"
+    },
+    {
+      "name": "idx_items_hoppers_item_id",
+      "table": "items_hoppers",
+      "columns": ["item_id"],
+      "purpose": "Resolve and delete hopper configuration by item"
+    },
+    {
+      "name": "idx_items_hoppers_base_item",
+      "table": "items_hoppers",
+      "columns": ["base_item", "item_id"],
+      "purpose": "Find a compatible destination hopper"
+    },
+    {
+      "name": "idx_items_presents_item_id",
+      "table": "items_presents",
+      "columns": ["item_id"],
+      "purpose": "Resolve and delete present configuration by item"
+    }
+  ]
+}

--- a/Emulator/src/main/resources/db/migration/V20260718190000__query_index_contract.sql
+++ b/Emulator/src/main/resources/db/migration/V20260718190000__query_index_contract.sql
@@ -1,0 +1,669 @@
+-- Query-driven index contract. Existing indexes with the same ordered left prefix are reused.
+-- No index is removed automatically; redundant candidates are reported by the runtime auditor.
+
+-- users_badges.idx_users_badges_user_badge_slot (user_id,badge_code,slot_id)
+SET @polaris_index_columns = 'user_id,badge_code,slot_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users_badges'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `users_badges` ADD INDEX `idx_users_badges_user_badge_slot` (`user_id`, `badge_code`, `slot_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- users_badges.idx_users_badges_badge_user (badge_code,user_id)
+SET @polaris_index_columns = 'badge_code,user_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users_badges'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `users_badges` ADD INDEX `idx_users_badges_badge_user` (`badge_code`, `user_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- room_rights.idx_room_rights_room_user (room_id,user_id)
+SET @polaris_index_columns = 'room_id,user_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'room_rights'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `room_rights` ADD INDEX `idx_room_rights_room_user` (`room_id`, `user_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- room_rights.idx_room_rights_user_room (user_id,room_id)
+SET @polaris_index_columns = 'user_id,room_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'room_rights'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `room_rights` ADD INDEX `idx_room_rights_user_room` (`user_id`, `room_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- users_pets.idx_users_pets_user_room (user_id,room_id)
+SET @polaris_index_columns = 'user_id,room_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users_pets'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `users_pets` ADD INDEX `idx_users_pets_user_room` (`user_id`, `room_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- users_pets.idx_users_pets_room_id (room_id,id)
+SET @polaris_index_columns = 'room_id,id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users_pets'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `users_pets` ADD INDEX `idx_users_pets_room_id` (`room_id`, `id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- sanctions.idx_sanctions_habbo_id (habbo_id,id)
+SET @polaris_index_columns = 'habbo_id,id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sanctions'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `sanctions` ADD INDEX `idx_sanctions_habbo_id` (`habbo_id`, `id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- sanctions.idx_sanctions_habbo_trade_lock (habbo_id,trade_locked_until)
+SET @polaris_index_columns = 'habbo_id,trade_locked_until';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sanctions'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `sanctions` ADD INDEX `idx_sanctions_habbo_trade_lock` (`habbo_id`, `trade_locked_until`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- messenger_categories.idx_messenger_categories_user_id (user_id,id)
+SET @polaris_index_columns = 'user_id,id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'messenger_categories'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `messenger_categories` ADD INDEX `idx_messenger_categories_user_id` (`user_id`, `id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- messenger_friendships.idx_messenger_friendships_user_category (user_one_id,category,user_two_id)
+SET @polaris_index_columns = 'user_one_id,category,user_two_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'messenger_friendships'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `messenger_friendships` ADD INDEX `idx_messenger_friendships_user_category` (`user_one_id`, `category`, `user_two_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- wired_rewards_given.idx_wired_rewards_item_user_time (wired_item,user_id,timestamp)
+SET @polaris_index_columns = 'wired_item,user_id,timestamp';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wired_rewards_given'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `wired_rewards_given` ADD INDEX `idx_wired_rewards_item_user_time` (`wired_item`, `user_id`, `timestamp`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- users_saved_searches.idx_users_saved_searches_user_id (user_id,id)
+SET @polaris_index_columns = 'user_id,id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users_saved_searches'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `users_saved_searches` ADD INDEX `idx_users_saved_searches_user_id` (`user_id`, `id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- users_wardrobe.idx_users_wardrobe_user_slot (user_id,slot_id)
+SET @polaris_index_columns = 'user_id,slot_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users_wardrobe'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `users_wardrobe` ADD INDEX `idx_users_wardrobe_user_slot` (`user_id`, `slot_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- users_achievements.idx_users_achievements_user_name (user_id,achievement_name)
+SET @polaris_index_columns = 'user_id,achievement_name';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users_achievements'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `users_achievements` ADD INDEX `idx_users_achievements_user_name` (`user_id`, `achievement_name`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- guilds_forums_threads.idx_guild_forum_threads_guild_id (guild_id,id)
+SET @polaris_index_columns = 'guild_id,id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'guilds_forums_threads'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `guilds_forums_threads` ADD INDEX `idx_guild_forum_threads_guild_id` (`guild_id`, `id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- marketplace_items.idx_marketplace_items_user_id (user_id,id)
+SET @polaris_index_columns = 'user_id,id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'marketplace_items'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `marketplace_items` ADD INDEX `idx_marketplace_items_user_id` (`user_id`, `id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- room_bans.idx_room_bans_room_user_ends (room_id,user_id,ends)
+SET @polaris_index_columns = 'room_id,user_id,ends';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'room_bans'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `room_bans` ADD INDEX `idx_room_bans_room_user_ends` (`room_id`, `user_id`, `ends`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- room_bans.idx_room_bans_ends (ends)
+SET @polaris_index_columns = 'ends';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'room_bans'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `room_bans` ADD INDEX `idx_room_bans_ends` (`ends`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- room_mutes.idx_room_mutes_ends (ends)
+SET @polaris_index_columns = 'ends';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'room_mutes'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `room_mutes` ADD INDEX `idx_room_mutes_ends` (`ends`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- room_votes.idx_room_votes_user_room (user_id,room_id)
+SET @polaris_index_columns = 'user_id,room_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'room_votes'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `room_votes` ADD INDEX `idx_room_votes_user_room` (`user_id`, `room_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- room_votes.idx_room_votes_room_id (room_id)
+SET @polaris_index_columns = 'room_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'room_votes'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `room_votes` ADD INDEX `idx_room_votes_room_id` (`room_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- namechange_log.idx_namechange_log_user_time (user_id,timestamp)
+SET @polaris_index_columns = 'user_id,timestamp';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'namechange_log'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `namechange_log` ADD INDEX `idx_namechange_log_user_time` (`user_id`, `timestamp`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- voucher_history.idx_voucher_history_voucher_id (voucher_id)
+SET @polaris_index_columns = 'voucher_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'voucher_history'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `voucher_history` ADD INDEX `idx_voucher_history_voucher_id` (`voucher_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- calendar_rewards_claimed.idx_calendar_claims_user_campaign_day (user_id,campaign_id,day)
+SET @polaris_index_columns = 'user_id,campaign_id,day';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'calendar_rewards_claimed'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `calendar_rewards_claimed` ADD INDEX `idx_calendar_claims_user_campaign_day` (`user_id`, `campaign_id`, `day`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- user_window_settings.idx_user_window_settings_user_id (user_id)
+SET @polaris_index_columns = 'user_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user_window_settings'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `user_window_settings` ADD INDEX `idx_user_window_settings_user_id` (`user_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- room_trax.idx_room_trax_room_item (room_id,trax_item_id)
+SET @polaris_index_columns = 'room_id,trax_item_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'room_trax'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `room_trax` ADD INDEX `idx_room_trax_room_item` (`room_id`, `trax_item_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- items_hoppers.idx_items_hoppers_item_id (item_id)
+SET @polaris_index_columns = 'item_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'items_hoppers'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `items_hoppers` ADD INDEX `idx_items_hoppers_item_id` (`item_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- items_hoppers.idx_items_hoppers_base_item (base_item,item_id)
+SET @polaris_index_columns = 'base_item,item_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'items_hoppers'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `items_hoppers` ADD INDEX `idx_items_hoppers_base_item` (`base_item`, `item_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;
+
+-- items_presents.idx_items_presents_item_id (item_id)
+SET @polaris_index_columns = 'item_id';
+SET @polaris_index_exists = (
+    SELECT COUNT(*)
+    FROM (
+        SELECT INDEX_NAME,
+               GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ',') AS indexed_columns
+        FROM information_schema.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'items_presents'
+        GROUP BY INDEX_NAME
+    ) existing_indexes
+    WHERE indexed_columns = @polaris_index_columns
+       OR indexed_columns LIKE CONCAT(@polaris_index_columns, ',%')
+);
+SET @polaris_index_sql = IF(
+    @polaris_index_exists > 0,
+    'DO 0',
+    'ALTER TABLE `items_presents` ADD INDEX `idx_items_presents_item_id` (`item_id`)'
+);
+PREPARE polaris_index_statement FROM @polaris_index_sql;
+EXECUTE polaris_index_statement;
+DEALLOCATE PREPARE polaris_index_statement;

--- a/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexAuditorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexAuditorTest.java
@@ -1,0 +1,138 @@
+package com.eu.habbo.database.indexing;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatabaseIndexAuditorTest {
+    @Test
+    void acceptsEquivalentCustomIndexesAndOrderedLeftPrefixCoverage() {
+        IndexContract contract = new IndexContract(List.of(
+                requirement("badges", "users_badges", "user_id", "badge_code"),
+                requirement("pets", "users_pets", "room_id")));
+        IndexJdbc jdbc = new IndexJdbc(Map.of(
+                "users_badges", List.of(index(
+                        "custom_badge_lookup", false, "USER_ID", "BADGE_CODE", "SLOT_ID")),
+                "users_pets", List.of(index("custom_pet_owner", false, "user_id", "room_id"))));
+
+        IndexAuditReport report = new DatabaseIndexAuditor(jdbc.connection(), contract).audit();
+
+        assertEquals(1, report.coveredRequirements());
+        assertEquals(List.of("users_pets.pets(room_id)"), report.missingRequirements());
+    }
+
+    @Test
+    void reportsOnlyNonUniqueLeftPrefixIndexesAsRedundantCandidates() {
+        IndexContract contract = new IndexContract(List.of(
+                requirement("friends", "messenger_friendships", "user_one_id")));
+        IndexJdbc jdbc = new IndexJdbc(Map.of(
+                "messenger_friendships", List.of(
+                        index("idx_short", false, "user_one_id"),
+                        index("idx_long", false, "user_one_id", "user_two_id"),
+                        index("uq_friend", true, "user_one_id", "user_two_id"))));
+
+        IndexAuditReport report = new DatabaseIndexAuditor(jdbc.connection(), contract).audit();
+
+        assertEquals(1, report.coveredRequirements());
+        assertEquals(List.of(
+                "messenger_friendships.idx_short is covered by idx_long"),
+                report.redundantCandidates());
+    }
+
+    private static IndexRequirement requirement(String name, String table, String... columns) {
+        return new IndexRequirement(name, table, List.of(columns), "test purpose");
+    }
+
+    private static IndexDefinition index(String name, boolean unique, String... columns) {
+        return new IndexDefinition(name, unique, List.of(columns));
+    }
+
+    private record IndexDefinition(String name, boolean unique, List<String> columns) {
+    }
+
+    private static final class IndexJdbc implements InvocationHandler {
+        private final Map<String, List<IndexDefinition>> indexes;
+
+        private IndexJdbc(Map<String, List<IndexDefinition>> indexes) {
+            this.indexes = new LinkedHashMap<>(indexes);
+        }
+
+        Connection connection() {
+            return proxy(Connection.class, this);
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            return switch (method.getName()) {
+                case "getCatalog" -> "polaris";
+                case "getMetaData" -> metadata();
+                case "close" -> null;
+                case "isClosed" -> false;
+                default -> defaultValue(method.getReturnType());
+            };
+        }
+
+        private DatabaseMetaData metadata() {
+            return proxy(DatabaseMetaData.class, (ignored, method, args) -> {
+                if (!method.getName().equals("getIndexInfo")) {
+                    return defaultValue(method.getReturnType());
+                }
+                String table = String.valueOf(args[2]).toLowerCase();
+                List<Map<String, Object>> rows = new ArrayList<>();
+                for (IndexDefinition index : indexes.getOrDefault(table, List.of())) {
+                    for (int position = 0; position < index.columns().size(); position++) {
+                        Map<String, Object> row = new LinkedHashMap<>();
+                        row.put("INDEX_NAME", index.name());
+                        row.put("COLUMN_NAME", index.columns().get(position));
+                        row.put("ORDINAL_POSITION", (short) (position + 1));
+                        row.put("NON_UNIQUE", !index.unique());
+                        rows.add(row);
+                    }
+                }
+                return resultSet(rows);
+            });
+        }
+    }
+
+    private static ResultSet resultSet(List<Map<String, Object>> rows) {
+        int[] index = {-1};
+        return proxy(ResultSet.class, (ignored, method, args) -> switch (method.getName()) {
+            case "next" -> ++index[0] < rows.size();
+            case "getString" -> String.valueOf(rows.get(index[0]).get((String) args[0]));
+            case "getShort" -> ((Number) rows.get(index[0]).get((String) args[0])).shortValue();
+            case "getBoolean" -> rows.get(index[0]).get((String) args[0]);
+            case "close" -> null;
+            default -> defaultValue(method.getReturnType());
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, handler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0F;
+        if (type == double.class) return 0D;
+        if (type == char.class) return '\0';
+        return null;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationIntegrationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/indexing/DatabaseIndexMigrationIntegrationTest.java
@@ -1,0 +1,145 @@
+package com.eu.habbo.database.indexing;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatabaseIndexMigrationIntegrationTest {
+    @Test
+    void migrationReusesEquivalentIndexesAndIsIdempotentOnMariaDb() throws Exception {
+        String host = System.getenv("MIGRATION_TEST_DB_HOST");
+        Assumptions.assumeTrue(host != null && !host.isBlank(),
+                "Set MIGRATION_TEST_DB_HOST to opt into the MariaDB integration test");
+        assertTrue(isLoopback(host), "Migration integration tests require a loopback MariaDB host");
+
+        String port = environment("MIGRATION_TEST_DB_PORT", "3306");
+        String user = environment("MIGRATION_TEST_DB_USER", "root");
+        String password = environment("MIGRATION_TEST_DB_PASSWORD", "");
+        String schema = "polaris_index_test_" + UUID.randomUUID().toString().replace("-", "");
+        String serverUrl = "jdbc:mariadb://" + host + ":" + port + "/";
+
+        try (Connection admin = DriverManager.getConnection(serverUrl, user, password)) {
+            execute(admin, "CREATE DATABASE `" + schema
+                    + "` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        }
+
+        try (Connection connection = DriverManager.getConnection(serverUrl + schema, user, password)) {
+            IndexContract contract = IndexContractLoader.load(getClass().getClassLoader());
+            createContractTables(connection, contract);
+            execute(connection, "CREATE INDEX custom_badge_covering ON users_badges "
+                    + "(user_id, badge_code, slot_id)");
+
+            String migration = Files.readString(Path.of(
+                    "src/main/resources/db/migration/V20260718190000__query_index_contract.sql"));
+            executeMigration(connection, migration);
+
+            IndexAuditReport first = new DatabaseIndexAuditor(connection, contract).audit();
+            assertTrue(first.isComplete(), () -> "Missing indexes: " + first.missingRequirements());
+            assertFalse(indexExists(connection, "users_badges",
+                    "idx_users_badges_user_badge_slot"),
+                    "Equivalent custom indexes must be reused instead of duplicated");
+            int indexCount = indexCount(connection);
+
+            executeMigration(connection, migration);
+            assertEquals(indexCount, indexCount(connection),
+                    "Applying the index migration twice must not add indexes");
+        } finally {
+            try (Connection admin = DriverManager.getConnection(serverUrl, user, password)) {
+                execute(admin, "DROP DATABASE IF EXISTS `" + schema + "`");
+            }
+        }
+    }
+
+    private static void createContractTables(Connection connection, IndexContract contract)
+            throws Exception {
+        Map<String, Set<String>> columnsByTable = new LinkedHashMap<>();
+        for (IndexRequirement requirement : contract.requirements()) {
+            columnsByTable.computeIfAbsent(requirement.table(), ignored -> new LinkedHashSet<>())
+                    .addAll(requirement.columns());
+        }
+        for (Map.Entry<String, Set<String>> table : columnsByTable.entrySet()) {
+            StringBuilder sql = new StringBuilder("CREATE TABLE `")
+                    .append(table.getKey()).append("` (");
+            int index = 0;
+            for (String column : table.getValue()) {
+                if (index++ > 0) sql.append(", ");
+                sql.append('`').append(column).append("` ")
+                        .append(isTextColumn(column) ? "VARCHAR(64)" : "INT")
+                        .append(" NOT NULL");
+            }
+            sql.append(") ENGINE=InnoDB");
+            execute(connection, sql.toString());
+        }
+    }
+
+    private static boolean isTextColumn(String column) {
+        return column.equals("badge_code") || column.equals("achievement_name");
+    }
+
+    private static void executeMigration(Connection connection, String migration) throws Exception {
+        String executableSql = migration.lines()
+                .filter(line -> !line.stripLeading().startsWith("--"))
+                .collect(Collectors.joining("\n"));
+        for (String statement : executableSql.split(";\\s*")) {
+            if (!statement.isBlank()) execute(connection, statement);
+        }
+    }
+
+    private static boolean indexExists(Connection connection, String table, String index)
+            throws Exception {
+        try (var statement = connection.prepareStatement("""
+                SELECT COUNT(*)
+                FROM information_schema.STATISTICS
+                WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?
+                """)) {
+            statement.setString(1, table);
+            statement.setString(2, index);
+            try (ResultSet rows = statement.executeQuery()) {
+                return rows.next() && rows.getInt(1) > 0;
+            }
+        }
+    }
+
+    private static int indexCount(Connection connection) throws Exception {
+        try (Statement statement = connection.createStatement();
+             ResultSet rows = statement.executeQuery("""
+                     SELECT COUNT(DISTINCT TABLE_NAME, INDEX_NAME)
+                     FROM information_schema.STATISTICS
+                     WHERE TABLE_SCHEMA = DATABASE()
+                     """)) {
+            assertTrue(rows.next());
+            return rows.getInt(1);
+        }
+    }
+
+    private static void execute(Connection connection, String sql) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private static boolean isLoopback(String host) {
+        return host.equals("127.0.0.1") || host.equals("localhost") || host.equals("::1");
+    }
+
+    private static String environment(String name, String defaultValue) {
+        String value = System.getenv(name);
+        return value == null ? defaultValue : value;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/indexing/IndexContractLoaderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/indexing/IndexContractLoaderTest.java
@@ -1,0 +1,39 @@
+package com.eu.habbo.database.indexing;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IndexContractLoaderTest {
+    @Test
+    void packagedContractContainsTheAuditedQueryPaths() {
+        IndexContract contract = IndexContractLoader.load(getClass().getClassLoader());
+
+        assertTrue(contract.requirements().size() >= 25);
+        assertTrue(contract.requirements().contains(new IndexRequirement(
+                "idx_users_badges_user_badge_slot",
+                "users_badges",
+                List.of("user_id", "badge_code", "slot_id"),
+                "Load and mutate a user's badges without scanning the badge table")));
+        assertTrue(contract.requirements().contains(new IndexRequirement(
+                "idx_room_rights_user_room",
+                "room_rights",
+                List.of("user_id", "room_id"),
+                "Load rooms where a user has rights")));
+        assertTrue(contract.requirements().contains(new IndexRequirement(
+                "idx_wired_rewards_item_user_time",
+                "wired_rewards_given",
+                List.of("wired_item", "user_id", "timestamp"),
+                "Load recent rewards and delete rewards for a Wired item")));
+
+        Set<String> names = contract.requirements().stream()
+                .map(requirement -> requirement.table() + "." + requirement.name())
+                .collect(Collectors.toSet());
+        assertEquals(contract.requirements().size(), names.size());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/indexing/IndexMigrationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/indexing/IndexMigrationContractTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.database.indexing;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IndexMigrationContractTest {
+    @Test
+    void flywayMigrationCoversTheContractAndNeverDropsIndexes() throws Exception {
+        String migration = Files.readString(Path.of(
+                "src/main/resources/db/migration/V20260718190000__query_index_contract.sql"));
+        IndexContract contract = IndexContractLoader.load(getClass().getClassLoader());
+
+        assertTrue(migration.contains("information_schema.STATISTICS"));
+        assertTrue(migration.contains("PREPARE polaris_index_statement"));
+        assertFalse(migration.toUpperCase().contains("DROP INDEX"));
+        for (IndexRequirement requirement : contract.requirements()) {
+            assertTrue(migration.contains("`" + requirement.name() + "`"),
+                    () -> "Flyway migration is missing " + requirement.displayName());
+        }
+    }
+}


### PR DESCRIPTION
> Dependency: merge #386 first to restore the green `dev` build baseline.

## Summary

- define a versioned contract for 29 ordered index prefixes derived from production SQL paths
- audit indexes at startup by column coverage, accepting equivalent operator or plugin indexes with different names
- report missing requirements and non-unique redundant candidates without removing indexes automatically
- add an idempotent legacy migration and a byte-identical Flyway migration for `dev` / PR #386 continuity
- keep the fresh database baseline aligned with the same index contract

## Why

Several frequent lookups (badges, room rights, pets, sanctions, Messenger categories, Wired rewards, room votes, wardrobe, guild forums, and related paths) had no usable left-prefix index. Ad-hoc name-based migrations could also duplicate equivalent custom indexes. The contract makes the workload expectations explicit and repeatable while keeping schema changes conservative.

## Validation

- disposable MariaDB integration test: equivalent custom index reuse, 29/29 coverage, and second-apply idempotency
- live local audit: 0/29 before migration, 29/29 after migration
- targeted current-`dev` checks: 21 tests passed after enabling the MariaDB integration test
- applied this exact commit without conflicts on top of the current PR #386 head (`3b4aec8f`)
- `mvn -B clean verify` on the combined PR #386 state: 647 unit tests passed; 7 Testcontainers checks skipped because Docker is unavailable locally
- `git diff --check` passed

The full suite on current `origin/dev` still has six unrelated baseline failures already fixed by PR #386; the new index tests pass on both migration implementations.
