### PR TITLE
Fix placed guild furniture refresh after badge changes

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeBadgeEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/guilds/GuildChangeBadgeEvent.java
@@ -24,25 +24,23 @@ public class GuildChangeBadgeEvent extends MessageHandler {
 
         Guild guild = Emulator.getGameEnvironment().getGuildManager().getGuild(guildId);
         if (guild != null) {
-            if (guild.getOwnerId() == this.client.getHabbo().getHabboInfo().getId() || this.client.getHabbo().hasPermission(Permission.ACC_GUILD_ADMIN)) {
+            if (guild.getOwnerId() == this.client.getHabbo().getHabboInfo().getId()
+                    || this.client.getHabbo().hasPermission(Permission.ACC_GUILD_ADMIN)) {
                 Room room = Emulator.getGameEnvironment().getRoomManager().getRoom(guild.getRoomId());
 
-                if (room == null || room.getId() != guild.getRoomId())
-                    return;
+                if (room == null || room.getId() != guild.getRoomId()) return;
 
                 int count = this.packet.readInt();
 
                 String badge = GuildBadgeBuilder.readBadge(this.packet, count);
                 if (badge == null) return;
 
-                if (guild.getBadge().equalsIgnoreCase(badge))
-                    return;
+                if (guild.getBadge().equalsIgnoreCase(badge)) return;
 
                 GuildChangedBadgeEvent badgeEvent = new GuildChangedBadgeEvent(guild, badge);
                 Emulator.getPluginManager().fireEvent(badgeEvent);
 
-                if (badgeEvent.isCancelled())
-                    return;
+                if (badgeEvent.isCancelled()) return;
 
                 guild.setBadge(badgeEvent.badge);
                 guild.needsUpdate = true;
@@ -52,6 +50,7 @@ public class GuildChangeBadgeEvent extends MessageHandler {
                 }
 
                 room.refreshGuild(guild);
+                room.refreshGuildColors(guild);
                 Emulator.getThreading().run(guild);
             }
         }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/guilds/GuildChangeBadgeEventTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/guilds/GuildChangeBadgeEventTest.java
@@ -1,0 +1,97 @@
+package com.eu.habbo.messages.incoming.guilds;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.guilds.Guild;
+import com.eu.habbo.habbohotel.guilds.GuildManager;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomManager;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.plugin.events.guilds.GuildChangedBadgeEvent;
+import com.eu.habbo.threading.ThreadPooling;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class GuildChangeBadgeEventTest {
+
+    @Test
+    void changingBadgeRefreshesPlacedGuildFurniture() throws Exception {
+        int guildId = 123;
+        int roomId = 456;
+        int ownerId = 789;
+
+        Guild guild = mock(Guild.class);
+        when(guild.getId()).thenReturn(guildId);
+        when(guild.getRoomId()).thenReturn(roomId);
+        when(guild.getOwnerId()).thenReturn(ownerId);
+        when(guild.getBadge()).thenReturn("b000000");
+
+        Room room = mock(Room.class);
+        when(room.getId()).thenReturn(roomId);
+
+        GuildManager guildManager = mock(GuildManager.class);
+        when(guildManager.getGuild(guildId)).thenReturn(guild);
+
+        RoomManager roomManager = mock(RoomManager.class);
+        when(roomManager.getRoom(roomId)).thenReturn(room);
+
+        GameEnvironment environment = mock(GameEnvironment.class);
+        when(environment.getGuildManager()).thenReturn(guildManager);
+        when(environment.getRoomManager()).thenReturn(roomManager);
+
+        HabboInfo habboInfo = mock(HabboInfo.class);
+        when(habboInfo.getId()).thenReturn(ownerId);
+
+        Habbo habbo = mock(Habbo.class);
+        when(habbo.getHabboInfo()).thenReturn(habboInfo);
+
+        GameClient client = mock(GameClient.class);
+        when(client.getHabbo()).thenReturn(habbo);
+
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(pluginManager.fireEvent(any(GuildChangedBadgeEvent.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ConfigurationManager configuration = mock(ConfigurationManager.class);
+        when(configuration.getBoolean("imager.internal.enabled")).thenReturn(false);
+
+        ThreadPooling threading = mock(ThreadPooling.class);
+
+        try (MockedStatic<Emulator> emulator = mockStatic(Emulator.class)) {
+            emulator.when(Emulator::getGameEnvironment).thenReturn(environment);
+            emulator.when(Emulator::getPluginManager).thenReturn(pluginManager);
+            emulator.when(Emulator::getConfig).thenReturn(configuration);
+            emulator.when(Emulator::getThreading).thenReturn(threading);
+
+            GuildChangeBadgeEvent event = new GuildChangeBadgeEvent();
+            event.client = client;
+            event.packet = badgePacket(guildId, 1, 2, 3);
+            event.handle();
+        }
+
+        verify(room).refreshGuildColors(guild);
+    }
+
+    private static ClientMessage badgePacket(int guildId, int partId, int colorId, int position) {
+        ByteBuf buffer = Unpooled.buffer();
+        buffer.writeInt(guildId);
+        buffer.writeInt(3);
+        buffer.writeInt(partId);
+        buffer.writeInt(colorId);
+        buffer.writeInt(position);
+        return new ClientMessage(0, buffer);
+    }
+}


### PR DESCRIPTION
## Summary

- refresh placed guild furniture after a guild badge is changed
- add a regression test for the room-wide refresh notification

## Root cause

`GuildChangeBadgeEvent` refreshed the guild assignment but did not trigger the guild furniture visual refresh path. Furniture already placed in the room could therefore keep showing the previous guild badge until another refresh or reload occurred.

## Impact

Placed guild furniture now receives the badge/color refresh immediately after the guild badge is saved.

## Validation

- `mvnw.cmd -q test` — 1,260 tests, 0 failures, 0 errors
- `mvnw.cmd -q package -DskipTests`
- `mvnw.cmd -q spotless:check`

## Companion PR

- Renderer: https://github.com/duckietm/Nitro_Render_V3/pull/156