### PR TITLE
Add fail-closed backups before database migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,46 @@ jobs:
         env:
           POLARIS_TEST_MARIADB_IMAGE: ${{ matrix.mariadb }}
         run: mvn -B test-compile failsafe:integration-test failsafe:verify -Dit.test=MigrationRunnerIT
+
+  backup-restore:
+    name: Migration backup + restore
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:11.4.12@sha256:a794d9eb009e20de605858a11f32f63b4075cbd197c650436f0e3b457e4caed7
+        env:
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+    defaults:
+      run:
+        working-directory: Emulator
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Install MariaDB client tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes mariadb-client
+
+      - name: Verify backup, drop and restore
+        env:
+          MIGRATION_TEST_DB_HOST: 127.0.0.1
+          MIGRATION_TEST_DB_PORT: 3306
+          MIGRATION_TEST_DB_USER: root
+          MIGRATION_TEST_DB_PASSWORD: root
+        run: mvn -B -Dtest=MariaDbMigrationBackupIntegrationTest test

--- a/Emulator/src/main/java/com/eu/habbo/Emulator.java
+++ b/Emulator/src/main/java/com/eu/habbo/Emulator.java
@@ -150,7 +150,9 @@ public final class Emulator {
 
                 if (migrationOptions.mode() == MigrationOptions.Mode.APPLY
                         || migrationOptions.migrationsOnly()) {
-                    MigrationRunner.migrateAtStartup(Emulator.getDatabase().getDataSource());
+                    MigrationRunner.migrateAtStartup(
+                            Emulator.getDatabase().getDataSource(),
+                            Emulator.getConfig());
                 } else {
                     MigrationRunner.runAtStartup(Emulator.getDatabase().getDataSource(), Emulator.getConfig());
                 }

--- a/Emulator/src/main/java/com/eu/habbo/database/backup/DatabaseBackupOptions.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/backup/DatabaseBackupOptions.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.database.backup;
+
+import com.eu.habbo.core.ConfigurationManager;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+
+public record DatabaseBackupOptions(
+        boolean enabled,
+        Path directory,
+        int retentionCount,
+        Duration timeout,
+        String executable) {
+
+    public DatabaseBackupOptions {
+        directory = Objects.requireNonNull(directory, "directory").toAbsolutePath().normalize();
+        timeout = Objects.requireNonNull(timeout, "timeout");
+        executable = Objects.requireNonNull(executable, "executable").trim();
+        if (retentionCount < 1 || retentionCount > 1000) {
+            throw new IllegalArgumentException("backup retention must be between 1 and 1000");
+        }
+        if (timeout.isNegative() || timeout.isZero() || timeout.compareTo(Duration.ofDays(1)) > 0) {
+            throw new IllegalArgumentException("backup timeout must be between 1 second and 1 day");
+        }
+        if (executable.isEmpty()) {
+            throw new IllegalArgumentException("backup executable must not be blank");
+        }
+    }
+
+    public static DatabaseBackupOptions resolve(ConfigurationManager config) {
+        Objects.requireNonNull(config, "config");
+        return new DatabaseBackupOptions(
+                config.getBoolean("db.migrations.backup.enabled", true),
+                Path.of(config.getValue("db.migrations.backup.directory", "backups/database")),
+                config.getInt("db.migrations.backup.keep", 7),
+                Duration.ofSeconds(config.getInt("db.migrations.backup.timeout_seconds", 900)),
+                config.getValue("db.migrations.backup.executable", "mariadb-dump"));
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/backup/DatabaseBackupRequest.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/backup/DatabaseBackupRequest.java
@@ -1,7 +1,7 @@
 package com.eu.habbo.database.backup;
 
-import com.eu.habbo.core.ConfigurationManager;
-
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Objects;
 
 public record DatabaseBackupRequest(
@@ -24,14 +24,36 @@ public record DatabaseBackupRequest(
         }
     }
 
-    public static DatabaseBackupRequest resolve(ConfigurationManager config) {
-        Objects.requireNonNull(config, "config");
+    public static DatabaseBackupRequest fromJdbc(
+            String jdbcUrl,
+            String username,
+            String password) {
+        Objects.requireNonNull(jdbcUrl, "jdbcUrl");
+        if (!jdbcUrl.startsWith("jdbc:mariadb://")) {
+            throw new IllegalArgumentException(
+                    "database backup requires a single-host jdbc:mariadb:// URL");
+        }
+
+        URI target;
+        try {
+            target = new URI(jdbcUrl.substring("jdbc:".length()));
+        } catch (URISyntaxException error) {
+            throw new IllegalArgumentException("database backup JDBC URL is invalid", error);
+        }
+
+        String path = target.getPath();
+        String database = path == null || path.length() <= 1 ? "" : path.substring(1);
+        if (database.contains("/")) {
+            throw new IllegalArgumentException(
+                    "database backup JDBC URL must identify exactly one database");
+        }
+
         return new DatabaseBackupRequest(
-                config.getValue("db.hostname", "localhost"),
-                config.getInt("db.port", 3306),
-                config.getValue("db.database"),
-                config.getValue("db.username"),
-                config.getValue("db.password"));
+                Objects.requireNonNullElse(target.getHost(), ""),
+                target.getPort() == -1 ? 3306 : target.getPort(),
+                database,
+                Objects.requireNonNullElse(username, ""),
+                Objects.requireNonNullElse(password, ""));
     }
 
     private static String safe(String value, String field) {

--- a/Emulator/src/main/java/com/eu/habbo/database/backup/DatabaseBackupRequest.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/backup/DatabaseBackupRequest.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.database.backup;
+
+import com.eu.habbo.core.ConfigurationManager;
+
+import java.util.Objects;
+
+public record DatabaseBackupRequest(
+        String host,
+        int port,
+        String database,
+        String username,
+        String password) {
+
+    public DatabaseBackupRequest {
+        host = safe(Objects.requireNonNull(host, "host"), "host");
+        database = safe(Objects.requireNonNull(database, "database"), "database");
+        username = safe(Objects.requireNonNull(username, "username"), "username");
+        password = safe(Objects.requireNonNull(password, "password"), "password");
+        if (host.isBlank() || database.isBlank() || username.isBlank()) {
+            throw new IllegalArgumentException("database backup connection fields must not be blank");
+        }
+        if (port < 1 || port > 65535) {
+            throw new IllegalArgumentException("database backup port must be between 1 and 65535");
+        }
+    }
+
+    public static DatabaseBackupRequest resolve(ConfigurationManager config) {
+        Objects.requireNonNull(config, "config");
+        return new DatabaseBackupRequest(
+                config.getValue("db.hostname", "localhost"),
+                config.getInt("db.port", 3306),
+                config.getValue("db.database"),
+                config.getValue("db.username"),
+                config.getValue("db.password"));
+    }
+
+    private static String safe(String value, String field) {
+        if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0 || value.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException(field + " contains an unsafe control character");
+        }
+        return value;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/backup/MariaDbMigrationBackup.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/backup/MariaDbMigrationBackup.java
@@ -2,6 +2,7 @@ package com.eu.habbo.database.backup;
 
 import com.eu.habbo.core.ConfigurationManager;
 import com.google.gson.Gson;
+import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,10 +73,17 @@ public final class MariaDbMigrationBackup implements MigrationBackup {
         this.clock = java.util.Objects.requireNonNull(clock, "clock");
     }
 
-    public static MigrationBackup resolve(ConfigurationManager config) {
+    public static MigrationBackup resolve(
+            ConfigurationManager config,
+            HikariDataSource migrationDataSource) {
         DatabaseBackupOptions options = DatabaseBackupOptions.resolve(config);
         if (!options.enabled()) return MigrationBackup.disabled();
-        return new MariaDbMigrationBackup(options, DatabaseBackupRequest.resolve(config));
+        return new MariaDbMigrationBackup(
+                options,
+                DatabaseBackupRequest.fromJdbc(
+                        migrationDataSource.getJdbcUrl(),
+                        migrationDataSource.getUsername(),
+                        migrationDataSource.getPassword()));
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/database/backup/MariaDbMigrationBackup.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/backup/MariaDbMigrationBackup.java
@@ -1,0 +1,410 @@
+package com.eu.habbo.database.backup;
+
+import com.eu.habbo.core.ConfigurationManager;
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.zip.GZIPOutputStream;
+
+public final class MariaDbMigrationBackup implements MigrationBackup {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MariaDbMigrationBackup.class);
+    private static final DateTimeFormatter STAMP = DateTimeFormatter
+            .ofPattern("yyyyMMdd'T'HHmmssSSS'Z'")
+            .withZone(ZoneOffset.UTC);
+    private static final int MAX_STDERR_BYTES = 16 * 1024;
+    private static final Gson GSON = new Gson();
+
+    private final DatabaseBackupOptions options;
+    private final DatabaseBackupRequest request;
+    private final ProcessStarter processStarter;
+    private final Clock clock;
+
+    public MariaDbMigrationBackup(
+            DatabaseBackupOptions options,
+            DatabaseBackupRequest request) {
+        this(options, request, command -> new ProcessBuilder(command).start(), Clock.systemUTC());
+    }
+
+    MariaDbMigrationBackup(
+            DatabaseBackupOptions options,
+            DatabaseBackupRequest request,
+            ProcessStarter processStarter,
+            Clock clock) {
+        this.options = java.util.Objects.requireNonNull(options, "options");
+        this.request = java.util.Objects.requireNonNull(request, "request");
+        this.processStarter = java.util.Objects.requireNonNull(processStarter, "processStarter");
+        this.clock = java.util.Objects.requireNonNull(clock, "clock");
+    }
+
+    public static MigrationBackup resolve(ConfigurationManager config) {
+        DatabaseBackupOptions options = DatabaseBackupOptions.resolve(config);
+        if (!options.enabled()) return MigrationBackup.disabled();
+        return new MariaDbMigrationBackup(options, DatabaseBackupRequest.resolve(config));
+    }
+
+    @Override
+    public void beforeMigrations(List<String> pendingVersions) {
+        List<String> pending = List.copyOf(pendingVersions);
+        if (!options.enabled() || pending.isEmpty()) return;
+
+        Path credentials = null;
+        Path archivePart = null;
+        Path archive = null;
+        Path checksumPart = null;
+        Path manifestPart = null;
+        Path checksum = null;
+        Path manifest = null;
+        boolean archiveCreated = false;
+        boolean checksumCreated = false;
+        boolean manifestCreated = false;
+        try {
+            Files.createDirectories(options.directory());
+            credentials = Files.createTempFile(options.directory(), ".polaris-db-backup-", ".cnf");
+            harden(credentials);
+            Files.writeString(
+                    credentials,
+                    optionFile(),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.TRUNCATE_EXISTING);
+
+            String baseName = artifactBaseName(pending);
+            archive = options.directory().resolve(baseName + ".sql.gz");
+            archivePart = options.directory().resolve(baseName + ".sql.gz.part");
+            checksum = options.directory().resolve(baseName + ".sql.gz.sha256");
+            checksumPart = options.directory().resolve(baseName + ".sql.gz.sha256.part");
+            manifest = options.directory().resolve(baseName + ".sql.gz.json");
+            manifestPart = options.directory().resolve(baseName + ".sql.gz.json.part");
+
+            List<String> command = command(credentials);
+            Process process = processStarter.start(command);
+            ProcessResult result = collect(process, archivePart);
+            if (result.exitCode() != 0) {
+                throw new MigrationBackupException(
+                        "mariadb-dump failed with exit code " + result.exitCode()
+                                + diagnostic(result.stderr()));
+            }
+            if (result.uncompressedBytes() == 0) {
+                throw new MigrationBackupException("mariadb-dump produced an empty backup");
+            }
+
+            harden(archivePart);
+            String sha256 = sha256(archivePart);
+            moveAtomically(archivePart, archive);
+            archiveCreated = true;
+            Files.writeString(
+                    checksumPart,
+                    sha256 + "  " + archive.getFileName() + System.lineSeparator(),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE_NEW);
+            harden(checksumPart);
+            moveAtomically(checksumPart, checksum);
+            checksumCreated = true;
+
+            Map<String, Object> metadata = new LinkedHashMap<>();
+            metadata.put("formatVersion", 1);
+            metadata.put("createdAt", Instant.now(clock).toString());
+            metadata.put("database", request.database());
+            metadata.put("pendingVersions", pending);
+            metadata.put("archive", archive.getFileName().toString());
+            metadata.put("compressedBytes", Files.size(archive));
+            metadata.put("uncompressedBytes", result.uncompressedBytes());
+            metadata.put("sha256", sha256);
+            metadata.put("tool", options.executable());
+            Files.writeString(
+                    manifestPart,
+                    GSON.toJson(metadata) + System.lineSeparator(),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE_NEW);
+            harden(manifestPart);
+            moveAtomically(manifestPart, manifest);
+            manifestCreated = true;
+
+            pruneOldBackups();
+            LOGGER.info(
+                    "Database migration backup -> archive={}, bytes={}, sha256={}, pending={}",
+                    archive,
+                    Files.size(archive),
+                    sha256,
+                    pending);
+        } catch (MigrationBackupException error) {
+            if (manifestCreated) deleteQuietly(manifest);
+            if (checksumCreated) deleteQuietly(checksum);
+            if (archiveCreated) deleteQuietly(archive);
+            throw error;
+        } catch (IOException | RuntimeException error) {
+            if (manifestCreated) deleteQuietly(manifest);
+            if (checksumCreated) deleteQuietly(checksum);
+            if (archiveCreated) deleteQuietly(archive);
+            throw new MigrationBackupException(
+                    "Unable to create the required database migration backup", error);
+        } finally {
+            deleteQuietly(credentials);
+            deleteQuietly(archivePart);
+            deleteQuietly(checksumPart);
+            deleteQuietly(manifestPart);
+        }
+    }
+
+    private ProcessResult collect(Process process, Path archivePart) throws IOException {
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<Long> stdout = executor.submit(() -> compress(process.getInputStream(), archivePart));
+            Future<String> stderr = executor.submit(() -> readDiagnostic(process.getErrorStream()));
+            boolean finished;
+            try {
+                finished = process.waitFor(options.timeout().toSeconds(), TimeUnit.SECONDS);
+            } catch (InterruptedException error) {
+                Thread.currentThread().interrupt();
+                stop(process);
+                throw new MigrationBackupException("Interrupted while waiting for mariadb-dump", error);
+            }
+            if (!finished) {
+                stop(process);
+                stdout.cancel(true);
+                stderr.cancel(true);
+                throw new MigrationBackupException(
+                        "mariadb-dump exceeded the configured timeout of "
+                                + options.timeout().toSeconds() + " seconds");
+            }
+            try {
+                long bytes = stdout.get(10, TimeUnit.SECONDS);
+                String diagnostic = stderr.get(10, TimeUnit.SECONDS);
+                return new ProcessResult(process.exitValue(), bytes, diagnostic);
+            } catch (InterruptedException error) {
+                Thread.currentThread().interrupt();
+                throw new MigrationBackupException("Interrupted while finalizing mariadb-dump output", error);
+            } catch (ExecutionException error) {
+                Throwable cause = error.getCause();
+                if (cause instanceof IOException io) throw io;
+                throw new MigrationBackupException("Unable to capture mariadb-dump output", cause);
+            } catch (TimeoutException error) {
+                throw new MigrationBackupException("Timed out while finalizing mariadb-dump output", error);
+            }
+        }
+    }
+
+    private List<String> command(Path credentials) {
+        return List.of(
+                options.executable(),
+                "--defaults-extra-file=" + credentials,
+                "--lock-all-tables",
+                "--quick",
+                "--routines",
+                "--events",
+                "--triggers",
+                "--hex-blob",
+                "--default-character-set=utf8mb4",
+                "--add-drop-database",
+                "--databases",
+                request.database());
+    }
+
+    private String optionFile() {
+        return "[client]" + System.lineSeparator()
+                + "protocol=tcp" + System.lineSeparator()
+                + "host=" + quote(request.host()) + System.lineSeparator()
+                + "port=" + request.port() + System.lineSeparator()
+                + "user=" + quote(request.username()) + System.lineSeparator()
+                + "password=" + quote(request.password()) + System.lineSeparator();
+    }
+
+    private static String quote(String value) {
+        return '"' + value.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+    }
+
+    private String artifactBaseName(List<String> pending) {
+        String database = request.database().replaceAll("[^A-Za-z0-9._-]", "_");
+        String base = "polaris-" + database + '-' + STAMP.format(Instant.now(clock))
+                + "-before-v" + safeVersion(pending.getFirst())
+                + "-v" + safeVersion(pending.getLast());
+        String candidate = base;
+        int suffix = 1;
+        while (artifactNameExists(candidate)) {
+            candidate = base + '-' + suffix++;
+        }
+        return candidate;
+    }
+
+    private static String safeVersion(String version) {
+        return version.replaceAll("[^A-Za-z0-9._-]", "_");
+    }
+
+    private boolean artifactNameExists(String baseName) {
+        return Files.exists(options.directory().resolve(baseName + ".sql.gz"))
+                || Files.exists(options.directory().resolve(baseName + ".sql.gz.part"))
+                || Files.exists(options.directory().resolve(baseName + ".sql.gz.sha256"))
+                || Files.exists(options.directory().resolve(baseName + ".sql.gz.json"));
+    }
+
+    private void pruneOldBackups() throws IOException {
+        List<Path> archives;
+        try (var stream = Files.list(options.directory())) {
+            archives = stream
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().startsWith("polaris-"))
+                    .filter(path -> path.getFileName().toString().endsWith(".sql.gz"))
+                    .sorted(Comparator.comparing(MariaDbMigrationBackup::modifiedAt).reversed())
+                    .toList();
+        }
+        for (Path expired : archives.stream().skip(options.retentionCount()).toList()) {
+            Files.deleteIfExists(expired);
+            Files.deleteIfExists(Path.of(expired + ".sha256"));
+            Files.deleteIfExists(Path.of(expired + ".json"));
+        }
+    }
+
+    private static long compress(InputStream source, Path target) throws IOException {
+        long total = 0;
+        byte[] buffer = new byte[64 * 1024];
+        try (InputStream input = source;
+             OutputStream file = Files.newOutputStream(target, StandardOpenOption.CREATE_NEW);
+             GZIPOutputStream gzip = new GZIPOutputStream(file, 64 * 1024)) {
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                gzip.write(buffer, 0, read);
+                total += read;
+            }
+        }
+        return total;
+    }
+
+    private static String readDiagnostic(InputStream source) throws IOException {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        try (InputStream input = source) {
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                int remaining = MAX_STDERR_BYTES - captured.size();
+                if (remaining > 0) captured.write(buffer, 0, Math.min(read, remaining));
+            }
+        }
+        return captured.toString(StandardCharsets.UTF_8).strip();
+    }
+
+    private static String diagnostic(String stderr) {
+        return stderr.isBlank() ? "" : ": " + stderr;
+    }
+
+    private static void stop(Process process) {
+        process.destroy();
+        try {
+            if (!process.waitFor(5, TimeUnit.SECONDS)) process.destroyForcibly();
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            process.destroyForcibly();
+        }
+    }
+
+    private static String sha256(Path path) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (InputStream input = Files.newInputStream(path)) {
+                byte[] buffer = new byte[64 * 1024];
+                int read;
+                while ((read = input.read(buffer)) != -1) digest.update(buffer, 0, read);
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException error) {
+            throw new IllegalStateException("SHA-256 is unavailable", error);
+        }
+    }
+
+    private static void moveAtomically(Path source, Path target) throws IOException {
+        try {
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException error) {
+            Files.move(source, target);
+        }
+    }
+
+    private static void harden(Path path) throws IOException {
+        IOException posixFailure = null;
+        try {
+            Files.setPosixFilePermissions(path, Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE));
+            return;
+        } catch (IOException error) {
+            posixFailure = error;
+        } catch (UnsupportedOperationException ignored) {
+            // Fall through to the Windows ACL view.
+        }
+        try {
+            AclFileAttributeView view = Files.getFileAttributeView(path, AclFileAttributeView.class);
+            if (view == null) {
+                throw new IOException("filesystem exposes neither POSIX permissions nor Windows ACLs");
+            }
+            AclEntry ownerOnly = AclEntry.newBuilder()
+                    .setType(AclEntryType.ALLOW)
+                    .setPrincipal(Files.getOwner(path))
+                    .setPermissions(EnumSet.allOf(AclEntryPermission.class))
+                    .build();
+            view.setAcl(List.of(ownerOnly));
+        } catch (IOException | UnsupportedOperationException error) {
+            IOException failure = new IOException(
+                    "Unable to restrict database backup artifact permissions: " + path, error);
+            if (posixFailure != null) failure.addSuppressed(posixFailure);
+            throw failure;
+        }
+    }
+
+    private static FileTime modifiedAt(Path path) {
+        try {
+            return Files.getLastModifiedTime(path);
+        } catch (IOException error) {
+            throw new MigrationBackupException("Unable to inspect backup retention metadata", error);
+        }
+    }
+
+    private static void deleteQuietly(Path path) {
+        if (path == null) return;
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException error) {
+            LOGGER.warn("Unable to delete temporary database backup artifact {}", path, error);
+        }
+    }
+
+    @FunctionalInterface
+    interface ProcessStarter {
+        Process start(List<String> command) throws IOException;
+    }
+
+    private record ProcessResult(int exitCode, long uncompressedBytes, String stderr) {
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/backup/MigrationBackup.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/backup/MigrationBackup.java
@@ -1,0 +1,13 @@
+package com.eu.habbo.database.backup;
+
+import java.util.List;
+
+@FunctionalInterface
+public interface MigrationBackup {
+    void beforeMigrations(List<String> pendingVersions);
+
+    static MigrationBackup disabled() {
+        return pendingVersions -> {
+        };
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/backup/MigrationBackupException.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/backup/MigrationBackupException.java
@@ -1,0 +1,11 @@
+package com.eu.habbo.database.backup;
+
+public final class MigrationBackupException extends RuntimeException {
+    public MigrationBackupException(String message) {
+        super(message);
+    }
+
+    public MigrationBackupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/database/migration/MigrationRunner.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/migration/MigrationRunner.java
@@ -60,7 +60,9 @@ public final class MigrationRunner {
         // The runtime datasource rewrites legacy plugin SQL. Migrations require an
         // unwrapped pool so their DDL cannot be silently translated.
         try (HikariDataSource rawMigrationDataSource = rawMigrationDataSource(runtimeDataSource)) {
-            return migrate(rawMigrationDataSource, MariaDbMigrationBackup.resolve(config));
+            return migrate(
+                    rawMigrationDataSource,
+                    MariaDbMigrationBackup.resolve(config, rawMigrationDataSource));
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/database/migration/MigrationRunner.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/migration/MigrationRunner.java
@@ -1,6 +1,8 @@
 package com.eu.habbo.database.migration;
 
 import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.database.backup.MariaDbMigrationBackup;
+import com.eu.habbo.database.backup.MigrationBackup;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.flywaydb.core.Flyway;
@@ -48,15 +50,17 @@ public final class MigrationRunner {
             return;
         }
 
-        migrateAtStartup(runtimeDataSource);
+        migrateAtStartup(runtimeDataSource, config);
     }
 
     /** Applies migrations immediately, regardless of the startup config switch. */
-    public static MigrateResult migrateAtStartup(HikariDataSource runtimeDataSource) {
+    public static MigrateResult migrateAtStartup(
+            HikariDataSource runtimeDataSource,
+            ConfigurationManager config) {
         // The runtime datasource rewrites legacy plugin SQL. Migrations require an
         // unwrapped pool so their DDL cannot be silently translated.
         try (HikariDataSource rawMigrationDataSource = rawMigrationDataSource(runtimeDataSource)) {
-            return migrate(rawMigrationDataSource);
+            return migrate(rawMigrationDataSource, MariaDbMigrationBackup.resolve(config));
         }
     }
 
@@ -69,11 +73,24 @@ public final class MigrationRunner {
 
     /** Runs the action permitted for the detected schema state. */
     public static MigrateResult migrate(DataSource dataSource) {
+        return migrate(dataSource, MigrationBackup.disabled());
+    }
+
+    static MigrateResult migrate(DataSource dataSource, MigrationBackup migrationBackup) {
         SchemaPreflight.State state = SchemaPreflight.detect(dataSource);
         Flyway flyway = flyway(dataSource);
 
         LOGGER.info("[migrate] Detected schema state: {}", state);
         try {
+            if (state != SchemaPreflight.State.EMPTY && state != SchemaPreflight.State.UNKNOWN) {
+                java.util.List<String> pending = java.util.Arrays.stream(flyway.info().pending())
+                        .filter(migration -> !isBaselineSkippedDuringAdoption(state, migration))
+                        .map(migration -> migration.getVersion() == null
+                                ? migration.getDescription()
+                                : migration.getVersion().getVersion())
+                        .toList();
+                if (!pending.isEmpty()) migrationBackup.beforeMigrations(pending);
+            }
             MigrateResult result = switch (state) {
                 case UNKNOWN -> throw new MigrationException(
                         "Refusing to migrate: the database is non-empty but is not a recognised Arc/Polaris schema. "

--- a/Emulator/src/main/resources/db/migration/README.md
+++ b/Emulator/src/main/resources/db/migration/README.md
@@ -35,6 +35,10 @@ credentials use a short-lived owner-only option file and never appear in the
 command line or metadata. A dump failure or timeout prevents Flyway from
 baselining or applying anything.
 
+The dump target is derived from the same raw JDBC datasource that Flyway will
+migrate, so embedded/test launchers and plugin wrappers cannot accidentally
+back up a different database through stale or incomplete config keys.
+
 Configure the archive directory, retention, timeout and executable with the
 `db.migrations.backup.*` keys in `config.ini`. The feature is enabled by
 default; disable it only when an independently verified backup system protects

--- a/Emulator/src/main/resources/db/migration/README.md
+++ b/Emulator/src/main/resources/db/migration/README.md
@@ -25,6 +25,21 @@ table and column, and atomically updates `db/runtime-schema-contract.json`.
 Normal `mvn verify` is check-only and fails if a migration changed the schema
 without a matching contract update.
 
+## Automatic pre-migration backup
+
+Before Flyway changes a recognized existing or managed hotel with pending
+migrations, Polaris creates a fail-closed logical backup using the official
+`mariadb-dump` client. Empty databases do not need a backup. The resulting
+`*.sql.gz` archive, SHA-256 sidecar and JSON manifest are written atomically;
+credentials use a short-lived owner-only option file and never appear in the
+command line or metadata. A dump failure or timeout prevents Flyway from
+baselining or applying anything.
+
+Configure the archive directory, retention, timeout and executable with the
+`db.migrations.backup.*` keys in `config.ini`. The feature is enabled by
+default; disable it only when an independently verified backup system protects
+the same deployment.
+
 ## Rules
 
 1. **One logical change per migration.** Never edit a released migration —

--- a/Emulator/src/test/java/com/eu/habbo/database/backup/DatabaseBackupRequestTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/backup/DatabaseBackupRequestTest.java
@@ -1,0 +1,51 @@
+package com.eu.habbo.database.backup;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DatabaseBackupRequestTest {
+
+    @Test
+    void derivesTheExactMigrationTargetFromTheRuntimeJdbcConnection() {
+        DatabaseBackupRequest request = DatabaseBackupRequest.fromJdbc(
+                "jdbc:mariadb://db.internal:3307/polaris_prod?sslMode=verify-full",
+                "runtime-user",
+                "runtime-secret");
+
+        assertEquals("db.internal", request.host());
+        assertEquals(3307, request.port());
+        assertEquals("polaris_prod", request.database());
+        assertEquals("runtime-user", request.username());
+        assertEquals("runtime-secret", request.password());
+    }
+
+    @Test
+    void usesMariaDbDefaultPortAndSupportsIpv6() {
+        DatabaseBackupRequest request = DatabaseBackupRequest.fromJdbc(
+                "jdbc:mariadb://[2001:db8::7]/polaris",
+                "user",
+                "");
+
+        assertEquals("[2001:db8::7]", request.host());
+        assertEquals(3306, request.port());
+        assertEquals("polaris", request.database());
+    }
+
+    @Test
+    void rejectsUnsupportedOrIncompleteJdbcTargets() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DatabaseBackupRequest.fromJdbc(
+                        "jdbc:mysql://localhost/polaris", "user", "secret"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DatabaseBackupRequest.fromJdbc(
+                        "jdbc:mariadb:loadbalance://db1,db2/polaris", "user", "secret"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> DatabaseBackupRequest.fromJdbc(
+                        "jdbc:mariadb://localhost", "user", "secret"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/backup/MariaDbMigrationBackupIntegrationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/backup/MariaDbMigrationBackupIntegrationTest.java
@@ -1,0 +1,149 @@
+package com.eu.habbo.database.backup;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.DriverManager;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MariaDbMigrationBackupIntegrationTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void createsAndRestoresAConsistentMariaDbBackup() throws Exception {
+        String host = System.getenv("MIGRATION_TEST_DB_HOST");
+        Assumptions.assumeTrue(host != null && !host.isBlank(),
+                "set MIGRATION_TEST_DB_HOST to run the real dump/restore test");
+        int port = Integer.parseInt(value("MIGRATION_TEST_DB_PORT", "3306"));
+        String username = value("MIGRATION_TEST_DB_USER", "root");
+        String password = value("MIGRATION_TEST_DB_PASSWORD", "");
+        String dumpExecutable = value("MIGRATION_TEST_DUMP_EXECUTABLE", "mariadb-dump");
+        String clientExecutable = value("MIGRATION_TEST_CLIENT_EXECUTABLE", "mariadb");
+        String database = "polaris_backup_it_" + UUID.randomUUID().toString().replace("-", "");
+        String serverUrl = "jdbc:mariadb://" + host + ':' + port + '/';
+
+        try {
+            execute(serverUrl, username, password, "CREATE DATABASE `" + database + "`");
+            String databaseUrl = serverUrl + database;
+            execute(databaseUrl, username, password,
+                    "CREATE TABLE transactional_data (id INT PRIMARY KEY, value VARCHAR(32)) ENGINE=InnoDB");
+            execute(databaseUrl, username, password,
+                    "CREATE TABLE legacy_data (id INT PRIMARY KEY, value VARCHAR(32)) ENGINE=MyISAM");
+            execute(databaseUrl, username, password,
+                    "INSERT INTO transactional_data VALUES (1, 'inno'), (2, 'db')");
+            execute(databaseUrl, username, password,
+                    "INSERT INTO legacy_data VALUES (1, 'myisam')");
+
+            MariaDbMigrationBackup backup = new MariaDbMigrationBackup(
+                    new DatabaseBackupOptions(
+                            true, tempDir, 2, Duration.ofSeconds(60), dumpExecutable),
+                    new DatabaseBackupRequest(host, port, database, username, password));
+            backup.beforeMigrations(List.of("28"));
+
+            Path archive;
+            try (var files = Files.list(tempDir)) {
+                archive = files.filter(path -> path.getFileName().toString().endsWith(".sql.gz"))
+                        .findFirst()
+                        .orElseThrow();
+            }
+            Path checksum = Path.of(archive + ".sha256");
+            assertTrue(Files.readString(checksum).startsWith(sha256(archive)));
+
+            execute(serverUrl, username, password, "DROP DATABASE `" + database + "`");
+            restore(clientExecutable, host, port, username, password, archive);
+
+            assertEquals(2, count(serverUrl + database, username, password, "transactional_data"));
+            assertEquals(1, count(serverUrl + database, username, password, "legacy_data"));
+        } finally {
+            try {
+                execute(serverUrl, username, password,
+                        "DROP DATABASE IF EXISTS `" + database + "`");
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private static void restore(
+            String executable,
+            String host,
+            int port,
+            String username,
+            String password,
+            Path archive) throws Exception {
+        ProcessBuilder builder = new ProcessBuilder(
+                executable,
+                "--protocol=tcp",
+                "--host=" + host,
+                "--port=" + port,
+                "--user=" + username);
+        builder.environment().put("MYSQL_PWD", password);
+        Process process = builder.start();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        Thread errorReader = Thread.startVirtualThread(() -> {
+            try (var input = process.getErrorStream()) {
+                input.transferTo(stderr);
+            } catch (Exception ignored) {
+            }
+        });
+        try (GZIPInputStream input = new GZIPInputStream(Files.newInputStream(archive));
+             var output = process.getOutputStream()) {
+            input.transferTo(output);
+        }
+        assertTrue(process.waitFor(60, TimeUnit.SECONDS), "restore client timed out");
+        errorReader.join(Duration.ofSeconds(5));
+        assertEquals(0, process.exitValue(), stderr.toString(StandardCharsets.UTF_8));
+    }
+
+    private static void execute(
+            String url,
+            String username,
+            String password,
+            String sql) throws Exception {
+        try (var connection = DriverManager.getConnection(url, username, password);
+             var statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private static int count(
+            String url,
+            String username,
+            String password,
+            String table) throws Exception {
+        try (var connection = DriverManager.getConnection(url, username, password);
+             var statement = connection.createStatement();
+             var result = statement.executeQuery("SELECT COUNT(*) FROM `" + table + "`")) {
+            result.next();
+            return result.getInt(1);
+        }
+    }
+
+    private static String sha256(Path path) throws Exception {
+        var digest = java.security.MessageDigest.getInstance("SHA-256");
+        try (var input = Files.newInputStream(path)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) digest.update(buffer, 0, read);
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+
+    private static String value(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? fallback : value;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/backup/MariaDbMigrationBackupTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/backup/MariaDbMigrationBackupTest.java
@@ -1,0 +1,237 @@
+package com.eu.habbo.database.backup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MariaDbMigrationBackupTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writesAtomicCompressedBackupChecksumAndManifestWithoutLeakingPassword() throws Exception {
+        List<List<String>> commands = new ArrayList<>();
+        DatabaseBackupOptions options = new DatabaseBackupOptions(
+                true, tempDir, 3, Duration.ofSeconds(30), "mariadb-dump");
+        DatabaseBackupRequest request = new DatabaseBackupRequest(
+                "db.internal", 3307, "polaris_prod", "polaris", "very-secret-password");
+        MariaDbMigrationBackup backup = new MariaDbMigrationBackup(
+                options,
+                request,
+                command -> {
+                    commands.add(List.copyOf(command));
+                    return FakeProcess.success("CREATE TABLE `users` (`id` int);\n");
+                },
+                Clock.fixed(Instant.parse("2026-07-18T20:45:12Z"), ZoneOffset.UTC));
+
+        backup.beforeMigrations(migrations());
+
+        List<Path> archives = files(".sql.gz");
+        assertEquals(1, archives.size());
+        assertEquals("CREATE TABLE `users` (`id` int);\n", gunzip(archives.getFirst()));
+        assertEquals(1, files(".sql.gz.sha256").size());
+        assertEquals(1, files(".sql.gz.json").size());
+        assertEquals(List.of(), files(".part"));
+        assertEquals(List.of(), files(".cnf"));
+
+        String command = String.join(" ", commands.getFirst());
+        assertFalse(command.contains("very-secret-password"));
+        assertTrue(commands.getFirst().get(1).startsWith("--defaults-extra-file="));
+        assertTrue(command.contains("--lock-all-tables"));
+        assertTrue(command.contains("--routines"));
+        assertTrue(command.contains("--events"));
+        assertTrue(command.contains("--triggers"));
+        assertTrue(command.endsWith("--databases polaris_prod"));
+
+        String manifest = Files.readString(files(".sql.gz.json").getFirst());
+        assertTrue(manifest.contains("\"pendingVersions\":[\"28\",\"29\"]"));
+        assertTrue(manifest.contains("\"database\":\"polaris_prod\""));
+        assertFalse(manifest.contains("very-secret-password"));
+        assertFalse(manifest.contains("polaris\""));
+    }
+
+    @Test
+    void failureDeletesPartialArtifactsAndKeepsExistingBackups() throws Exception {
+        Path existing = tempDir.resolve("polaris-old.sql.gz");
+        Files.writeString(existing, "keep");
+        DatabaseBackupOptions options = new DatabaseBackupOptions(
+                true, tempDir, 3, Duration.ofSeconds(30), "mariadb-dump");
+        MariaDbMigrationBackup backup = new MariaDbMigrationBackup(
+                options,
+                new DatabaseBackupRequest("localhost", 3306, "polaris", "user", "password"),
+                command -> FakeProcess.failure(2, "access denied"),
+                Clock.systemUTC());
+
+        MigrationBackupException error = assertThrows(
+                MigrationBackupException.class,
+                () -> backup.beforeMigrations(migrations()));
+
+        assertTrue(error.getMessage().contains("access denied"));
+        assertTrue(Files.exists(existing));
+        assertEquals(List.of(), files(".part"));
+        assertEquals(List.of(), files(".cnf"));
+    }
+
+    @Test
+    void successfulBackupPrunesOldArchivesOnlyAfterTheNewArtifactExists() throws Exception {
+        for (int index = 1; index <= 3; index++) {
+            Path archive = tempDir.resolve("polaris-old-" + index + ".sql.gz");
+            Files.writeString(archive, "old-" + index);
+            Files.writeString(Path.of(archive + ".sha256"), "hash");
+            Files.writeString(Path.of(archive + ".json"), "{}");
+            Files.setLastModifiedTime(archive, java.nio.file.attribute.FileTime.fromMillis(index));
+        }
+        DatabaseBackupOptions options = new DatabaseBackupOptions(
+                true, tempDir, 2, Duration.ofSeconds(30), "mariadb-dump");
+        MariaDbMigrationBackup backup = new MariaDbMigrationBackup(
+                options,
+                new DatabaseBackupRequest("localhost", 3306, "polaris", "user", "password"),
+                command -> FakeProcess.success("SELECT 1;\n"),
+                Clock.fixed(Instant.parse("2026-07-18T20:45:12Z"), ZoneOffset.UTC));
+
+        backup.beforeMigrations(migrations());
+
+        assertEquals(2, files(".sql.gz").size());
+        assertEquals(2, files(".sql.gz.sha256").size());
+        assertEquals(2, files(".sql.gz.json").size());
+    }
+
+    @Test
+    void nameCollisionNeverDeletesOrOverwritesAnExistingBackup() throws Exception {
+        Path existing = tempDir.resolve(
+                "polaris-polaris-20260718T204512000Z-before-v28-v29.sql.gz");
+        Files.writeString(existing, "existing-backup");
+        DatabaseBackupOptions options = new DatabaseBackupOptions(
+                true, tempDir, 3, Duration.ofSeconds(30), "mariadb-dump");
+        MariaDbMigrationBackup backup = new MariaDbMigrationBackup(
+                options,
+                new DatabaseBackupRequest("localhost", 3306, "polaris", "user", "password"),
+                command -> FakeProcess.success("SELECT 1;\n"),
+                Clock.fixed(Instant.parse("2026-07-18T20:45:12Z"), ZoneOffset.UTC));
+
+        backup.beforeMigrations(migrations());
+
+        assertEquals("existing-backup", Files.readString(existing));
+        assertEquals(2, files(".sql.gz").size());
+    }
+
+    @Test
+    void timeoutStopsTheDumpAndRemovesCredentialsAndPartialOutput() throws Exception {
+        DatabaseBackupOptions options = new DatabaseBackupOptions(
+                true, tempDir, 3, Duration.ofSeconds(1), "mariadb-dump");
+        FakeProcess process = FakeProcess.timeout();
+        MariaDbMigrationBackup backup = new MariaDbMigrationBackup(
+                options,
+                new DatabaseBackupRequest("localhost", 3306, "polaris", "user", "password"),
+                command -> process,
+                Clock.systemUTC());
+
+        MigrationBackupException error = assertThrows(
+                MigrationBackupException.class,
+                () -> backup.beforeMigrations(migrations()));
+
+        assertTrue(error.getMessage().contains("timeout"));
+        assertTrue(process.destroyed);
+        assertEquals(List.of(), files(".part"));
+        assertEquals(List.of(), files(".cnf"));
+        assertEquals(List.of(), files(".sql.gz"));
+    }
+
+    private List<String> migrations() {
+        return List.of("28", "29");
+    }
+
+    private List<Path> files(String suffix) throws Exception {
+        try (var stream = Files.list(tempDir)) {
+            return stream.filter(path -> path.getFileName().toString().endsWith(suffix)).sorted().toList();
+        }
+    }
+
+    private static String gunzip(Path archive) throws Exception {
+        try (GZIPInputStream input = new GZIPInputStream(Files.newInputStream(archive))) {
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static final class FakeProcess extends Process {
+        private final InputStream stdout;
+        private final InputStream stderr;
+        private final int exitCode;
+        private final boolean timesOut;
+        private boolean destroyed;
+
+        private FakeProcess(String stdout, String stderr, int exitCode, boolean timesOut) {
+            this.stdout = new ByteArrayInputStream(stdout.getBytes(StandardCharsets.UTF_8));
+            this.stderr = new ByteArrayInputStream(stderr.getBytes(StandardCharsets.UTF_8));
+            this.exitCode = exitCode;
+            this.timesOut = timesOut;
+        }
+
+        static FakeProcess success(String stdout) {
+            return new FakeProcess(stdout, "", 0, false);
+        }
+
+        static FakeProcess failure(int exitCode, String stderr) {
+            return new FakeProcess("", stderr, exitCode, false);
+        }
+
+        static FakeProcess timeout() {
+            return new FakeProcess("", "", 143, true);
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return new ByteArrayOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return stdout;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return stderr;
+        }
+
+        @Override
+        public int waitFor() {
+            return exitCode;
+        }
+
+        @Override
+        public boolean waitFor(long timeout, TimeUnit unit) {
+            return destroyed || !timesOut;
+        }
+
+        @Override
+        public int exitValue() {
+            return exitCode;
+        }
+
+        @Override
+        public void destroy() {
+            destroyed = true;
+        }
+    }
+}

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -7,6 +7,13 @@ db.password=root
 db.params=
 # Automatically prepare empty databases and upgrade recognized Arcturus/Polaris hotels.
 db.migrate.on_startup=true
+# Required fail-closed backup before pending migrations are applied.
+db.migrations.backup.enabled=true
+db.migrations.backup.directory=backups/database
+db.migrations.backup.keep=7
+db.migrations.backup.timeout_seconds=900
+# Absolute path is recommended when mariadb-dump is not on PATH.
+db.migrations.backup.executable=mariadb-dump
 db.pool.minsize=25
 db.pool.maxsize=100
 


### PR DESCRIPTION
## Summary

- create a fail-closed MariaDB backup immediately before pending startup migrations
- stream the dump to a compressed archive without exposing credentials in process arguments or logs
- write SHA-256 and JSON metadata sidecars, then apply retention only after a successful backup
- add configurable executable, destination, retention, and timeout settings
- exercise a real dump, database drop, and restore path for both InnoDB and MyISAM tables in CI

## Why

Schema migrations are intentionally automated, but they previously had no recovery point. A failed or incompatible migration could therefore leave a production database without a deterministic rollback artifact. This change makes a verified backup a prerequisite for any write performed by the migration runner.

## Safety properties

- validation and no-op startup runs remain read-only
- backup failures abort before migration history or schema writes
- credentials use a short-lived secured option file
- partial archives are never published as completed backups
- existing archives are never overwritten
- retention only removes completed backup artifact sets

## Validation

- backup and migration unit/contract suite: 15 tests passed
- real local MariaDB dump/drop/restore integration: passed for InnoDB and MyISAM
- Java 25 package build: passed
- compatibility adaptation against the Flyway runner from #386: `mvn -B clean verify` passed with 647 unit tests; the seven Testcontainers cases were skipped because Docker is unavailable locally
- current `dev` full-suite failures were confirmed as the six pre-existing baseline failures addressed by #386; no backup test failed

## Compatibility

The backup service lives in a stable package independent from the legacy migration runner. The integration hook has also been adapted and verified against #386 so that the backup behavior can be retained when the Flyway migration work lands.