### PR TITLE
Catalog Studio: add Smart Save foundation

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogOperationRecord.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogOperationRecord.java
@@ -1,0 +1,41 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import java.util.Objects;
+
+public record CatalogOperationRecord(
+        String operationId,
+        int actorId,
+        long versionId,
+        CatalogChangeSource source,
+        long resultRevision,
+        String requestFingerprint,
+        CatalogChangeOperation action,
+        CatalogEntityType entityType,
+        CatalogPageType catalogType,
+        Integer entityId,
+        Long historyGroupId,
+        String resultJson) {
+
+    public CatalogOperationRecord {
+        validateIdentity(operationId, actorId);
+        if (versionId <= 0) throw new IllegalArgumentException("Version ID must be positive");
+        source = Objects.requireNonNull(source, "source");
+        if (resultRevision < 0) throw new IllegalArgumentException("Result revision cannot be negative");
+        if (catalogType == CatalogPageType.BOTH) {
+            throw new IllegalArgumentException("An operation cannot target both catalogs");
+        }
+        if (entityId != null && entityId <= 0) throw new IllegalArgumentException("Entity ID must be positive");
+        if (historyGroupId != null && historyGroupId <= 0) {
+            throw new IllegalArgumentException("History group ID must be positive");
+        }
+    }
+
+    static void validateIdentity(String operationId, int actorId) {
+        operationId = Objects.requireNonNull(operationId, "operationId");
+        if (operationId.isBlank() || operationId.length() > 96) {
+            throw new IllegalArgumentException("Operation ID must be nonblank and at most 96 characters");
+        }
+        if (actorId <= 0) throw new IllegalArgumentException("Actor ID must be positive");
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogOperationRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogOperationRepository.java
@@ -1,0 +1,12 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Optional;
+
+public interface CatalogOperationRepository {
+    Optional<CatalogOperationRecord> findForUpdate(Connection connection, String operationId, int actorId)
+            throws SQLException;
+
+    void insert(Connection connection, CatalogOperationRecord record) throws SQLException;
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogVersionRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogVersionRepository.java
@@ -3,11 +3,26 @@ package com.eu.habbo.habbohotel.catalog.versioning;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Optional;
 
 public interface CatalogVersionRepository {
     CatalogRuntimeState lockRuntimeState(Connection connection) throws SQLException;
 
     CatalogVersionSnapshot loadSnapshot(Connection connection, long versionId) throws SQLException;
+
+    default CatalogVersion loadVersion(Connection connection, long versionId) throws SQLException {
+        return loadSnapshot(connection, versionId).version();
+    }
+
+    default Optional<CatalogPageSnapshot> loadPage(
+            Connection connection, long versionId, CatalogPageType catalogType, int pageId) throws SQLException {
+        return loadSnapshot(connection, versionId).page(catalogType, pageId);
+    }
+
+    default Optional<CatalogOfferSnapshot> loadOffer(
+            Connection connection, long versionId, CatalogPageType catalogType, int offerId) throws SQLException {
+        return loadSnapshot(connection, versionId).offer(catalogType, offerId);
+    }
 
     long cloneAsDraft(Connection connection, long sourceVersionId, int actorId, String label) throws SQLException;
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveProjection.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveProjection.java
@@ -53,7 +53,11 @@ public final class JdbcCatalogLiveProjection implements CatalogLiveProjection {
     static final String DELETE_OFFERS_SQL =
             "DELETE FROM catalog_items WHERE NOT EXISTS (SELECT 1 FROM catalog_version_offers version_offer "
                     + "WHERE version_offer.version_id = ? AND version_offer.catalog_type = 'NORMAL' "
-                    + "AND version_offer.offer_id = catalog_items.id)";
+                    + "AND version_offer.offer_id = catalog_items.id "
+                    + "AND EXISTS (SELECT 1 FROM catalog_version_pages version_page "
+                    + "WHERE version_page.version_id = version_offer.version_id "
+                    + "AND version_page.catalog_type = version_offer.catalog_type "
+                    + "AND version_page.page_id = version_offer.page_id))";
     static final String DELETE_PAGES_SQL =
             "DELETE FROM catalog_pages WHERE NOT EXISTS (SELECT 1 FROM catalog_version_pages version_page "
                     + "WHERE version_page.version_id = ? AND version_page.catalog_type = 'NORMAL' "
@@ -61,7 +65,11 @@ public final class JdbcCatalogLiveProjection implements CatalogLiveProjection {
     static final String DELETE_BUILDER_OFFERS_SQL =
             "DELETE FROM catalog_items_bc WHERE NOT EXISTS (SELECT 1 FROM catalog_version_offers version_offer "
                     + "WHERE version_offer.version_id = ? AND version_offer.catalog_type = 'BUILDER' "
-                    + "AND version_offer.offer_id = catalog_items_bc.id)";
+                    + "AND version_offer.offer_id = catalog_items_bc.id "
+                    + "AND EXISTS (SELECT 1 FROM catalog_version_pages version_page "
+                    + "WHERE version_page.version_id = version_offer.version_id "
+                    + "AND version_page.catalog_type = version_offer.catalog_type "
+                    + "AND version_page.page_id = version_offer.page_id))";
     static final String DELETE_BUILDER_PAGES_SQL =
             "DELETE FROM catalog_pages_bc WHERE NOT EXISTS (SELECT 1 FROM catalog_version_pages version_page "
                     + "WHERE version_page.version_id = ? AND version_page.catalog_type = 'BUILDER' "
@@ -122,6 +130,7 @@ public final class JdbcCatalogLiveProjection implements CatalogLiveProjection {
             try {
                 for (CatalogOfferSnapshot offer : snapshot.offers()) {
                     if (offer.catalogType() != CatalogPageType.NORMAL) continue;
+                    if (snapshot.page(offer.catalogType(), offer.pageId()).isEmpty()) continue;
                     statement.setInt(1, offer.offerId());
                     statement.setString(2, offer.itemIds());
                     statement.setInt(3, offer.pageId());
@@ -180,6 +189,7 @@ public final class JdbcCatalogLiveProjection implements CatalogLiveProjection {
         try (PreparedStatement statement = connection.prepareStatement(UPSERT_BUILDER_OFFER_SQL)) {
             for (CatalogOfferSnapshot offer : snapshot.offers()) {
                 if (offer.catalogType() != CatalogPageType.BUILDER) continue;
+                if (snapshot.page(offer.catalogType(), offer.pageId()).isEmpty()) continue;
                 statement.setInt(1, offer.offerId());
                 statement.setString(2, offer.itemIds());
                 statement.setInt(3, offer.pageId());

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogOperationRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogOperationRepository.java
@@ -9,9 +9,10 @@ import java.sql.Types;
 import java.util.Optional;
 
 public final class JdbcCatalogOperationRepository implements CatalogOperationRepository {
-    private static final String SELECT_FOR_UPDATE = "SELECT operation_id, actor_id, version_id, source, result_revision, "
-            + "request_fingerprint, action, entity_type, catalog_type, entity_id, history_group_id, result_json "
-            + "FROM catalog_operations WHERE operation_id = ? AND actor_id = ? FOR UPDATE";
+    private static final String SELECT_FOR_UPDATE =
+            "SELECT operation_id, actor_id, version_id, source, result_revision, "
+                    + "request_fingerprint, action, entity_type, catalog_type, entity_id, history_group_id, result_json "
+                    + "FROM catalog_operations WHERE operation_id = ? AND actor_id = ? FOR UPDATE";
     private static final String INSERT = "INSERT INTO catalog_operations "
             + "(operation_id, actor_id, version_id, source, result_revision, request_fingerprint, action, entity_type, "
             + "catalog_type, entity_id, history_group_id, result_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogOperationRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogOperationRepository.java
@@ -1,0 +1,89 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Optional;
+
+public final class JdbcCatalogOperationRepository implements CatalogOperationRepository {
+    private static final String SELECT_FOR_UPDATE = "SELECT operation_id, actor_id, version_id, source, result_revision, "
+            + "request_fingerprint, action, entity_type, catalog_type, entity_id, history_group_id, result_json "
+            + "FROM catalog_operations WHERE operation_id = ? AND actor_id = ? FOR UPDATE";
+    private static final String INSERT = "INSERT INTO catalog_operations "
+            + "(operation_id, actor_id, version_id, source, result_revision, request_fingerprint, action, entity_type, "
+            + "catalog_type, entity_id, history_group_id, result_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    @Override
+    public Optional<CatalogOperationRecord> findForUpdate(Connection connection, String operationId, int actorId)
+            throws SQLException {
+        CatalogOperationRecord.validateIdentity(operationId, actorId);
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_FOR_UPDATE)) {
+            statement.setString(1, operationId);
+            statement.setInt(2, actorId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) return Optional.empty();
+                return Optional.of(new CatalogOperationRecord(
+                        resultSet.getString("operation_id"),
+                        resultSet.getInt("actor_id"),
+                        resultSet.getLong("version_id"),
+                        CatalogChangeSource.valueOf(resultSet.getString("source")),
+                        resultSet.getLong("result_revision"),
+                        resultSet.getString("request_fingerprint"),
+                        nullableEnum(resultSet, "action", CatalogChangeOperation.class),
+                        nullableEnum(resultSet, "entity_type", CatalogEntityType.class),
+                        nullableEnum(resultSet, "catalog_type", CatalogPageType.class),
+                        resultSet.getObject("entity_id", Integer.class),
+                        resultSet.getObject("history_group_id", Long.class),
+                        resultSet.getString("result_json")));
+            }
+        }
+    }
+
+    @Override
+    public void insert(Connection connection, CatalogOperationRecord record) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(INSERT)) {
+            statement.setString(1, record.operationId());
+            statement.setInt(2, record.actorId());
+            statement.setLong(3, record.versionId());
+            statement.setString(4, record.source().name());
+            statement.setLong(5, record.resultRevision());
+            setNullableString(statement, 6, record.requestFingerprint());
+            setNullableEnum(statement, 7, record.action());
+            setNullableEnum(statement, 8, record.entityType());
+            setNullableEnum(statement, 9, record.catalogType());
+            setNullableInteger(statement, 10, record.entityId());
+            setNullableLong(statement, 11, record.historyGroupId());
+            setNullableString(statement, 12, record.resultJson());
+            if (statement.executeUpdate() != 1) throw new SQLException("Catalog operation was not persisted");
+        }
+    }
+
+    private static <E extends Enum<E>> E nullableEnum(ResultSet resultSet, String column, Class<E> enumType)
+            throws SQLException {
+        String value = resultSet.getString(column);
+        return value == null ? null : Enum.valueOf(enumType, value);
+    }
+
+    private static void setNullableString(PreparedStatement statement, int index, String value) throws SQLException {
+        if (value == null) statement.setNull(index, Types.VARCHAR);
+        else statement.setString(index, value);
+    }
+
+    private static void setNullableEnum(PreparedStatement statement, int index, Enum<?> value) throws SQLException {
+        if (value == null) statement.setNull(index, Types.VARCHAR);
+        else statement.setString(index, value.name());
+    }
+
+    private static void setNullableInteger(PreparedStatement statement, int index, Integer value) throws SQLException {
+        if (value == null) statement.setNull(index, Types.INTEGER);
+        else statement.setInt(index, value);
+    }
+
+    private static void setNullableLong(PreparedStatement statement, int index, Long value) throws SQLException {
+        if (value == null) statement.setNull(index, Types.BIGINT);
+        else statement.setLong(index, value);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogVersionRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogVersionRepository.java
@@ -9,6 +9,7 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public final class JdbcCatalogVersionRepository implements CatalogVersionRepository {
     static final String LOCK_RUNTIME_STATE_SQL = "SELECT active_version_id, draft_version_id, updated_at "
@@ -22,7 +23,7 @@ public final class JdbcCatalogVersionRepository implements CatalogVersionReposit
     static final String UPDATE_NEXT_ID_SQL =
             "UPDATE catalog_id_sequences SET next_id = ? WHERE entity_type = ? AND catalog_type = ?";
 
-    private static final String LOAD_VERSION_SQL =
+    static final String LOAD_VERSION_SQL =
             "SELECT id, status, based_on_version_id, revision, label, created_by, created_at, "
                     + "published_by, published_at FROM catalog_versions WHERE id = ?";
     static final String LOAD_PAGES_SQL =
@@ -31,11 +32,22 @@ public final class JdbcCatalogVersionRepository implements CatalogVersionReposit
                     + "page_headline, page_teaser, page_special, page_text1, page_text2, "
                     + "page_text_details, page_text_teaser, room_id, includes "
                     + "FROM catalog_version_pages WHERE version_id = ? ORDER BY catalog_type, page_id";
-    private static final String LOAD_OFFERS_SQL =
+    static final String LOAD_OFFERS_SQL =
             "SELECT catalog_type, offer_id, item_ids, page_id, catalog_name, cost_credits, cost_points, points_type, "
                     + "amount, limited_stack, order_number, offer_id_client, song_id, extradata, "
                     + "have_offer, club_only FROM catalog_version_offers "
                     + "WHERE version_id = ? ORDER BY catalog_type, offer_id";
+    static final String LOAD_PAGE_SQL =
+            "SELECT catalog_type, page_id, parent_id, caption_save, caption, page_layout, icon_color, icon_image, "
+                    + "min_rank, order_num, visible, enabled, club_only, catalog_mode, vip_only, "
+                    + "page_headline, page_teaser, page_special, page_text1, page_text2, "
+                    + "page_text_details, page_text_teaser, room_id, includes "
+                    + "FROM catalog_version_pages WHERE version_id = ? AND catalog_type = ? AND page_id = ?";
+    static final String LOAD_OFFER_SQL =
+            "SELECT catalog_type, offer_id, item_ids, page_id, catalog_name, cost_credits, cost_points, points_type, "
+                    + "amount, limited_stack, order_number, offer_id_client, song_id, extradata, "
+                    + "have_offer, club_only FROM catalog_version_offers "
+                    + "WHERE version_id = ? AND catalog_type = ? AND offer_id = ?";
     private static final String CREATE_DRAFT_SQL = "INSERT INTO catalog_versions "
             + "(status, based_on_version_id, revision, label, created_by) "
             + "VALUES ('DRAFT', ?, 0, ?, ?)";
@@ -150,7 +162,8 @@ public final class JdbcCatalogVersionRepository implements CatalogVersionReposit
         }
     }
 
-    private static CatalogVersion loadVersion(Connection connection, long versionId) throws SQLException {
+    @Override
+    public CatalogVersion loadVersion(Connection connection, long versionId) throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(LOAD_VERSION_SQL)) {
             statement.setLong(1, versionId);
             try (ResultSet resultSet = statement.executeQuery()) {
@@ -166,6 +179,32 @@ public final class JdbcCatalogVersionRepository implements CatalogVersionReposit
                         resultSet.getTimestamp("created_at").toInstant(),
                         nullableInteger(resultSet, "published_by"),
                         publishedAt == null ? null : publishedAt.toInstant());
+            }
+        }
+    }
+
+    @Override
+    public Optional<CatalogPageSnapshot> loadPage(
+            Connection connection, long versionId, CatalogPageType catalogType, int pageId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(LOAD_PAGE_SQL)) {
+            statement.setLong(1, versionId);
+            statement.setString(2, catalogType.name());
+            statement.setInt(3, pageId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() ? Optional.of(mapPage(resultSet)) : Optional.empty();
+            }
+        }
+    }
+
+    @Override
+    public Optional<CatalogOfferSnapshot> loadOffer(
+            Connection connection, long versionId, CatalogPageType catalogType, int offerId) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(LOAD_OFFER_SQL)) {
+            statement.setLong(1, versionId);
+            statement.setString(2, catalogType.name());
+            statement.setInt(3, offerId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() ? Optional.of(mapOffer(resultSet)) : Optional.empty();
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
@@ -8,10 +8,12 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 public class CatalogPagesListComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogPagesListComposer.class);
@@ -33,7 +35,8 @@ public class CatalogPagesListComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         try {
             CatalogPageType requestedType = CatalogPageType.fromString(this.mode);
-            List<CatalogPage> pages = Emulator.getGameEnvironment().getCatalogManager().getCatalogPages(-1, this.habbo, requestedType);
+            List<CatalogPage> pages =
+                    Emulator.getGameEnvironment().getCatalogManager().getCatalogPages(-1, this.habbo, requestedType);
 
             this.response.init(Outgoing.CatalogPagesListComposer);
 
@@ -64,7 +67,9 @@ public class CatalogPagesListComposer extends MessageComposer {
     }
 
     private void append(CatalogPage category, int depth, CatalogPageType requestedType) {
-        List<CatalogPage> pagesList = Emulator.getGameEnvironment().getCatalogManager().getCatalogPages(category.getId(), this.habbo, requestedType);
+        List<CatalogPage> pagesList = Emulator.getGameEnvironment()
+                .getCatalogManager()
+                .getCatalogPages(category.getId(), this.habbo, requestedType);
 
         this.response.appendBoolean(category.isVisible());
         this.response.appendInt(category.getIconImage());
@@ -73,9 +78,18 @@ public class CatalogPagesListComposer extends MessageComposer {
         this.response.appendString(category.getPageName());
         this.response.appendString(category.getCaption() + (this.hasPermission ? " (" + category.getId() + ")" : ""));
 
-        // Offer IDs are resolved when a page is opened (GetCatalogPage). Embedding ~80k
-        // ids in the index bloats the first catalog open by seconds on large catalogs.
-        this.response.appendInt(0);
+        IntList pageOfferIds = category.getOfferIds();
+        IntList offerIds = new IntArrayList(pageOfferIds.size());
+        IntOpenHashSet seenOfferIds = new IntOpenHashSet();
+        for (int idx = 0; idx < pageOfferIds.size(); idx++) {
+            int offerId = pageOfferIds.getInt(idx);
+            if (offerId > 0 && seenOfferIds.add(offerId)) offerIds.add(offerId);
+        }
+
+        this.response.appendInt(offerIds.size());
+        for (int idx = 0; idx < offerIds.size(); idx++) {
+            this.response.appendInt(offerIds.getInt(idx));
+        }
 
         if (depth >= MAX_DEPTH) {
             this.response.appendInt(0);
@@ -89,7 +103,6 @@ public class CatalogPagesListComposer extends MessageComposer {
             this.append(pagesList.get(idx), depth + 1, requestedType);
         }
     }
-
 
     public Habbo getHabbo() {
         return habbo;

--- a/Emulator/src/main/resources/db/migration/V20260805210000__catalog_smart_save.sql
+++ b/Emulator/src/main/resources/db/migration/V20260805210000__catalog_smart_save.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `catalog_operations`
+  ADD COLUMN `request_fingerprint` char(64) NULL AFTER `result_revision`,
+  ADD COLUMN `action` varchar(24) NULL AFTER `request_fingerprint`,
+  ADD COLUMN `entity_type` enum('PAGE','OFFER') NULL AFTER `action`,
+  ADD COLUMN `catalog_type` enum('NORMAL','BUILDER') NULL AFTER `entity_type`,
+  ADD COLUMN `entity_id` int NULL AFTER `catalog_type`,
+  ADD COLUMN `history_group_id` bigint NULL AFTER `entity_id`,
+  ADD COLUMN `result_json` mediumtext NULL AFTER `history_group_id`;

--- a/Emulator/src/main/resources/db/migration/V20260805213000__catalog_official_identity_utf8mb4.sql
+++ b/Emulator/src/main/resources/db/migration/V20260805213000__catalog_official_identity_utf8mb4.sql
@@ -1,0 +1,17 @@
+-- Official catalog page identities can exceed the legacy 25-character limit.
+-- Keep the live projection and version snapshots lossless and Unicode-safe.
+ALTER TABLE `catalog_pages`
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  MODIFY COLUMN `caption_save` varchar(128) NOT NULL DEFAULT '';
+
+ALTER TABLE `catalog_items`
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `catalog_pages_bc`
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `catalog_items_bc`
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE `catalog_version_pages`
+  MODIFY COLUMN `caption_save` varchar(128) NOT NULL DEFAULT '';

--- a/Emulator/src/main/resources/db/runtime-schema-contract.json
+++ b/Emulator/src/main/resources/db/runtime-schema-contract.json
@@ -23,7 +23,7 @@
     "catalog_items": ["amount", "catalog_name", "club_only", "cost_credits", "cost_points", "extradata", "have_offer", "id", "item_ids", "limited_sells", "limited_stack", "offer_id", "order_number", "page_id", "points_type", "song_id"],
     "catalog_items_bc": ["catalog_name", "extradata", "id", "item_ids", "order_number", "page_id"],
     "catalog_items_limited": ["catalog_item_id", "item_id", "number", "timestamp", "user_id"],
-    "catalog_operations": ["actor_id", "created_at", "operation_id", "result_revision", "source", "version_id"],
+    "catalog_operations": ["action", "actor_id", "catalog_type", "created_at", "entity_id", "entity_type", "history_group_id", "operation_id", "request_fingerprint", "result_json", "result_revision", "source", "version_id"],
     "catalog_pages": ["caption", "caption_save", "catalog_mode", "club_only", "enabled", "icon_color", "icon_image", "id", "includes", "min_rank", "order_num", "page_headline", "page_layout", "page_special", "page_teaser", "page_text1", "page_text2", "page_text_details", "page_text_teaser", "parent_id", "room_id", "vip_only", "visible"],
     "catalog_pages_bc": ["caption", "enabled", "icon_color", "icon_image", "id", "order_num", "page_headline", "page_layout", "page_special", "page_teaser", "page_text1", "page_text2", "page_text_details", "page_text_teaser", "parent_id", "visible"],
     "catalog_runtime_state": ["active_version_id", "draft_version_id", "singleton_id", "updated_at"],

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogVersionedDraftSchemaTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogVersionedDraftSchemaTest.java
@@ -15,6 +15,8 @@ class CatalogVersionedDraftSchemaTest {
             Path.of("src/main/resources/db/migration/V20260802100000__catalog_versioned_drafts_compatibility.sql");
     private static final Path SMART_SAVE_MIGRATION =
             Path.of("src/main/resources/db/migration/V20260805210000__catalog_smart_save.sql");
+    private static final Path OFFICIAL_IDENTITY_MIGRATION =
+            Path.of("src/main/resources/db/migration/V20260805213000__catalog_official_identity_utf8mb4.sql");
 
     @Test
     void migrationDefinesVersionRuntimeSnapshotJournalAndLocks() throws Exception {
@@ -81,5 +83,16 @@ class CatalogVersionedDraftSchemaTest {
                 () -> assertTrue(contract.contains("request_fingerprint")),
                 () -> assertTrue(contract.contains("history_group_id")),
                 () -> assertTrue(contract.contains("result_json")));
+    }
+
+    @Test
+    void officialCatalogIdentityMigrationPreservesLongUnicodePageKeys() throws Exception {
+        String sql = Files.readString(OFFICIAL_IDENTITY_MIGRATION);
+
+        assertAll(
+                () -> assertTrue(sql.contains("CONVERT TO CHARACTER SET utf8mb4")),
+                () -> assertTrue(sql.contains("MODIFY COLUMN `caption_save` varchar(128)")),
+                () -> assertTrue(sql.contains("ALTER TABLE `catalog_version_pages`")),
+                () -> assertTrue(sql.contains("ALTER TABLE `catalog_items_bc`")));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogVersionedDraftSchemaTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogVersionedDraftSchemaTest.java
@@ -13,6 +13,8 @@ class CatalogVersionedDraftSchemaTest {
             Path.of("src/main/resources/db/migration/V20260802090000__catalog_versioned_drafts.sql");
     private static final Path COMPATIBILITY_MIGRATION =
             Path.of("src/main/resources/db/migration/V20260802100000__catalog_versioned_drafts_compatibility.sql");
+    private static final Path SMART_SAVE_MIGRATION =
+            Path.of("src/main/resources/db/migration/V20260805210000__catalog_smart_save.sql");
 
     @Test
     void migrationDefinesVersionRuntimeSnapshotJournalAndLocks() throws Exception {
@@ -65,5 +67,19 @@ class CatalogVersionedDraftSchemaTest {
                 () -> assertTrue(sql.contains("FROM `catalog_pages_bc`")),
                 () -> assertTrue(sql.contains("FROM `catalog_items_bc`")),
                 () -> assertTrue(!sql.toUpperCase().contains("DROP TABLE")));
+    }
+
+    @Test
+    void smartSaveMigrationAndRuntimeContractExposeReplayMetadata() throws Exception {
+        String sql = Files.readString(SMART_SAVE_MIGRATION);
+        String contract = Files.readString(Path.of("src/main/resources/db/runtime-schema-contract.json"));
+
+        assertAll(
+                () -> assertTrue(sql.contains("ADD COLUMN `request_fingerprint`")),
+                () -> assertTrue(sql.contains("ADD COLUMN `history_group_id`")),
+                () -> assertTrue(sql.contains("ADD COLUMN `result_json`")),
+                () -> assertTrue(contract.contains("request_fingerprint")),
+                () -> assertTrue(contract.contains("history_group_id")),
+                () -> assertTrue(contract.contains("result_json")));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveProjectionTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveProjectionTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -69,6 +70,25 @@ class JdbcCatalogLiveProjectionTest {
         verify(statement, never()).setBoolean(anyInt(), anyBoolean());
     }
 
+    @Test
+    void projectionSkipsOffersWhosePageIsAbsentFromThePublishedSnapshot() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement fallbackStatement = mock(PreparedStatement.class);
+        PreparedStatement offerStatement = mock(PreparedStatement.class);
+        when(connection.prepareStatement(anyString())).thenReturn(fallbackStatement);
+        when(connection.prepareStatement(JdbcCatalogLiveProjection.UPSERT_OFFER_SQL)).thenReturn(offerStatement);
+        CatalogVersion version = new CatalogVersion(
+                3, CatalogVersionStatus.PUBLISHED, 2L, 1, "Published", 1, Instant.EPOCH, 1, Instant.EPOCH);
+        CatalogVersionSnapshot snapshot = new CatalogVersionSnapshot(
+                version,
+                List.of(page(CatalogPageType.NORMAL, 17, true, true)),
+                List.of(offerAt(42, 17), offerAt(43, 999)));
+
+        new JdbcCatalogLiveProjection().replace(connection, snapshot);
+
+        verify(offerStatement, times(1)).addBatch();
+    }
+
     private static CatalogPageSnapshot page(CatalogPageType catalogType, int pageId, boolean visible, boolean enabled) {
         return new CatalogPageSnapshot(
                 catalogType,
@@ -99,5 +119,10 @@ class JdbcCatalogLiveProjectionTest {
 
     private static CatalogOfferSnapshot offer(boolean haveOffer, boolean clubOnly) {
         return new CatalogOfferSnapshot(42, "12", 17, "rare_dragon", 25, 0, 0, 1, 0, 1, -1, 0, "", haveOffer, clubOnly);
+    }
+
+    private static CatalogOfferSnapshot offerAt(int offerId, int pageId) {
+        return new CatalogOfferSnapshot(
+                offerId, "12", pageId, "rare_dragon", 25, 0, 0, 1, 0, 1, -1, 0, "", true, false);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveProjectionTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveProjectionTest.java
@@ -76,7 +76,8 @@ class JdbcCatalogLiveProjectionTest {
         PreparedStatement fallbackStatement = mock(PreparedStatement.class);
         PreparedStatement offerStatement = mock(PreparedStatement.class);
         when(connection.prepareStatement(anyString())).thenReturn(fallbackStatement);
-        when(connection.prepareStatement(JdbcCatalogLiveProjection.UPSERT_OFFER_SQL)).thenReturn(offerStatement);
+        when(connection.prepareStatement(JdbcCatalogLiveProjection.UPSERT_OFFER_SQL))
+                .thenReturn(offerStatement);
         CatalogVersion version = new CatalogVersion(
                 3, CatalogVersionStatus.PUBLISHED, 2L, 1, "Published", 1, Instant.EPOCH, 1, Instant.EPOCH);
         CatalogVersionSnapshot snapshot = new CatalogVersionSnapshot(

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogOperationRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogOperationRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+
+class JdbcCatalogOperationRepositoryTest {
+
+    private static final String SELECT_FOR_UPDATE = "SELECT operation_id, actor_id, version_id, source, result_revision, "
+            + "request_fingerprint, action, entity_type, catalog_type, entity_id, history_group_id, result_json "
+            + "FROM catalog_operations WHERE operation_id = ? AND actor_id = ? FOR UPDATE";
+    private static final String INSERT = "INSERT INTO catalog_operations "
+            + "(operation_id, actor_id, version_id, source, result_revision, request_fingerprint, action, entity_type, "
+            + "catalog_type, entity_id, history_group_id, result_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    private final JdbcCatalogOperationRepository repository = new JdbcCatalogOperationRepository();
+
+    @Test
+    void findForUpdateLoadsFingerprintAndOriginalResult() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(connection.prepareStatement(SELECT_FOR_UPDATE)).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString("operation_id")).thenReturn("save-page-1");
+        when(resultSet.getInt("actor_id")).thenReturn(9);
+        when(resultSet.getLong("version_id")).thenReturn(4L);
+        when(resultSet.getString("source")).thenReturn("UI");
+        when(resultSet.getLong("result_revision")).thenReturn(8L);
+        when(resultSet.getString("request_fingerprint")).thenReturn("abc123");
+        when(resultSet.getString("action")).thenReturn("UPDATE");
+        when(resultSet.getString("entity_type")).thenReturn("PAGE");
+        when(resultSet.getString("catalog_type")).thenReturn("NORMAL");
+        when(resultSet.getObject("entity_id", Integer.class)).thenReturn(42);
+        when(resultSet.getObject("history_group_id", Long.class)).thenReturn(17L);
+        when(resultSet.getString("result_json")).thenReturn("{\"revision\":8}");
+
+        CatalogOperationRecord record = repository.findForUpdate(connection, "save-page-1", 9).orElseThrow();
+
+        assertEquals("abc123", record.requestFingerprint());
+        assertEquals("{\"revision\":8}", record.resultJson());
+        assertEquals(CatalogChangeOperation.UPDATE, record.action());
+        assertEquals(17L, record.historyGroupId());
+        verify(statement).setString(1, "save-page-1");
+        verify(statement).setInt(2, 9);
+    }
+
+    @Test
+    void insertPersistsEverySmartSaveIdentityField() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        when(connection.prepareStatement(INSERT)).thenReturn(statement);
+        when(statement.executeUpdate()).thenReturn(1);
+
+        repository.insert(connection, operationRecord());
+
+        verify(statement).setString(1, "save-page-1");
+        verify(statement).setInt(2, 9);
+        verify(statement).setLong(3, 4L);
+        verify(statement).setString(4, "UI");
+        verify(statement).setLong(5, 8L);
+        verify(statement).setString(6, "abc123");
+        verify(statement).setString(7, "UPDATE");
+        verify(statement).setString(8, "PAGE");
+        verify(statement).setString(9, "NORMAL");
+        verify(statement).setInt(10, 42);
+        verify(statement).setLong(11, 17L);
+        verify(statement).setString(12, "{\"revision\":8}");
+        verify(statement).executeUpdate();
+    }
+
+    @Test
+    void findForUpdateRejectsAnOperationIdLongerThanTheDatabaseLimit() {
+        Connection connection = mock(Connection.class);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> repository.findForUpdate(connection, "x".repeat(97), 9));
+    }
+
+    @Test
+    void insertRejectsAnyUpdateCountOtherThanOne() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        when(connection.prepareStatement(INSERT)).thenReturn(statement);
+        when(statement.executeUpdate()).thenReturn(0);
+
+        assertThrows(SQLException.class, () -> repository.insert(connection, operationRecord()));
+    }
+
+    private static CatalogOperationRecord operationRecord() {
+        return new CatalogOperationRecord(
+                "save-page-1",
+                9,
+                4L,
+                CatalogChangeSource.UI,
+                8L,
+                "abc123",
+                CatalogChangeOperation.UPDATE,
+                CatalogEntityType.PAGE,
+                CatalogPageType.NORMAL,
+                42,
+                17L,
+                "{\"revision\":8}");
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogOperationRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogOperationRepositoryTest.java
@@ -15,9 +15,10 @@ import org.junit.jupiter.api.Test;
 
 class JdbcCatalogOperationRepositoryTest {
 
-    private static final String SELECT_FOR_UPDATE = "SELECT operation_id, actor_id, version_id, source, result_revision, "
-            + "request_fingerprint, action, entity_type, catalog_type, entity_id, history_group_id, result_json "
-            + "FROM catalog_operations WHERE operation_id = ? AND actor_id = ? FOR UPDATE";
+    private static final String SELECT_FOR_UPDATE =
+            "SELECT operation_id, actor_id, version_id, source, result_revision, "
+                    + "request_fingerprint, action, entity_type, catalog_type, entity_id, history_group_id, result_json "
+                    + "FROM catalog_operations WHERE operation_id = ? AND actor_id = ? FOR UPDATE";
     private static final String INSERT = "INSERT INTO catalog_operations "
             + "(operation_id, actor_id, version_id, source, result_revision, request_fingerprint, action, entity_type, "
             + "catalog_type, entity_id, history_group_id, result_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
@@ -45,7 +46,8 @@ class JdbcCatalogOperationRepositoryTest {
         when(resultSet.getObject("history_group_id", Long.class)).thenReturn(17L);
         when(resultSet.getString("result_json")).thenReturn("{\"revision\":8}");
 
-        CatalogOperationRecord record = repository.findForUpdate(connection, "save-page-1", 9).orElseThrow();
+        CatalogOperationRecord record =
+                repository.findForUpdate(connection, "save-page-1", 9).orElseThrow();
 
         assertEquals("abc123", record.requestFingerprint());
         assertEquals("{\"revision\":8}", record.resultJson());
@@ -83,9 +85,7 @@ class JdbcCatalogOperationRepositoryTest {
     void findForUpdateRejectsAnOperationIdLongerThanTheDatabaseLimit() {
         Connection connection = mock(Connection.class);
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> repository.findForUpdate(connection, "x".repeat(97), 9));
+        assertThrows(IllegalArgumentException.class, () -> repository.findForUpdate(connection, "x".repeat(97), 9));
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogVersionRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogVersionRepositoryTest.java
@@ -24,7 +24,8 @@ class JdbcCatalogVersionRepositoryTest {
         PreparedStatement statement = mock(PreparedStatement.class);
         ResultSet resultSet = mock(ResultSet.class);
         Instant createdAt = Instant.parse("2026-08-05T10:00:00Z");
-        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_VERSION_SQL)).thenReturn(statement);
+        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_VERSION_SQL))
+                .thenReturn(statement);
         when(statement.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true);
         when(resultSet.getLong("id")).thenReturn(12L);
@@ -52,7 +53,8 @@ class JdbcCatalogVersionRepositoryTest {
         Connection connection = mock(Connection.class);
         PreparedStatement statement = mock(PreparedStatement.class);
         ResultSet resultSet = mock(ResultSet.class);
-        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_PAGE_SQL)).thenReturn(statement);
+        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_PAGE_SQL))
+                .thenReturn(statement);
         when(statement.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true);
         stubPageRow(resultSet);
@@ -74,7 +76,8 @@ class JdbcCatalogVersionRepositoryTest {
         Connection connection = mock(Connection.class);
         PreparedStatement statement = mock(PreparedStatement.class);
         ResultSet resultSet = mock(ResultSet.class);
-        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_OFFER_SQL)).thenReturn(statement);
+        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_OFFER_SQL))
+                .thenReturn(statement);
         when(statement.executeQuery()).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(false);
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogVersionRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogVersionRepositoryTest.java
@@ -2,7 +2,9 @@ package com.eu.habbo.habbohotel.catalog.versioning;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +17,77 @@ import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class JdbcCatalogVersionRepositoryTest {
+
+    @Test
+    void loadsOneVersionWithoutLoadingTheWholeSnapshot() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        Instant createdAt = Instant.parse("2026-08-05T10:00:00Z");
+        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_VERSION_SQL)).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getLong("id")).thenReturn(12L);
+        when(resultSet.getString("status")).thenReturn("DRAFT");
+        when(resultSet.getLong("based_on_version_id")).thenReturn(7L);
+        when(resultSet.wasNull()).thenReturn(false);
+        when(resultSet.getLong("revision")).thenReturn(3L);
+        when(resultSet.getString("label")).thenReturn("Current draft");
+        when(resultSet.getInt("created_by")).thenReturn(4);
+        when(resultSet.getTimestamp("created_at")).thenReturn(Timestamp.from(createdAt));
+        when(resultSet.getInt("published_by")).thenReturn(0);
+        when(resultSet.getTimestamp("published_at")).thenReturn(null);
+
+        CatalogVersion version = new JdbcCatalogVersionRepository().loadVersion(connection, 12);
+
+        assertEquals(12L, version.id());
+        assertEquals(CatalogVersionStatus.DRAFT, version.status());
+        verify(statement).setLong(1, 12L);
+        verify(connection, never()).prepareStatement(JdbcCatalogVersionRepository.LOAD_PAGES_SQL);
+        verify(connection, never()).prepareStatement(JdbcCatalogVersionRepository.LOAD_OFFERS_SQL);
+    }
+
+    @Test
+    void loadsOnePageUsingVersionTypeAndPageId() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_PAGE_SQL)).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        stubPageRow(resultSet);
+
+        CatalogPageSnapshot page = new JdbcCatalogVersionRepository()
+                .loadPage(connection, 12, CatalogPageType.NORMAL, 42)
+                .orElseThrow();
+
+        assertEquals(42, page.pageId());
+        verify(statement).setLong(1, 12L);
+        verify(statement).setString(2, "NORMAL");
+        verify(statement).setInt(3, 42);
+        verify(connection, never()).prepareStatement(JdbcCatalogVersionRepository.LOAD_PAGES_SQL);
+        verify(connection, never()).prepareStatement(JdbcCatalogVersionRepository.LOAD_OFFERS_SQL);
+    }
+
+    @Test
+    void returnsEmptyWhenTheTargetedOfferIsMissing() throws Exception {
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(connection.prepareStatement(JdbcCatalogVersionRepository.LOAD_OFFER_SQL)).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(false);
+
+        assertTrue(new JdbcCatalogVersionRepository()
+                .loadOffer(connection, 12, CatalogPageType.BUILDER, 99)
+                .isEmpty());
+
+        verify(statement).setLong(1, 12L);
+        verify(statement).setString(2, "BUILDER");
+        verify(statement).setInt(3, 99);
+        verify(connection, never()).prepareStatement(JdbcCatalogVersionRepository.LOAD_PAGES_SQL);
+        verify(connection, never()).prepareStatement(JdbcCatalogVersionRepository.LOAD_OFFERS_SQL);
+    }
 
     @Test
     void locksAndLoadsTheSingletonRuntimeState() throws Exception {
@@ -126,5 +199,32 @@ class JdbcCatalogVersionRepositoryTest {
         assertThrows(
                 CatalogConcurrentModificationException.class,
                 () -> new JdbcCatalogVersionRepository().incrementRevision(connection, 8, 12));
+    }
+
+    private static void stubPageRow(ResultSet resultSet) throws Exception {
+        when(resultSet.getString("catalog_type")).thenReturn("NORMAL");
+        when(resultSet.getInt("page_id")).thenReturn(42);
+        when(resultSet.getInt("parent_id")).thenReturn(-1);
+        when(resultSet.getString("caption_save")).thenReturn("root");
+        when(resultSet.getString("caption")).thenReturn("Root");
+        when(resultSet.getString("page_layout")).thenReturn("default_3x3");
+        when(resultSet.getInt("icon_color")).thenReturn(1);
+        when(resultSet.getInt("icon_image")).thenReturn(2);
+        when(resultSet.getInt("min_rank")).thenReturn(1);
+        when(resultSet.getInt("order_num")).thenReturn(3);
+        when(resultSet.getBoolean("visible")).thenReturn(true);
+        when(resultSet.getBoolean("enabled")).thenReturn(true);
+        when(resultSet.getBoolean("club_only")).thenReturn(false);
+        when(resultSet.getString("catalog_mode")).thenReturn("NORMAL");
+        when(resultSet.getBoolean("vip_only")).thenReturn(false);
+        when(resultSet.getString("page_headline")).thenReturn("");
+        when(resultSet.getString("page_teaser")).thenReturn("");
+        when(resultSet.getString("page_special")).thenReturn("");
+        when(resultSet.getString("page_text1")).thenReturn("");
+        when(resultSet.getString("page_text2")).thenReturn("");
+        when(resultSet.getString("page_text_details")).thenReturn("");
+        when(resultSet.getString("page_text_teaser")).thenReturn("");
+        when(resultSet.getInt("room_id")).thenReturn(0);
+        when(resultSet.getString("includes")).thenReturn("");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListOfferIndexTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListOfferIndexTest.java
@@ -1,0 +1,81 @@
+package com.eu.habbo.messages.outgoing.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.habbohotel.catalog.CatalogManager;
+import com.eu.habbo.habbohotel.catalog.CatalogPage;
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.messages.outgoing.Outgoing;
+import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class CatalogPagesListOfferIndexTest {
+
+    @Test
+    void indexPublishesDistinctPositiveOfferIdsInPageOrder() {
+        Habbo habbo = mock(Habbo.class);
+        GameEnvironment environment = mock(GameEnvironment.class);
+        CatalogManager catalogManager = mock(CatalogManager.class);
+        CatalogPage page = mock(CatalogPage.class);
+
+        when(environment.getCatalogManager()).thenReturn(catalogManager);
+        when(catalogManager.getCatalogPages(-1, habbo, CatalogPageType.NORMAL)).thenReturn(List.of(page));
+        when(catalogManager.getCatalogPages(42, habbo, CatalogPageType.NORMAL)).thenReturn(List.of());
+        when(page.isVisible()).thenReturn(true);
+        when(page.isEnabled()).thenReturn(true);
+        when(page.getIconImage()).thenReturn(7);
+        when(page.getId()).thenReturn(42);
+        when(page.getParentId()).thenReturn(-1);
+        when(page.getPageName()).thenReturn("chairs");
+        when(page.getCaption()).thenReturn("Chairs");
+        when(page.getOfferIds()).thenReturn(new IntArrayList(new int[] {100, 100, -5, 200, 0}));
+
+        try (MockedStatic<Emulator> emulator = mockStatic(Emulator.class)) {
+            emulator.when(Emulator::getGameEnvironment).thenReturn(environment);
+
+            ByteBuf packet =
+                    new CatalogPagesListComposer(habbo, "NORMAL").compose().get();
+            assertEquals(packet.readableBytes() - Integer.BYTES, packet.readInt());
+            assertEquals(Outgoing.CatalogPagesListComposer, packet.readUnsignedShort());
+
+            skipNodeHeader(packet);
+            assertEquals(0, packet.readInt());
+            assertEquals(1, packet.readInt());
+
+            skipNodeHeader(packet);
+            assertEquals(2, packet.readInt());
+            assertEquals(100, packet.readInt());
+            assertEquals(200, packet.readInt());
+            assertEquals(0, packet.readInt());
+
+            assertFalse(packet.readBoolean());
+            assertEquals("NORMAL", readString(packet));
+            assertFalse(packet.isReadable());
+        }
+    }
+
+    private static void skipNodeHeader(ByteBuf packet) {
+        packet.readBoolean();
+        packet.readInt();
+        packet.readInt();
+        packet.readInt();
+        readString(packet);
+        readString(packet);
+    }
+
+    private static String readString(ByteBuf packet) {
+        int length = packet.readUnsignedShort();
+        return packet.readCharSequence(length, StandardCharsets.UTF_8).toString();
+    }
+}


### PR DESCRIPTION
## What changed

- adds idempotent, actor-scoped persistence for Catalog Studio operations, including request fingerprints and replay metadata
- adds targeted version, page, and offer reads while preserving full snapshots for existing workflows
- prevents the live catalog projection from publishing offers whose page is missing
- supports longer, Unicode-safe official catalog page identities through utf8mb4
- restores distinct positive offer IDs in the catalog index so room furniture can resolve its exact catalog page
- fixes the Spotless violations reported by CI

## Why

This provides the emulator-side foundation for Smart Save and keeps the live catalog protocol complete. The Nitro client needs offer-to-page mappings from the catalog index to open the correct page from room furniture; omitting every offer ID made that navigation resolve to an empty catalog.

## Scope

This PR contains emulator-only Catalog Studio and catalog-index updates. The scraper, renderer, UI, JAR files, logs, backups, pet changes, and experimental negative page ID changes are intentionally excluded.

The atomic Smart Save change-set transaction and renderer/UI routing remain separate follow-up work.

## Verification

- `mvnw -B -Dtest=CatalogVersionedDraftSchemaTest,JdbcCatalogOperationRepositoryTest,JdbcCatalogVersionRepositoryTest,JdbcCatalogLiveProjectionTest,CatalogPagesListOfferIndexTest test`
- 23 tests run, 0 failures, 0 errors, 0 skipped
- `mvnw -B spotless:check -Dspotless.ratchetFrom=66fd8ca7ffd2e6728a847c5aaf4f399beaca7415`
- `git diff --cached --check`