### PR TITLE
Formalize packet ID registry policy

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.messages.incoming.Incoming;
 import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.incoming.UnsupportedIncoming;
 import com.eu.habbo.messages.incoming.achievements.RequestAchievementConfigurationEvent;
 import com.eu.habbo.messages.incoming.achievements.RequestAchievementsEvent;
 import com.eu.habbo.messages.incoming.ambassadors.AmbassadorAlertCommandEvent;
@@ -834,7 +835,7 @@ public class PacketManager {
         this.registerHandler(Incoming.RequestPromotedRoomsEvent, RequestPromotedRoomsEvent.class);
         this.registerHandler(Incoming.RequestCreateRoomEvent, RequestCreateRoomEvent.class);
         this.registerHandler(Incoming.RequestTagsEvent, RequestTagsEvent.class);
-        this.registerHandler(Incoming.SearchRoomsByTagEvent, SearchRoomsByTagEvent.class);
+        this.registerHandler(UnsupportedIncoming.SearchRoomsByTagEvent, SearchRoomsByTagEvent.class);
         this.registerHandler(Incoming.SearchRoomsEvent, SearchRoomsEvent.class);
         this.registerHandler(Incoming.SearchRoomsFriendsNowEvent, SearchRoomsFriendsNowEvent.class);
         this.registerHandler(Incoming.SearchRoomsFriendsOwnEvent, SearchRoomsFriendsOwnEvent.class);
@@ -862,7 +863,7 @@ public class PacketManager {
         this.registerHandler(Incoming.RequestNewsListEvent, RequestNewsListEvent.class);
         this.registerHandler(Incoming.HotelViewDataEvent, HotelViewDataEvent.class);
         this.registerHandler(Incoming.HotelViewRequestBadgeRewardEvent, HotelViewRequestBadgeRewardEvent.class);
-        this.registerHandler(Incoming.HotelViewClaimBadgeRewardEvent, HotelViewClaimBadgeRewardEvent.class);
+        this.registerHandler(UnsupportedIncoming.HotelViewClaimBadgeRewardEvent, HotelViewClaimBadgeRewardEvent.class);
         this.registerHandler(Incoming.HotelViewRequestLTDAvailabilityEvent, HotelViewRequestLTDAvailabilityEvent.class);
         this.registerHandler(Incoming.HotelViewRequestSecondsUntilEvent, HotelViewRequestSecondsUntilEvent.class);
         this.registerHandler(Incoming.HotelViewLandingRequestEvent, HotelViewLandingRequestEvent.class);
@@ -1026,13 +1027,14 @@ public class PacketManager {
         this.registerHandler(Incoming.ModToolCloseTicketEvent, ModToolCloseTicketEvent.class);
         this.registerHandler(Incoming.ModToolReleaseTicketEvent, ModToolReleaseTicketEvent.class);
         this.registerHandler(Incoming.ModToolAlertEvent, ModToolAlertEvent.class);
-        this.registerHandler(Incoming.ModToolWarnEvent, ModToolWarnEvent.class);
+        this.registerHandler(UnsupportedIncoming.ModToolWarnEvent, ModToolWarnEvent.class);
         this.registerHandler(Incoming.ModToolKickEvent, ModToolKickEvent.class);
         this.registerHandler(Incoming.ModToolRoomAlertEvent, ModToolRoomAlertEvent.class);
         this.registerHandler(Incoming.ModToolChangeRoomSettingsEvent, ModToolChangeRoomSettingsEvent.class);
         this.registerHandler(Incoming.ModToolRequestRoomVisitsEvent, ModToolRequestRoomVisitsEvent.class);
         this.registerHandler(Incoming.ModToolRequestIssueChatlogEvent, ModToolRequestIssueChatlogEvent.class);
-        this.registerHandler(Incoming.ModToolRequestRoomUserChatlogEvent, ModToolRequestRoomUserChatlogEvent.class);
+        this.registerHandler(
+                UnsupportedIncoming.ModToolRequestRoomUserChatlogEvent, ModToolRequestRoomUserChatlogEvent.class);
         this.registerHandler(Incoming.ModToolRequestUserChatlogEvent, ModToolRequestUserChatlogEvent.class);
         this.registerHandler(Incoming.ModToolSanctionAlertEvent, ModToolSanctionAlertEvent.class);
         this.registerHandler(Incoming.ModToolSanctionMuteEvent, ModToolSanctionMuteEvent.class);
@@ -1162,7 +1164,8 @@ public class PacketManager {
 
     void registerAchievements() throws Exception {
         this.registerHandler(Incoming.RequestAchievementsEvent, RequestAchievementsEvent.class);
-        this.registerHandler(Incoming.RequestAchievementConfigurationEvent, RequestAchievementConfigurationEvent.class);
+        this.registerHandler(
+                UnsupportedIncoming.RequestAchievementConfigurationEvent, RequestAchievementConfigurationEvent.class);
     }
 
     void registerGuides() throws Exception {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -96,13 +96,19 @@ public class Incoming {
     public static final int GuildAcceptMembershipEvent = 3386;
     public static final int RequestRecylerLogicEvent = 398;
     public static final int RequestGuildJoinEvent = 998;
-    public static int RequestCatalogIndexEvent = 2529;
     public static final int BuildersClubQueryFurniCountEvent = 2529;
+    /** @deprecated Compatibility alias; use {@link #BuildersClubQueryFurniCountEvent}. */
+    @Deprecated
+    public static int RequestCatalogIndexEvent = BuildersClubQueryFurniCountEvent;
+
     public static final int BuildersClubPlaceRoomItemEvent = 1051;
     public static final int BuildersClubPlaceWallItemEvent = 462;
     public static final int RequestInventoryPetsEvent = 3095;
     public static final int ModToolRequestRoomVisitsEvent = 3526;
-    public static final int ModToolWarnEvent = -1; // 3763
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int ModToolWarnEvent = UnsupportedIncoming.ModToolWarnEvent;
+
     public static final int RequestItemInfoEvent = 3288;
     public static final int ModToolRequestRoomChatlogEvent = 2587;
     public static final int UserSaveLookEvent = 2730;
@@ -160,14 +166,20 @@ public class Incoming {
     public static final int HotelViewInventoryEvent = 3500;
     public static final int RequestPetBreedsEvent = 1756;
     public static final int GuildChangeBadgeEvent = 1991;
-    public static final int ModToolBanEvent = -1;
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int ModToolBanEvent = UnsupportedIncoming.ModToolBanEvent;
+
     public static final int SaveWardrobeEvent = 800;
     public static final int HotelViewEvent = 105;
     public static final int ModToolPickTicketEvent = 15;
     public static final int ModToolReleaseTicketEvent = 1572;
     public static final int ModToolCloseTicketEvent = 2067;
     public static final int TriggerColorWheelEvent = 2144;
-    public static final int SearchRoomsByTagEvent = -1; // 1956
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int SearchRoomsByTagEvent = UnsupportedIncoming.SearchRoomsByTagEvent;
+
     public static final int RequestPublicRoomsEvent = 1229;
     public static final int RequestResolutionEvent = 359;
     public static final int RequestInventoryItemsEvent = 3150;
@@ -246,7 +258,10 @@ public class Incoming {
 
     public static final int MoodLightSaveSettingsEvent = 1648;
     public static final int ModToolRequestIssueChatlogEvent = 211;
-    public static final int ModToolRequestRoomUserChatlogEvent = -1;
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int ModToolRequestRoomUserChatlogEvent = UnsupportedIncoming.ModToolRequestRoomUserChatlogEvent;
+
     public static final int GetIgnoredUsersEvent = 3878;
     public static final int RequestClubGiftsEvent = 487;
     public static final int RentSpaceEvent = 2946;
@@ -298,7 +313,11 @@ public class Incoming {
     public static final int GuardianNoUpdatesWantedEvent = 2501;
     public static final int GuardianVoteEvent = 3961;
     public static final int GuardianAcceptRequestEvent = 3365;
-    public static final int RequestAchievementConfigurationEvent = -1;
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int RequestAchievementConfigurationEvent =
+            UnsupportedIncoming.RequestAchievementConfigurationEvent;
+
     public static final int RequestReportUserBullyingEvent = 3786;
     public static final int ReportBullyEvent = 3060;
     public static final int CameraRoomPictureEvent = 3226;
@@ -339,7 +358,9 @@ public class Incoming {
     public static final int YoutubeRequestPlaylistChange = 2069;
 
     public static final int HotelViewRequestBadgeRewardEvent = 2318;
-    public static final int HotelViewClaimBadgeRewardEvent = -1;
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int HotelViewClaimBadgeRewardEvent = UnsupportedIncoming.HotelViewClaimBadgeRewardEvent;
 
     public static final int JukeBoxAddSoundTrackEvent = 753;
     public static final int JukeBoxRemoveSoundTrackEvent = 3050;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/UnsupportedIncoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/UnsupportedIncoming.java
@@ -1,0 +1,17 @@
+package com.eu.habbo.messages.incoming;
+
+/**
+ * Packet handlers retained for source compatibility whose wire headers are not known for this revision.
+ *
+ * <p>These values must never be added to the active {@link Incoming} registry.</p>
+ */
+public final class UnsupportedIncoming {
+    public static final int ModToolWarnEvent = -1; // Historical candidate: 3763
+    public static final int ModToolBanEvent = -1;
+    public static final int SearchRoomsByTagEvent = -1; // Historical candidate: 1956
+    public static final int ModToolRequestRoomUserChatlogEvent = -1;
+    public static final int RequestAchievementConfigurationEvent = -1;
+    public static final int HotelViewClaimBadgeRewardEvent = -1;
+
+    private UnsupportedIncoming() {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -67,12 +67,18 @@ public class Outgoing {
     public static final int GuildRefreshMembersListComposer = 2445;
     public static final int UserPerksComposer = 2586;
     public static final int UserCitizinShipComposer = 1203;
-    public static final int PublicRoomsComposer = -1; // error 404
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int PublicRoomsComposer = UnsupportedOutgoing.PublicRoomsComposer;
+
     public static final int MarketplaceOffersComposer = 680;
     public static final int ModToolComposer = 2696;
     public static final int UserBadgesComposer = 1087;
     public static final int GuildManageComposer = 3965;
-    public static final int RemoveFriendComposer = -1; // error 404
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int RemoveFriendComposer = UnsupportedOutgoing.RemoveFriendComposer;
+
     public static final int InitDiffieHandshakeComposer = 1347;
     public static final int CompleteDiffieHandshakeComposer = 3885;
     public static final int UserDataComposer = 2725;
@@ -152,11 +158,17 @@ public class Outgoing {
     public static final int WallItemUpdateComposer = 2009; // PRODUCTION-201611291003-338511768
     public static final int TradeAcceptedComposer = 2568; // PRODUCTION-201611291003-338511768
     public static final int AddWallItemComposer = 2187; // PRODUCTION-201611291003-338511768
-    public static final int RoomEntryInfoComposer = -1; // PRODUCTION-201611291003-338511768
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int RoomEntryInfoComposer = UnsupportedOutgoing.RoomEntryInfoComposer;
+
     public static final int HotelViewDataComposer = 1745; // PRODUCTION-201611291003-338511768
     public static final int PresentItemOpenedComposer = 56; // PRODUCTION-201611291003-338511768
     public static final int RoomUserRemoveRightsComposer = 84; // PRODUCTION-201611291003-338511768
-    public static final int UserBCLimitsComposer = -1; // PRODUCTION-201611291003-338511768
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int UserBCLimitsComposer = UnsupportedOutgoing.UserBCLimitsComposer;
+
     public static final int PetTrainingPanelComposer = 1164; // PRODUCTION-201611291003-338511768
     public static final int RoomPaneComposer = 749; // PRODUCTION-201611291003-338511768
     public static final int RedeemVoucherErrorComposer = 714; // PRODUCTION-201611291003-338511768
@@ -250,7 +262,10 @@ public class Outgoing {
     public static final int ItemExtraDataComposer = 2547; // PRODUCTION-201611291003-338511768
     public static final int PostUpdateMessageComposer = 324; // PRODUCTION-201611291003-338511768
     // NotSure Needs Testing
-    public static final int QuestionInfoComposer = -1; // PRODUCTION-201611291003-338511768
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int QuestionInfoComposer = UnsupportedOutgoing.QuestionInfoComposer;
+
     public static final int TalentTrackEmailVerifiedComposer = 612; // PRODUCTION-201611291003-338511768
     public static final int TalentTrackEmailFailedComposer = 1815; // PRODUCTION-201611291003-338511768
     public static final int UnknownAvatarEditorComposer = 3473; // PRODUCTION-201611291003-338511768
@@ -262,8 +277,14 @@ public class Outgoing {
     public static final int GuildForumAddCommentComposer = 2049; // PRODUCTION-201611291003-338511768
     public static final int GuildForumDataComposer = 3011; // PRODUCTION-201611291003-338511768
     public static final int GuildForumCommentsComposer = 509; // PRODUCTION-201611291003-338511768
-    public static final int UnknownGuildForumComposer6 = -1; // PRODUCTION-201611291003-338511768
-    public static final int UnknownGuildForumComposer7 = -1; // PRODUCTION-201611291003-338511768
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int UnknownGuildForumComposer6 = UnsupportedOutgoing.UnknownGuildForumComposer6;
+
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int UnknownGuildForumComposer7 = UnsupportedOutgoing.UnknownGuildForumComposer7;
+
     public static final int GuildForumThreadsComposer = 1073; // PRODUCTION-201611291003-338511768
     public static final int GuildForumListComposer = 3001; // PRODUCTION-201611291003-338511768
     public static final int ThreadUpdateMessageComposer = 2528;
@@ -356,11 +377,17 @@ public class Outgoing {
     public static final int MostUselessErrorAlertComposer = 662; // PRODUCTION-201611291003-338511768
     public static final int AchievementsConfigurationComposer = 1689; // PRODUCTION-201611291003-338511768
     public static final int PetBreedingResultComposer = 634; // PRODUCTION-201611291003-338511768
-    public static final int RoomUserQuestionAnsweredComposer = -1; // PRODUCTION-201611291003-338511768
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int RoomUserQuestionAnsweredComposer = UnsupportedOutgoing.RoomUserQuestionAnsweredComposer;
+
     public static final int PetBreedingStartComposer = 1746; // PRODUCTION-201611291003-338511768
     public static final int CustomNotificationComposer = 909; // PRODUCTION-201611291003-338511768
     public static final int UpdateStackHeightTileHeightComposer = 2816; // PRODUCTION-201611291003-338511768
-    public static final int HotelViewCustomTimerComposer = -1; // PRODUCTION-201611291003-338511768
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int HotelViewCustomTimerComposer = UnsupportedOutgoing.HotelViewCustomTimerComposer;
+
     public static final int MarketplaceItemPostedComposer = 1359; // PRODUCTION-201611291003-338511768
     public static final int HabboWayQuizComposer2 = 2927; // PRODUCTION-201611291003-338511768
     public static final int GuildFavoriteRoomUserUpdateComposer = 3403; // PRODUCTION-201611291003-338511768
@@ -379,7 +406,10 @@ public class Outgoing {
     public static final int CompetitionEntrySubmitResultComposer = 1177; // PRODUCTION-201611291003-338511768
     public static final int ExtendClubMessageComposer = 3964; // PRODUCTION-201611291003-338511768
     public static final int HotelViewConcurrentUsersComposer = 2737; // PRODUCTION-201611291003-338511768
-    public static final int InventoryAddEffectComposer = -1; // error 404
+    /** @deprecated Unsupported wire header retained for plugin ABI compatibility. */
+    @Deprecated
+    public static final int InventoryAddEffectComposer = UnsupportedOutgoing.InventoryAddEffectComposer;
+
     public static final int TalentLevelUpdateComposer = 638; // PRODUCTION-201611291003-338511768
     public static final int BullyReportedMessageComposer = 3285; // PRODUCTION-201611291003-338511768
     public static final int UnknownQuestComposer3 = 1122; // PRODUCTION-201611291003-338511768

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/UnsupportedOutgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/UnsupportedOutgoing.java
@@ -1,0 +1,21 @@
+package com.eu.habbo.messages.outgoing;
+
+/**
+ * Message composers retained for source compatibility whose wire headers are not known for this revision.
+ *
+ * <p>These values must never be added to the active {@link Outgoing} registry.</p>
+ */
+public final class UnsupportedOutgoing {
+    public static final int PublicRoomsComposer = -1;
+    public static final int RemoveFriendComposer = -1;
+    public static final int RoomEntryInfoComposer = -1;
+    public static final int UserBCLimitsComposer = -1;
+    public static final int QuestionInfoComposer = -1;
+    public static final int UnknownGuildForumComposer6 = -1;
+    public static final int UnknownGuildForumComposer7 = -1;
+    public static final int RoomUserQuestionAnsweredComposer = -1;
+    public static final int HotelViewCustomTimerComposer = -1;
+    public static final int InventoryAddEffectComposer = -1;
+
+    private UnsupportedOutgoing() {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/hotelview/HotelViewCustomTimerComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/hotelview/HotelViewCustomTimerComposer.java
@@ -2,7 +2,7 @@ package com.eu.habbo.messages.outgoing.hotelview;
 
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
-import com.eu.habbo.messages.outgoing.Outgoing;
+import com.eu.habbo.messages.outgoing.UnsupportedOutgoing;
 
 public class HotelViewCustomTimerComposer extends MessageComposer {
     private final String name;
@@ -15,8 +15,8 @@ public class HotelViewCustomTimerComposer extends MessageComposer {
 
     @Override
     protected ServerMessage composeInternal() {
-        this.response.init(Outgoing.HotelViewCustomTimerComposer);
-        this.response.appendString(this.name); //Send by the client.
+        this.response.init(UnsupportedOutgoing.HotelViewCustomTimerComposer);
+        this.response.appendString(this.name); // Send by the client.
         this.response.appendInt(this.seconds);
         return this.response;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/quests/QuestionInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/quests/QuestionInfoComposer.java
@@ -2,12 +2,12 @@ package com.eu.habbo.messages.outgoing.quests;
 
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
-import com.eu.habbo.messages.outgoing.Outgoing;
+import com.eu.habbo.messages.outgoing.UnsupportedOutgoing;
 
 public class QuestionInfoComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
-        this.response.init(Outgoing.QuestionInfoComposer);
+        this.response.init(UnsupportedOutgoing.QuestionInfoComposer);
 
         return this.response;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/RoomEntryInfoComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/RoomEntryInfoComposer.java
@@ -3,7 +3,7 @@ package com.eu.habbo.messages.outgoing.rooms;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
-import com.eu.habbo.messages.outgoing.Outgoing;
+import com.eu.habbo.messages.outgoing.UnsupportedOutgoing;
 
 public class RoomEntryInfoComposer extends MessageComposer {
     private final Room room;
@@ -14,7 +14,7 @@ public class RoomEntryInfoComposer extends MessageComposer {
 
     @Override
     protected ServerMessage composeInternal() {
-        this.response.init(Outgoing.RoomEntryInfoComposer);
+        this.response.init(UnsupportedOutgoing.RoomEntryInfoComposer);
         this.response.appendInt(this.room.getId());
         this.response.appendString(this.room.getOwnerName());
         return this.response;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/unknown/RoomUserQuestionAnsweredComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/unknown/RoomUserQuestionAnsweredComposer.java
@@ -2,8 +2,7 @@ package com.eu.habbo.messages.outgoing.unknown;
 
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
-import com.eu.habbo.messages.outgoing.Outgoing;
-
+import com.eu.habbo.messages.outgoing.UnsupportedOutgoing;
 import java.util.Map;
 
 public class RoomUserQuestionAnsweredComposer extends MessageComposer {
@@ -19,7 +18,7 @@ public class RoomUserQuestionAnsweredComposer extends MessageComposer {
 
     @Override
     protected ServerMessage composeInternal() {
-        this.response.init(Outgoing.RoomUserQuestionAnsweredComposer);
+        this.response.init(UnsupportedOutgoing.RoomUserQuestionAnsweredComposer);
         this.response.appendInt(this.userId);
         this.response.appendString(this.value);
         this.response.appendInt(this.unknownMap.size());

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserBCLimitsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/users/UserBCLimitsComposer.java
@@ -2,12 +2,12 @@ package com.eu.habbo.messages.outgoing.users;
 
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
-import com.eu.habbo.messages.outgoing.Outgoing;
+import com.eu.habbo.messages.outgoing.UnsupportedOutgoing;
 
 public class UserBCLimitsComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
-        this.response.init(Outgoing.UserBCLimitsComposer);
+        this.response.init(UnsupportedOutgoing.UserBCLimitsComposer);
         this.response.appendInt(0);
         this.response.appendInt(500);
         this.response.appendInt(0);

--- a/Emulator/src/test/java/com/eu/habbo/messages/contracts/JavaPacketRegistry.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/contracts/JavaPacketRegistry.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 final class JavaPacketRegistry {
@@ -50,6 +51,28 @@ final class JavaPacketRegistry {
 
         String canonical(String symbol) {
             return canonicalSymbols.getOrDefault(symbol, symbol);
+        }
+
+        void validateDeclarations(Direction direction) {
+            Map<Integer, List<String>> symbolsByHeader = new LinkedHashMap<>();
+            for (Map.Entry<String, Integer> declaration : values.entrySet()) {
+                if (declaration.getValue() <= 0) {
+                    throw new IllegalArgumentException("non-positive " + direction.manifestName() + " header "
+                            + declaration.getKey() + "=" + declaration.getValue());
+                }
+                symbolsByHeader
+                        .computeIfAbsent(declaration.getValue(), ignored -> new ArrayList<>())
+                        .add(declaration.getKey());
+            }
+            for (Map.Entry<Integer, List<String>> entry : symbolsByHeader.entrySet()) {
+                if (entry.getValue().size() < 2) continue;
+                Set<String> roots =
+                        entry.getValue().stream().map(this::canonical).collect(java.util.stream.Collectors.toSet());
+                if (roots.size() > 1) {
+                    throw new IllegalArgumentException("duplicate declared " + direction.manifestName() + " header "
+                            + entry.getKey() + ": " + String.join(" and ", entry.getValue()));
+                }
+            }
         }
     }
 
@@ -131,6 +154,9 @@ final class JavaPacketRegistry {
             active.put(key, packet);
         }
 
+        incoming.validateDeclarations(Direction.CLIENT_TO_SERVER);
+        outgoing.validateDeclarations(Direction.SERVER_TO_CLIENT);
+
         List<DeclaredPacket> declaredOnly = new ArrayList<>();
         addDeclaredOnly(declaredOnly, active, Direction.CLIENT_TO_SERVER, incoming);
         addDeclaredOnly(declaredOnly, active, Direction.SERVER_TO_CLIENT, outgoing);
@@ -184,8 +210,10 @@ final class JavaPacketRegistry {
                                 .asString()
                                 .equals("int")
                         || variable.getInitializer().isEmpty()) continue;
-                declarations.put(
-                        variable.getNameAsString(), variable.getInitializer().orElseThrow());
+                Expression initializer = variable.getInitializer().orElseThrow();
+                if (field.getAnnotationByName("Deprecated").isPresent() && isUnsupportedCompatibilityAlias(initializer))
+                    continue;
+                declarations.put(variable.getNameAsString(), initializer);
             }
         }
         Map<String, Integer> headers = new LinkedHashMap<>();
@@ -223,6 +251,12 @@ final class JavaPacketRegistry {
             canonical.put(symbol, root);
         }
         return new HeaderTable(Map.copyOf(headers), Map.copyOf(canonical));
+    }
+
+    private static boolean isUnsupportedCompatibilityAlias(Expression expression) {
+        if (!expression.isFieldAccessExpr()) return false;
+        String owner = expression.asFieldAccessExpr().getScope().toString();
+        return owner.equals("UnsupportedIncoming") || owner.equals("UnsupportedOutgoing");
     }
 
     private static Integer integerLiteral(Expression expression) {

--- a/Emulator/src/test/java/com/eu/habbo/messages/contracts/JavaPacketRegistryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/contracts/JavaPacketRegistryTest.java
@@ -1,15 +1,14 @@
 package com.eu.habbo.messages.contracts;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class JavaPacketRegistryTest {
     @TempDir
@@ -25,7 +24,8 @@ class JavaPacketRegistryTest {
                 IllegalArgumentException.class,
                 () -> registry.require(JavaPacketRegistry.Direction.SERVER_TO_CLIENT, 84));
         assertTrue(registry.require(JavaPacketRegistry.Direction.SERVER_TO_CLIENT, 1327)
-                .source().endsWith("RoomRemoveRightsListComposer.java"));
+                .source()
+                .endsWith("RoomRemoveRightsListComposer.java"));
     }
 
     @Test
@@ -50,7 +50,9 @@ class JavaPacketRegistryTest {
                     void register() { registerHandler(Incoming.OpenEvent, OpenEvent.class); }
                 }
                 """);
-        Path handler = write(root, "com/eu/habbo/messages/incoming/test/OpenEvent.java",
+        Path handler = write(
+                root,
+                "com/eu/habbo/messages/incoming/test/OpenEvent.java",
                 "package com.eu.habbo.messages.incoming.test; class OpenEvent {}\n");
         Path composer = write(root, "com/eu/habbo/messages/outgoing/test/OpenComposer.java", """
                 package com.eu.habbo.messages.outgoing.test;
@@ -61,8 +63,14 @@ class JavaPacketRegistryTest {
 
         JavaPacketRegistry registry = JavaPacketRegistry.discover(root);
 
-        assertEquals(handler, registry.require(JavaPacketRegistry.Direction.CLIENT_TO_SERVER, 100).source());
-        assertEquals(composer, registry.require(JavaPacketRegistry.Direction.SERVER_TO_CLIENT, 200).source());
+        assertEquals(
+                handler,
+                registry.require(JavaPacketRegistry.Direction.CLIENT_TO_SERVER, 100)
+                        .source());
+        assertEquals(
+                composer,
+                registry.require(JavaPacketRegistry.Direction.SERVER_TO_CLIENT, 200)
+                        .source());
         assertTrue(registry.declaredOnly().stream().anyMatch(packet -> packet.header() == 101));
     }
 
@@ -76,7 +84,9 @@ class JavaPacketRegistryTest {
                     public static final int SecondEvent = 100;
                 }
                 """);
-        write(root, "com/eu/habbo/messages/outgoing/Outgoing.java",
+        write(
+                root,
+                "com/eu/habbo/messages/outgoing/Outgoing.java",
                 "package com.eu.habbo.messages.outgoing; public class Outgoing {}\n");
         write(root, "com/eu/habbo/messages/PacketManager.java", """
                 package com.eu.habbo.messages;
@@ -85,18 +95,146 @@ class JavaPacketRegistryTest {
                     registerHandler(Incoming.SecondEvent, SecondEvent.class);
                 }}
                 """);
-        write(root, "com/eu/habbo/messages/incoming/test/FirstEvent.java",
+        write(
+                root,
+                "com/eu/habbo/messages/incoming/test/FirstEvent.java",
                 "package com.eu.habbo.messages.incoming.test; class FirstEvent {}\n");
-        write(root, "com/eu/habbo/messages/incoming/test/SecondEvent.java",
+        write(
+                root,
+                "com/eu/habbo/messages/incoming/test/SecondEvent.java",
                 "package com.eu.habbo.messages.incoming.test; class SecondEvent {}\n");
 
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
-                () -> JavaPacketRegistry.discover(root));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> JavaPacketRegistry.discover(root));
 
         assertTrue(error.getMessage().contains("duplicate active client_to_server header 100"));
         assertTrue(error.getMessage().contains("FirstEvent"));
         assertTrue(error.getMessage().contains("SecondEvent"));
+    }
+
+    @Test
+    void rejectsDuplicateDeclaredHeadersThatAreNotExplicitAliases() throws IOException {
+        Path root = fixtureRoot();
+        write(root, "com/eu/habbo/messages/incoming/Incoming.java", """
+                package com.eu.habbo.messages.incoming;
+                public class Incoming {
+                    public static final int ActiveEvent = 100;
+                    public static final int StaleEvent = 100;
+                }
+                """);
+        write(
+                root,
+                "com/eu/habbo/messages/outgoing/Outgoing.java",
+                "package com.eu.habbo.messages.outgoing; public class Outgoing {}\n");
+        write(root, "com/eu/habbo/messages/PacketManager.java", """
+                package com.eu.habbo.messages;
+                class PacketManager { void register() {
+                    registerHandler(Incoming.ActiveEvent, ActiveEvent.class);
+                }}
+                """);
+        write(
+                root,
+                "com/eu/habbo/messages/incoming/test/ActiveEvent.java",
+                "package com.eu.habbo.messages.incoming.test; class ActiveEvent {}\n");
+
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> JavaPacketRegistry.discover(root));
+
+        assertTrue(error.getMessage().contains("duplicate declared client_to_server header 100"));
+        assertTrue(error.getMessage().contains("ActiveEvent"));
+        assertTrue(error.getMessage().contains("StaleEvent"));
+    }
+
+    @Test
+    void acceptsExplicitAliasesForTheSameHeader() throws IOException {
+        Path root = fixtureRoot();
+        write(root, "com/eu/habbo/messages/incoming/Incoming.java", """
+                package com.eu.habbo.messages.incoming;
+                public class Incoming {
+                    public static final int ActiveEvent = 100;
+                    public static final int CompatibilityEvent = ActiveEvent;
+                }
+                """);
+        write(
+                root,
+                "com/eu/habbo/messages/outgoing/Outgoing.java",
+                "package com.eu.habbo.messages.outgoing; public class Outgoing {}\n");
+        write(root, "com/eu/habbo/messages/PacketManager.java", """
+                package com.eu.habbo.messages;
+                class PacketManager { void register() {
+                    registerHandler(Incoming.CompatibilityEvent, ActiveEvent.class);
+                }}
+                """);
+        write(
+                root,
+                "com/eu/habbo/messages/incoming/test/ActiveEvent.java",
+                "package com.eu.habbo.messages.incoming.test; class ActiveEvent {}\n");
+
+        JavaPacketRegistry registry = JavaPacketRegistry.discover(root);
+
+        assertEquals(
+                "CompatibilityEvent",
+                registry.require(JavaPacketRegistry.Direction.CLIENT_TO_SERVER, 100)
+                        .symbol());
+    }
+
+    @Test
+    void rejectsNonPositiveHeadersInTheActiveRegistryFiles() throws IOException {
+        Path root = fixtureRoot();
+        write(root, "com/eu/habbo/messages/incoming/Incoming.java", """
+                package com.eu.habbo.messages.incoming;
+                public class Incoming { public static final int UnsupportedEvent = -1; }
+                """);
+        write(
+                root,
+                "com/eu/habbo/messages/outgoing/Outgoing.java",
+                "package com.eu.habbo.messages.outgoing; public class Outgoing {}\n");
+        write(
+                root,
+                "com/eu/habbo/messages/PacketManager.java",
+                "package com.eu.habbo.messages; class PacketManager {}\n");
+
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> JavaPacketRegistry.discover(root));
+
+        assertTrue(error.getMessage().contains("non-positive client_to_server header"));
+        assertTrue(error.getMessage().contains("UnsupportedEvent"));
+    }
+
+    @Test
+    void ignoresQualifiedUnsupportedCompatibilityAliases() throws IOException {
+        Path root = fixtureRoot();
+        write(root, "com/eu/habbo/messages/incoming/Incoming.java", """
+                package com.eu.habbo.messages.incoming;
+                public class Incoming {
+                    public static final int ActiveEvent = 100;
+                    @Deprecated
+                    public static final int UnsupportedEvent = UnsupportedIncoming.UnsupportedEvent;
+                }
+                """);
+        write(
+                root,
+                "com/eu/habbo/messages/outgoing/Outgoing.java",
+                "package com.eu.habbo.messages.outgoing; public class Outgoing {}\n");
+        write(root, "com/eu/habbo/messages/PacketManager.java", """
+                package com.eu.habbo.messages;
+                class PacketManager { void register() {
+                    registerHandler(Incoming.ActiveEvent, ActiveEvent.class);
+                }}
+                """);
+        write(
+                root,
+                "com/eu/habbo/messages/incoming/test/ActiveEvent.java",
+                "package com.eu.habbo.messages.incoming.test; class ActiveEvent {}\n");
+
+        JavaPacketRegistry registry = JavaPacketRegistry.discover(root);
+
+        assertEquals(
+                100,
+                registry.require(JavaPacketRegistry.Direction.CLIENT_TO_SERVER, 100)
+                        .header());
+        assertTrue(registry.declaredOnly().stream()
+                .noneMatch(packet -> packet.symbol().equals("UnsupportedEvent")));
     }
 
     @Test
@@ -106,7 +244,9 @@ class JavaPacketRegistryTest {
                 package com.eu.habbo.messages.incoming;
                 public class Incoming { public static final int MissingEvent = 100; }
                 """);
-        write(root, "com/eu/habbo/messages/outgoing/Outgoing.java",
+        write(
+                root,
+                "com/eu/habbo/messages/outgoing/Outgoing.java",
                 "package com.eu.habbo.messages.outgoing; public class Outgoing {}\n");
         write(root, "com/eu/habbo/messages/PacketManager.java", """
                 package com.eu.habbo.messages;
@@ -115,9 +255,8 @@ class JavaPacketRegistryTest {
                 }}
                 """);
 
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
-                () -> JavaPacketRegistry.discover(root));
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> JavaPacketRegistry.discover(root));
 
         assertTrue(error.getMessage().contains("source for MissingEvent is missing"));
     }

--- a/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketContractCatalogGenerator.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketContractCatalogGenerator.java
@@ -1,11 +1,10 @@
 package com.eu.habbo.messages.contracts;
 
-import com.google.gson.GsonBuilder;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -36,8 +35,7 @@ record TypeScriptPacketInventoryEntry(
         String className,
         String path,
         List<JsonObject> fields,
-        String unsupportedReason) {
-}
+        String unsupportedReason) {}
 
 final class PacketContractCatalogGenerator {
     private final Path repositoryRoot;
@@ -88,9 +86,12 @@ final class PacketContractCatalogGenerator {
 
     String generate(Path typescriptInventoryPath) throws IOException {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        PacketRegistryPolicy registry = new PacketContractManifestLoader()
+                .load(repositoryRoot.resolve("protocol/packet-field-contracts.json"))
+                .registry();
         List<TypeScriptPacketInventoryEntry> typescript = gson.fromJson(
                 Files.readString(typescriptInventoryPath, StandardCharsets.UTF_8),
-                new TypeToken<List<TypeScriptPacketInventoryEntry>>() { }.getType());
+                new TypeToken<List<TypeScriptPacketInventoryEntry>>() {}.getType());
         Map<String, JavaPacketInventoryEntry> javaByKey = new LinkedHashMap<>();
         javaInventory().forEach(packet -> javaByKey.put(key(packet.direction(), packet.header()), packet));
         Map<String, TypeScriptPacketInventoryEntry> typescriptByKey = new LinkedHashMap<>();
@@ -102,10 +103,12 @@ final class PacketContractCatalogGenerator {
         javaByKey.values().stream()
                 .filter(javaPacket -> typescriptByKey.containsKey(key(javaPacket.direction(), javaPacket.header())))
                 .forEach(javaPacket -> {
-                    TypeScriptPacketInventoryEntry tsPacket = typescriptByKey.get(
-                            key(javaPacket.direction(), javaPacket.header()));
-                    List<String> javaSignature = javaPacket.fields().stream().map(this::signature).toList();
-                    List<String> tsSignature = tsPacket.fields().stream().map(this::signature).toList();
+                    TypeScriptPacketInventoryEntry tsPacket =
+                            typescriptByKey.get(key(javaPacket.direction(), javaPacket.header()));
+                    List<String> javaSignature =
+                            javaPacket.fields().stream().map(this::signature).toList();
+                    List<String> tsSignature =
+                            tsPacket.fields().stream().map(this::signature).toList();
                     boolean analyzable = javaPacket.unsupportedReason() == null && tsPacket.unsupportedReason() == null;
                     if (analyzable && signaturesCompatible(javaSignature, tsSignature)) {
                         contracts.add(contract(javaPacket, tsPacket, !javaSignature.equals(tsSignature)));
@@ -116,16 +119,25 @@ final class PacketContractCatalogGenerator {
         javaByKey.values().stream()
                 .filter(packet -> !typescriptByKey.containsKey(key(packet.direction(), packet.header())))
                 .forEach(packet -> unpaired.add(unpaired(
-                        packet.direction(), "java", packet.header(), packet.symbol(), packet.path(),
+                        packet.direction(),
+                        "java",
+                        packet.header(),
+                        packet.symbol(),
+                        packet.path(),
                         "Header is registered only by the Polaris Emulator packet registry")));
         typescriptByKey.values().stream()
                 .filter(packet -> !javaByKey.containsKey(key(packet.direction(), packet.header())))
                 .forEach(packet -> unpaired.add(unpaired(
-                        packet.direction(), "typescript", packet.header(), packet.symbol(), packet.path(),
+                        packet.direction(),
+                        "typescript",
+                        packet.header(),
+                        packet.symbol(),
+                        packet.path(),
                         "Header is registered only by the Nitro Renderer packet registry")));
 
         JsonObject manifest = new JsonObject();
-        manifest.addProperty("schemaVersion", 1);
+        manifest.addProperty("schemaVersion", 2);
+        manifest.add("registry", gson.toJsonTree(registry));
         manifest.add("contracts", contracts);
         manifest.add("unpaired", unpaired);
         manifest.add("exemptions", exemptions);
@@ -144,9 +156,7 @@ final class PacketContractCatalogGenerator {
     }
 
     private JsonObject contract(
-            JavaPacketInventoryEntry javaPacket,
-            TypeScriptPacketInventoryEntry tsPacket,
-            boolean useTypeScriptFields) {
+            JavaPacketInventoryEntry javaPacket, TypeScriptPacketInventoryEntry tsPacket, boolean useTypeScriptFields) {
         JsonObject result = base(javaPacket, tsPacket);
         JsonArray fields = new JsonArray();
         if (useTypeScriptFields) {
@@ -163,8 +173,7 @@ final class PacketContractCatalogGenerator {
         if (javaSignature.size() >= typescriptSignature.size()) return false;
         if (!javaSignature.equals(typescriptSignature.subList(0, javaSignature.size()))) return false;
         return typescriptSignature.subList(javaSignature.size(), typescriptSignature.size()).stream()
-                .allMatch(field -> field.startsWith("optional<")
-                        || field.startsWith("{\"type\":\"optional\""));
+                .allMatch(field -> field.startsWith("optional<") || field.startsWith("{\"type\":\"optional\""));
     }
 
     private JsonObject exemption(
@@ -177,8 +186,8 @@ final class PacketContractCatalogGenerator {
         if (javaPacket.unsupportedReason() != null) reasons.add("Java analyzer: " + javaPacket.unsupportedReason());
         if (tsPacket.unsupportedReason() != null) reasons.add("TypeScript analyzer: " + tsPacket.unsupportedReason());
         if (reasons.isEmpty()) {
-            reasons.add("Pre-existing wire mismatch requires runtime protocol decision: Java "
-                    + javaSignature + " versus TypeScript " + tsSignature);
+            reasons.add("Pre-existing wire mismatch requires runtime protocol decision: Java " + javaSignature
+                    + " versus TypeScript " + tsSignature);
         }
         result.addProperty("reason", String.join("; ", reasons));
         return result;
@@ -216,10 +225,12 @@ final class PacketContractCatalogGenerator {
 
     private String signature(WireSchema schema) {
         if (schema instanceof ScalarSchema scalar) return scalar.type();
-        if (schema instanceof ListSchema list) return "list<" + list.countType() + ":"
-                + list.item().stream().map(this::signature).toList() + ">";
-        if (schema instanceof OptionalSchema optional) return "optional<" + optional.controller() + ":"
-                + optional.fields().stream().map(this::signature).toList() + ">";
+        if (schema instanceof ListSchema list)
+            return "list<" + list.countType() + ":"
+                    + list.item().stream().map(this::signature).toList() + ">";
+        if (schema instanceof OptionalSchema optional)
+            return "optional<" + optional.controller() + ":"
+                    + optional.fields().stream().map(this::signature).toList() + ">";
         VariantSchema variant = (VariantSchema) schema;
         return "variant<" + variant.discriminator() + ":" + variant.branches() + ">";
     }
@@ -301,7 +312,8 @@ final class PacketContractCatalogGenerator {
     }
 
     private String relative(Path source) {
-        return repositoryRoot.relativize(source.toAbsolutePath().normalize())
+        return repositoryRoot
+                .relativize(source.toAbsolutePath().normalize())
                 .toString()
                 .replace('\\', '/');
     }

--- a/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketContractManifest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketContractManifest.java
@@ -2,8 +2,7 @@ package com.eu.habbo.messages.contracts;
 
 import java.util.List;
 
-record PacketEndpoint(String symbol, String className, String path) {
-}
+record PacketEndpoint(String symbol, String className, String path) {}
 
 record PacketContract(
         String name,
@@ -17,26 +16,50 @@ record PacketContract(
     }
 }
 
-record UnpairedPacket(
-        String direction,
-        String side,
-        int header,
-        String symbol,
-        String path,
-        String reason) {
-}
+record UnpairedPacket(String direction, String side, int header, String symbol, String path, String reason) {}
 
 record PacketExemption(
-        String name,
-        String direction,
-        int header,
-        PacketEndpoint java,
-        PacketEndpoint typescript,
-        String reason) {
+        String name, String direction, int header, PacketEndpoint java, PacketEndpoint typescript, String reason) {}
+
+record PacketMetadata(String range, String origin, String feature, String stability) {}
+
+record PacketRegistryDefaults(String origin, String stability) {}
+
+record PacketHeaderRange(
+        String name, String direction, int start, int end, String origin, String feature, String stability) {}
+
+record PacketAlias(String side, String direction, int header, String canonical, List<String> aliases, String reason) {
+    PacketAlias {
+        aliases = List.copyOf(aliases);
+    }
+}
+
+record UnsupportedPacket(String side, String direction, String symbol, String reason) {}
+
+record PacketRegistryPolicy(
+        PacketRegistryDefaults defaults,
+        List<PacketHeaderRange> ranges,
+        List<PacketAlias> aliases,
+        List<UnsupportedPacket> unsupported) {
+    PacketRegistryPolicy {
+        ranges = List.copyOf(ranges);
+        aliases = List.copyOf(aliases);
+        unsupported = List.copyOf(unsupported);
+    }
+
+    PacketMetadata metadataFor(String direction, int header) {
+        return ranges.stream()
+                .filter(range ->
+                        range.direction().equals(direction) && header >= range.start() && header <= range.end())
+                .findFirst()
+                .map(range -> new PacketMetadata(range.name(), range.origin(), range.feature(), range.stability()))
+                .orElseGet(() -> new PacketMetadata("", defaults.origin(), "", defaults.stability()));
+    }
 }
 
 record PacketContractManifest(
         int schemaVersion,
+        PacketRegistryPolicy registry,
         List<PacketContract> contracts,
         List<UnpairedPacket> unpaired,
         List<PacketExemption> exemptions) {

--- a/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketContractManifestLoader.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketContractManifestLoader.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -19,10 +18,12 @@ import java.util.Set;
 final class PacketContractManifestLoader {
     private static final Set<String> DIRECTIONS = Set.of("client_to_server", "server_to_client");
     private static final Set<String> SIDES = Set.of("java", "typescript");
-    private static final Set<String> SCALAR_TYPES = Set.of(
-            "byte", "short", "int", "long", "boolean", "string", "bytes");
-    private static final Set<String> VAGUE_REASONS = Set.of(
-            "complex packet", "dynamic packet", "unsupported packet", "legacy packet");
+    private static final Set<String> ORIGINS = Set.of("official", "custom");
+    private static final Set<String> STABILITIES = Set.of("stable", "experimental", "deprecated");
+    private static final Set<String> SCALAR_TYPES =
+            Set.of("byte", "short", "int", "long", "boolean", "string", "bytes");
+    private static final Set<String> VAGUE_REASONS =
+            Set.of("complex packet", "dynamic packet", "unsupported packet", "legacy packet");
 
     PacketContractManifest load(Path path) throws IOException {
         return parse(Files.readString(path, StandardCharsets.UTF_8));
@@ -31,15 +32,147 @@ final class PacketContractManifestLoader {
     PacketContractManifest parse(String json) {
         JsonObject root = JsonParser.parseString(json).getAsJsonObject();
         int schemaVersion = requiredInt(root, "schemaVersion", "manifest");
-        if (schemaVersion != 1) {
-            throw new IllegalArgumentException("Expected packet contract schemaVersion 1 but found " + schemaVersion);
+        if (schemaVersion != 2) {
+            throw new IllegalArgumentException("Expected packet contract schemaVersion 2 but found " + schemaVersion);
         }
 
+        PacketRegistryPolicy registry = parseRegistry(requiredObject(root, "registry", "manifest"));
         List<PacketContract> contracts = parseContracts(requiredArray(root, "contracts", "manifest"));
         List<UnpairedPacket> unpaired = parseUnpaired(requiredArray(root, "unpaired", "manifest"));
         List<PacketExemption> exemptions = parseExemptions(requiredArray(root, "exemptions", "manifest"));
         validateUniqueClassifications(contracts, unpaired, exemptions);
-        return new PacketContractManifest(schemaVersion, contracts, unpaired, exemptions);
+        validateAliasClassifications(registry, contracts, unpaired, exemptions);
+        return new PacketContractManifest(schemaVersion, registry, contracts, unpaired, exemptions);
+    }
+
+    private static PacketRegistryPolicy parseRegistry(JsonObject object) {
+        JsonObject defaultsObject = requiredObject(object, "defaults", "registry");
+        PacketRegistryDefaults defaults = new PacketRegistryDefaults(
+                origin(defaultsObject, "registry defaults"), stability(defaultsObject, "registry defaults"));
+
+        List<PacketHeaderRange> ranges = new ArrayList<>();
+        for (JsonElement value : requiredArray(object, "ranges", "registry")) {
+            JsonObject range = value.getAsJsonObject();
+            String name = requiredString(range, "name", "registry range");
+            int start = positiveInt(range, "start", "registry range " + name);
+            int end = positiveInt(range, "end", "registry range " + name);
+            if (end < start) throw new IllegalArgumentException("registry range " + name + " ends before it starts");
+            ranges.add(new PacketHeaderRange(
+                    name,
+                    direction(range, "registry range " + name),
+                    start,
+                    end,
+                    origin(range, "registry range " + name),
+                    requiredString(range, "feature", "registry range " + name),
+                    stability(range, "registry range " + name)));
+        }
+        validateRanges(ranges);
+
+        List<PacketAlias> aliases = new ArrayList<>();
+        for (JsonElement value : requiredArray(object, "aliases", "registry")) {
+            JsonObject alias = value.getAsJsonObject();
+            String canonical = requiredString(alias, "canonical", "packet alias");
+            List<String> symbols = stringList(
+                    requiredArray(alias, "aliases", "packet alias " + canonical), "packet alias " + canonical);
+            if (symbols.isEmpty())
+                throw new IllegalArgumentException("packet alias " + canonical + " requires aliases");
+            if (symbols.contains(canonical) || new HashSet<>(symbols).size() != symbols.size()) {
+                throw new IllegalArgumentException("packet alias " + canonical + " contains duplicate symbols");
+            }
+            aliases.add(new PacketAlias(
+                    side(alias, "packet alias " + canonical),
+                    direction(alias, "packet alias " + canonical),
+                    positiveHeader(alias, "packet alias " + canonical),
+                    canonical,
+                    symbols,
+                    concreteReason(alias, "packet alias " + canonical)));
+        }
+
+        List<UnsupportedPacket> unsupported = new ArrayList<>();
+        Set<String> unsupportedKeys = new HashSet<>();
+        for (JsonElement value : requiredArray(object, "unsupported", "registry")) {
+            JsonObject packet = value.getAsJsonObject();
+            String symbol = requiredString(packet, "symbol", "unsupported packet");
+            UnsupportedPacket entry = new UnsupportedPacket(
+                    side(packet, "unsupported packet " + symbol),
+                    direction(packet, "unsupported packet " + symbol),
+                    symbol,
+                    concreteReason(packet, "unsupported packet " + symbol));
+            String key = entry.side() + ':' + entry.direction() + ':' + entry.symbol();
+            if (!unsupportedKeys.add(key)) throw new IllegalArgumentException("duplicate unsupported packet " + key);
+            unsupported.add(entry);
+        }
+        return new PacketRegistryPolicy(defaults, ranges, aliases, unsupported);
+    }
+
+    private static void validateRanges(List<PacketHeaderRange> ranges) {
+        Set<String> names = new HashSet<>();
+        for (PacketHeaderRange range : ranges) {
+            if (!names.add(range.name()))
+                throw new IllegalArgumentException("duplicate registry range " + range.name());
+        }
+        for (int left = 0; left < ranges.size(); left++) {
+            for (int right = left + 1; right < ranges.size(); right++) {
+                PacketHeaderRange first = ranges.get(left);
+                PacketHeaderRange second = ranges.get(right);
+                if (!first.direction().equals(second.direction())) continue;
+                if (first.start() <= second.end() && second.start() <= first.end()) {
+                    throw new IllegalArgumentException("overlapping " + first.direction() + " registry ranges "
+                            + first.name() + " and " + second.name());
+                }
+            }
+        }
+    }
+
+    private static void validateAliasClassifications(
+            PacketRegistryPolicy registry,
+            List<PacketContract> contracts,
+            List<UnpairedPacket> unpaired,
+            List<PacketExemption> exemptions) {
+        Set<String> classified = new HashSet<>();
+        contracts.forEach(packet -> classified.add(packet.direction() + ':' + packet.header()));
+        unpaired.forEach(packet -> classified.add(packet.direction() + ':' + packet.header()));
+        exemptions.forEach(packet -> classified.add(packet.direction() + ':' + packet.header()));
+        for (PacketAlias alias : registry.aliases()) {
+            String key = alias.direction() + ':' + alias.header();
+            if (!classified.contains(key)) {
+                throw new IllegalArgumentException("alias header " + key + " is not classified");
+            }
+        }
+    }
+
+    private static String origin(JsonObject object, String context) {
+        String origin = requiredString(object, "origin", context);
+        if (!ORIGINS.contains(origin)) throw new IllegalArgumentException(context + " has unknown origin " + origin);
+        return origin;
+    }
+
+    private static String stability(JsonObject object, String context) {
+        String stability = requiredString(object, "stability", context);
+        if (!STABILITIES.contains(stability)) {
+            throw new IllegalArgumentException(context + " has unknown stability " + stability);
+        }
+        return stability;
+    }
+
+    private static String side(JsonObject object, String context) {
+        String side = requiredString(object, "side", context);
+        if (!SIDES.contains(side)) throw new IllegalArgumentException(context + " has unknown side " + side);
+        return side;
+    }
+
+    private static List<String> stringList(JsonArray values, String context) {
+        List<String> result = new ArrayList<>();
+        for (int index = 0; index < values.size(); index++) {
+            JsonElement value = values.get(index);
+            if (!value.isJsonPrimitive() || !value.getAsJsonPrimitive().isString()) {
+                throw new IllegalArgumentException(context + " requires string at index " + index);
+            }
+            String symbol = value.getAsString().strip();
+            if (symbol.isEmpty()) throw new IllegalArgumentException(context + " requires non-empty symbol");
+            result.add(symbol);
+        }
+        return result;
     }
 
     private static List<PacketContract> parseContracts(JsonArray values) {
@@ -117,12 +250,12 @@ final class PacketContractManifestLoader {
                 String countType = requiredString(object, "countType", context);
                 validateScalarType(countType, context + " countType");
                 yield new ListSchema(
-                        countType,
-                        parseSchemas(requiredArray(object, "item", context), context + ".list.item"));
+                        countType, parseSchemas(requiredArray(object, "item", context), context + ".list.item"));
             }
-            case "optional" -> new OptionalSchema(
-                    requiredString(object, "controller", context),
-                    parseSchemas(requiredArray(object, "fields", context), context + ".optional.fields"));
+            case "optional" ->
+                new OptionalSchema(
+                        requiredString(object, "controller", context),
+                        parseSchemas(requiredArray(object, "fields", context), context + ".optional.fields"));
             case "variant" -> {
                 String discriminator = requiredString(object, "discriminator", context);
                 JsonObject branchesObject = requiredObject(object, "branches", context);
@@ -164,7 +297,12 @@ final class PacketContractManifestLoader {
     }
 
     private static int positiveHeader(JsonObject object, String context) {
-        int header = requiredInt(object, "header", context);
+        int header = positiveInt(object, "header", context);
+        return header;
+    }
+
+    private static int positiveInt(JsonObject object, String key, String context) {
+        int header = requiredInt(object, key, context);
         if (header <= 0) throw new IllegalArgumentException(context + " header must be positive");
         return header;
     }
@@ -178,9 +316,7 @@ final class PacketContractManifestLoader {
     }
 
     private static void validateUniqueClassifications(
-            List<PacketContract> contracts,
-            List<UnpairedPacket> unpaired,
-            List<PacketExemption> exemptions) {
+            List<PacketContract> contracts, List<UnpairedPacket> unpaired, List<PacketExemption> exemptions) {
         Set<String> seen = new HashSet<>();
         for (PacketContract contract : contracts) addClassification(seen, contract.direction(), contract.header());
         for (UnpairedPacket packet : unpaired) addClassification(seen, packet.direction(), packet.header());
@@ -214,7 +350,9 @@ final class PacketContractManifestLoader {
 
     private static String requiredString(JsonObject object, String key, String context) {
         JsonElement value = object.get(key);
-        if (value == null || !value.isJsonPrimitive() || !value.getAsJsonPrimitive().isString()) {
+        if (value == null
+                || !value.isJsonPrimitive()
+                || !value.getAsJsonPrimitive().isString()) {
             throw new IllegalArgumentException(context + " requires string " + key);
         }
         String result = value.getAsString().strip();
@@ -229,7 +367,9 @@ final class PacketContractManifestLoader {
 
     private static int requiredInt(JsonObject object, String key, String context) {
         JsonElement value = object.get(key);
-        if (value == null || !value.isJsonPrimitive() || !value.getAsJsonPrimitive().isNumber()) {
+        if (value == null
+                || !value.isJsonPrimitive()
+                || !value.getAsJsonPrimitive().isNumber()) {
             throw new IllegalArgumentException(context + " requires integer " + key);
         }
         try {

--- a/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketContractManifestLoaderTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketContractManifestLoaderTest.java
@@ -1,10 +1,10 @@
 package com.eu.habbo.messages.contracts;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 class PacketContractManifestLoaderTest {
     private final PacketContractManifestLoader loader = new PacketContractManifestLoader();
@@ -13,7 +13,8 @@ class PacketContractManifestLoaderTest {
     void loadsScalarAndStructuredWireSchemas() {
         PacketContractManifest manifest = loader.parse("""
                 {
-                  "schemaVersion": 1,
+                  "schemaVersion": 2,
+                  "registry": {"defaults":{"origin":"official","stability":"stable"},"ranges":[],"aliases":[],"unsupported":[]},
                   "contracts": [{
                     "name": "FIXTURE",
                     "direction": "client_to_server",
@@ -32,7 +33,7 @@ class PacketContractManifestLoaderTest {
                 }
                 """);
 
-        assertEquals(1, manifest.schemaVersion());
+        assertEquals(2, manifest.schemaVersion());
         assertEquals(1, manifest.contracts().size());
         assertEquals(4, manifest.contracts().getFirst().fields().size());
         assertTrue(manifest.contracts().getFirst().fields().get(0) instanceof ScalarSchema);
@@ -42,21 +43,91 @@ class PacketContractManifestLoaderTest {
     }
 
     @Test
-    void rejectsUnsupportedSchemaVersion() {
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
-                () -> loader.parse(emptyManifest(2)));
+    void loadsRegistryMetadataAndResolvesCustomRanges() {
+        PacketContractManifest manifest = loader.parse("""
+                {
+                  "schemaVersion": 2,
+                  "registry": {
+                    "defaults": {"origin":"official","stability":"stable"},
+                    "ranges": [{
+                      "name":"catalog_tools","direction":"client_to_server","start":10000,"end":10099,
+                      "origin":"custom","feature":"catalog_studio","stability":"stable"
+                    }],
+                    "aliases": [{
+                      "side":"typescript","direction":"client_to_server","header":10050,
+                      "canonical":"CATALOG_SAVE","aliases":["LEGACY_CATALOG_SAVE"],
+                      "reason":"Legacy public symbol retained for renderer source compatibility"
+                    }],
+                    "unsupported": [{
+                      "side":"java","direction":"server_to_client","symbol":"UnknownComposer",
+                      "reason":"Wire header is not known for the supported client revision"
+                    }]
+                  },
+                  "contracts": [],
+                  "unpaired": [{
+                    "direction":"client_to_server","side":"typescript","header":10050,
+                    "symbol":"CATALOG_SAVE","path":"CatalogSave.ts",
+                    "reason":"Only the renderer exposes this catalog administration packet"
+                  }],
+                  "exemptions": []
+                }
+                """);
 
-        assertTrue(error.getMessage().contains("schemaVersion 1"));
+        PacketMetadata official = manifest.registry().metadataFor("server_to_client", 400);
+        PacketMetadata custom = manifest.registry().metadataFor("client_to_server", 10050);
+
+        assertEquals("official", official.origin());
+        assertEquals("stable", official.stability());
+        assertEquals("catalog_tools", custom.range());
+        assertEquals("custom", custom.origin());
+        assertEquals("catalog_studio", custom.feature());
+        assertEquals(1, manifest.registry().aliases().size());
+        assertEquals(1, manifest.registry().unsupported().size());
+    }
+
+    @Test
+    void rejectsOverlappingRegistryRangesInTheSameDirection() {
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> loader.parse(registryManifest("""
+                        [
+                          {"name":"one","direction":"client_to_server","start":9300,"end":9399,
+                           "origin":"custom","feature":"one","stability":"stable"},
+                          {"name":"two","direction":"client_to_server","start":9350,"end":9450,
+                           "origin":"custom","feature":"two","stability":"experimental"}
+                        ]
+                        """, "[]")));
+
+        assertTrue(error.getMessage().contains("overlapping client_to_server registry ranges"));
+    }
+
+    @Test
+    void rejectsAliasesWhoseHeaderIsNotClassified() {
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> loader.parse(registryManifest("[]", """
+                        [{
+                          "side":"typescript","direction":"server_to_client","header":9999,
+                          "canonical":"CANONICAL","aliases":["COMPATIBILITY"],
+                          "reason":"Compatibility name retained for existing renderer integrations"
+                        }]
+                        """)));
+
+        assertTrue(error.getMessage().contains("alias header server_to_client:9999 is not classified"));
+    }
+
+    @Test
+    void rejectsUnsupportedSchemaVersion() {
+        IllegalArgumentException error =
+                assertThrows(IllegalArgumentException.class, () -> loader.parse(emptyManifest(3)));
+
+        assertTrue(error.getMessage().contains("schemaVersion 2"));
     }
 
     @Test
     void rejectsDuplicateDirectionalHeaderClassification() {
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
-                () -> loader.parse("""
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () -> loader.parse("""
                         {
-                          "schemaVersion": 1,
+                          "schemaVersion": 2,
+                          "registry": {"defaults":{"origin":"official","stability":"stable"},"ranges":[],"aliases":[],"unsupported":[]},
                           "contracts": [{
                             "name":"ONE","direction":"server_to_client","header":4900,
                             "java":{"symbol":"One","className":"One","path":"One.java"},
@@ -76,11 +147,10 @@ class PacketContractManifestLoaderTest {
 
     @Test
     void rejectsUnknownScalarType() {
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
-                () -> loader.parse("""
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () -> loader.parse("""
                         {
-                          "schemaVersion": 1,
+                          "schemaVersion": 2,
+                          "registry": {"defaults":{"origin":"official","stability":"stable"},"ranges":[],"aliases":[],"unsupported":[]},
                           "contracts": [{
                             "name":"ONE","direction":"server_to_client","header":1,
                             "java":{"symbol":"One","className":"One","path":"One.java"},
@@ -97,11 +167,10 @@ class PacketContractManifestLoaderTest {
 
     @Test
     void rejectsVagueExemptionReason() {
-        IllegalArgumentException error = assertThrows(
-                IllegalArgumentException.class,
-                () -> loader.parse("""
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, () -> loader.parse("""
                         {
-                          "schemaVersion": 1,
+                          "schemaVersion": 2,
+                          "registry": {"defaults":{"origin":"official","stability":"stable"},"ranges":[],"aliases":[],"unsupported":[]},
                           "contracts": [],
                           "unpaired": [],
                           "exemptions": [{
@@ -118,7 +187,24 @@ class PacketContractManifestLoaderTest {
 
     private static String emptyManifest(int version) {
         return """
-                {"schemaVersion": %d, "contracts": [], "unpaired": [], "exemptions": []}
+                {"schemaVersion": %d,
+                 "registry":{"defaults":{"origin":"official","stability":"stable"},"ranges":[],"aliases":[],"unsupported":[]},
+                 "contracts": [], "unpaired": [], "exemptions": []}
                 """.formatted(version);
+    }
+
+    private static String registryManifest(String ranges, String aliases) {
+        return """
+                {
+                  "schemaVersion":2,
+                  "registry":{
+                    "defaults":{"origin":"official","stability":"stable"},
+                    "ranges":%s,
+                    "aliases":%s,
+                    "unsupported":[]
+                  },
+                  "contracts":[],"unpaired":[],"exemptions":[]
+                }
+                """.formatted(ranges, aliases);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketRegistryPolicyContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/contracts/PacketRegistryPolicyContractTest.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.messages.contracts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.eu.habbo.messages.incoming.UnsupportedIncoming;
+import com.eu.habbo.messages.outgoing.UnsupportedOutgoing;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class PacketRegistryPolicyContractTest {
+    private final Path repositoryRoot = Path.of("..").toAbsolutePath().normalize();
+
+    @Test
+    void keepsUnsupportedJavaHeadersSynchronizedWithTheSharedPolicy() throws Exception {
+        PacketContractManifest manifest =
+                new PacketContractManifestLoader().load(repositoryRoot.resolve("protocol/packet-field-contracts.json"));
+        Set<String> expected = manifest.registry().unsupported().stream()
+                .filter(packet -> packet.side().equals("java"))
+                .map(packet -> packet.direction() + ':' + packet.symbol())
+                .collect(Collectors.toSet());
+        Set<String> actual = Stream.concat(
+                        unsupported("client_to_server", UnsupportedIncoming.class),
+                        unsupported("server_to_client", UnsupportedOutgoing.class))
+                .collect(Collectors.toSet());
+
+        assertEquals(expected, actual);
+    }
+
+    private static Stream<String> unsupported(String direction, Class<?> registry) {
+        return Stream.of(registry.getDeclaredFields())
+                .filter(field -> Modifier.isPublic(field.getModifiers()) && Modifier.isStatic(field.getModifiers()))
+                .peek(PacketRegistryPolicyContractTest::requireUnsupportedValue)
+                .map(Field::getName)
+                .map(symbol -> direction + ':' + symbol);
+    }
+
+    private static void requireUnsupportedValue(Field field) {
+        try {
+            if (field.getInt(null) != -1) {
+                throw new AssertionError(field.getDeclaringClass().getSimpleName() + '.' + field.getName()
+                        + " must remain an unsupported -1 placeholder");
+            }
+        } catch (IllegalAccessException exception) {
+            throw new AssertionError("Cannot read unsupported packet header " + field.getName(), exception);
+        }
+    }
+}

--- a/protocol/packet-field-contracts.json
+++ b/protocol/packet-field-contracts.json
@@ -1,5 +1,436 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "registry": {
+    "defaults": {
+      "origin": "official",
+      "stability": "stable"
+    },
+    "ranges": [
+      {
+        "name": "mentions_client",
+        "direction": "client_to_server",
+        "start": 4800,
+        "end": 4899,
+        "origin": "custom",
+        "feature": "mentions",
+        "stability": "stable"
+      },
+      {
+        "name": "messenger_client",
+        "direction": "client_to_server",
+        "start": 4900,
+        "end": 4999,
+        "origin": "custom",
+        "feature": "messenger",
+        "stability": "stable"
+      },
+      {
+        "name": "custom_gameplay_client",
+        "direction": "client_to_server",
+        "start": 6000,
+        "end": 6099,
+        "origin": "custom",
+        "feature": "custom_gameplay",
+        "stability": "stable"
+      },
+      {
+        "name": "social_client",
+        "direction": "client_to_server",
+        "start": 7000,
+        "end": 7099,
+        "origin": "custom",
+        "feature": "social_extensions",
+        "stability": "stable"
+      },
+      {
+        "name": "youtube_client",
+        "direction": "client_to_server",
+        "start": 8000,
+        "end": 8099,
+        "origin": "custom",
+        "feature": "youtube_room",
+        "stability": "stable"
+      },
+      {
+        "name": "housekeeping_client",
+        "direction": "client_to_server",
+        "start": 9100,
+        "end": 9199,
+        "origin": "custom",
+        "feature": "housekeeping",
+        "stability": "stable"
+      },
+      {
+        "name": "custom_features_client",
+        "direction": "client_to_server",
+        "start": 9300,
+        "end": 9399,
+        "origin": "custom",
+        "feature": "custom_features",
+        "stability": "stable"
+      },
+      {
+        "name": "custom_features_high_client",
+        "direction": "client_to_server",
+        "start": 9400,
+        "end": 9499,
+        "origin": "custom",
+        "feature": "custom_features",
+        "stability": "stable"
+      },
+      {
+        "name": "catalog_tools_client",
+        "direction": "client_to_server",
+        "start": 10000,
+        "end": 10099,
+        "origin": "custom",
+        "feature": "catalog_tools",
+        "stability": "stable"
+      },
+      {
+        "name": "mentions_server",
+        "direction": "server_to_client",
+        "start": 4800,
+        "end": 4899,
+        "origin": "custom",
+        "feature": "mentions",
+        "stability": "stable"
+      },
+      {
+        "name": "messenger_server",
+        "direction": "server_to_client",
+        "start": 4900,
+        "end": 4999,
+        "origin": "custom",
+        "feature": "messenger",
+        "stability": "stable"
+      },
+      {
+        "name": "snowwar_server",
+        "direction": "server_to_client",
+        "start": 5000,
+        "end": 5099,
+        "origin": "custom",
+        "feature": "snowwar",
+        "stability": "stable"
+      },
+      {
+        "name": "custom_gameplay_server",
+        "direction": "server_to_client",
+        "start": 6000,
+        "end": 6099,
+        "origin": "custom",
+        "feature": "custom_gameplay",
+        "stability": "stable"
+      },
+      {
+        "name": "social_server",
+        "direction": "server_to_client",
+        "start": 7000,
+        "end": 7099,
+        "origin": "custom",
+        "feature": "social_extensions",
+        "stability": "stable"
+      },
+      {
+        "name": "youtube_server",
+        "direction": "server_to_client",
+        "start": 8000,
+        "end": 8099,
+        "origin": "custom",
+        "feature": "youtube_room",
+        "stability": "stable"
+      },
+      {
+        "name": "housekeeping_server",
+        "direction": "server_to_client",
+        "start": 9200,
+        "end": 9299,
+        "origin": "custom",
+        "feature": "housekeeping",
+        "stability": "stable"
+      },
+      {
+        "name": "custom_features_server",
+        "direction": "server_to_client",
+        "start": 9300,
+        "end": 9399,
+        "origin": "custom",
+        "feature": "custom_features",
+        "stability": "stable"
+      },
+      {
+        "name": "custom_features_high_server",
+        "direction": "server_to_client",
+        "start": 9400,
+        "end": 9499,
+        "origin": "custom",
+        "feature": "custom_features",
+        "stability": "stable"
+      },
+      {
+        "name": "catalog_tools_server",
+        "direction": "server_to_client",
+        "start": 10000,
+        "end": 10099,
+        "origin": "custom",
+        "feature": "catalog_tools",
+        "stability": "stable"
+      }
+    ],
+    "aliases": [
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 233,
+        "canonical": "USER_BOT_REMOVE",
+        "aliases": [
+          "REMOVE_BOT_FROM_INVENTORY"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 286,
+        "canonical": "DESKTOP_NEWS",
+        "aliases": [
+          "PROMO_ARTICLES"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 340,
+        "canonical": "USER_EFFECTS",
+        "aliases": [
+          "USER_EFFECT_LIST"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 826,
+        "canonical": "ROOM_MUTE_USER",
+        "aliases": [
+          "REMAINING_MUTE"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 892,
+        "canonical": "MESSENGER_MESSAGE_ERROR",
+        "aliases": [
+          "MESSENGER_REQUEST_ERROR"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 1452,
+        "canonical": "BUILDERS_CLUB_EXPIRED",
+        "aliases": [
+          "BUILDERS_CLUB_SUBSCRIPTION"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 1651,
+        "canonical": "MODERATION_REPORT_DISABLED",
+        "aliases": [
+          "CFH_DISABLED_NOTIFY"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 1745,
+        "canonical": "DESKTOP_CAMPAIGN",
+        "aliases": [
+          "COMPETITION_TIMING_CODE"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 2064,
+        "canonical": "NAVIGATOR_OPEN_ROOM_CREATOR",
+        "aliases": [
+          "COMPETITION_NO_OWNED_ROOMS"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "header": 3315,
+        "canonical": "USER_OUTFITS",
+        "aliases": [
+          "USER_WARDROBE_PAGE"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "client_to_server",
+        "header": 168,
+        "canonical": "FURNITURE_WALL_UPDATE",
+        "aliases": [
+          "ITEM_WALL_UPDATE"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "client_to_server",
+        "header": 210,
+        "canonical": "FURNITURE_WALL_MULTISTATE",
+        "aliases": [
+          "ITEM_WALL_CLICK"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "client_to_server",
+        "header": 1036,
+        "canonical": "PET_RIDE",
+        "aliases": [
+          "PET_MOUNT"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      },
+      {
+        "side": "typescript",
+        "direction": "client_to_server",
+        "header": 1827,
+        "canonical": "DESKTOP_NEWS",
+        "aliases": [
+          "GET_PROMO_ARTICLES"
+        ],
+        "reason": "Legacy semantic name retained for renderer source compatibility"
+      }
+    ],
+    "unsupported": [
+      {
+        "side": "java",
+        "direction": "client_to_server",
+        "symbol": "ModToolWarnEvent",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "client_to_server",
+        "symbol": "ModToolBanEvent",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "client_to_server",
+        "symbol": "SearchRoomsByTagEvent",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "client_to_server",
+        "symbol": "ModToolRequestRoomUserChatlogEvent",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "client_to_server",
+        "symbol": "RequestAchievementConfigurationEvent",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "client_to_server",
+        "symbol": "HotelViewClaimBadgeRewardEvent",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "PublicRoomsComposer",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "RemoveFriendComposer",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "RoomEntryInfoComposer",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "UserBCLimitsComposer",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "QuestionInfoComposer",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "UnknownGuildForumComposer6",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "UnknownGuildForumComposer7",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "RoomUserQuestionAnsweredComposer",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "HotelViewCustomTimerComposer",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "java",
+        "direction": "server_to_client",
+        "symbol": "InventoryAddEffectComposer",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "typescript",
+        "direction": "server_to_client",
+        "symbol": "AUTHENTICATION",
+        "reason": "Wire header is not known for the supported client revision"
+      },
+      {
+        "side": "typescript",
+        "direction": "client_to_server",
+        "symbol": "AUTHENTICATION",
+        "reason": "Wire header is not known for the supported client revision"
+      }
+    ]
+  },
   "contracts": [
     {
       "name": "GAME2GETACCOUNTGAMESTATUSMESSAGE",
@@ -16261,6 +16692,14 @@
   ],
   "unpaired": [
     {
+      "direction": "server_to_client",
+      "side": "typescript",
+      "header": 9350,
+      "symbol": "BUILD_HEIGHT_AVAILABLE",
+      "path": "packages/communication/src/messages/parser/room/furniture/BuildHeightAvailableParser.ts",
+      "reason": "Header is registered only by the Nitro Renderer packet registry"
+    },
+    {
       "direction": "client_to_server",
       "side": "java",
       "header": 295,
@@ -17739,14 +18178,6 @@
       "symbol": "FIREWORK_CHARGE_DATA",
       "path": "packages/communication/src/messages/parser/catalog/FireworkChargeDataParser.ts",
       "reason": "Header is registered only by the Nitro Renderer packet registry"
-    },
-    {
-      "direction": "server_to_client",
-      "side": "typescript",
-      "header": 9350,
-      "symbol": "BUILD_HEIGHT_AVAILABLE",
-      "path": "packages/communication/src/messages/parser/room/furniture/BuildHeightAvailableParser.ts",
-      "reason": "Header is registered only by the Nitro Renderer packet registry"
     }
   ],
   "exemptions": [
@@ -18116,7 +18547,7 @@
         "className": "RoomUnitChatWhisperComposer",
         "path": "packages/communication/src/messages/outgoing/room/unit/chat/RoomUnitChatWhisperComposer.ts"
       },
-      "reason": "Java analyzer: Packet fields delegated to external constructor RoomChatMessage inside handle; TypeScript analyzer: Outgoing value recipientName + \u0027 \u0027 + message has no statically resolvable wire type"
+      "reason": "Java analyzer: Packet fields delegated to external constructor RoomChatMessage inside handle; TypeScript analyzer: Outgoing value recipientName + ' ' + message has no statically resolvable wire type"
     },
     {
       "name": "RELEASE_ISSUES",
@@ -19044,7 +19475,7 @@
         "className": "ClientHelloMessageComposer",
         "path": "packages/communication/src/messages/outgoing/handshake/ClientHelloMessageComposer.ts"
       },
-      "reason": "TypeScript analyzer: Outgoing value `NITRO-${NitroVersion.RENDERER_VERSION.replaceAll(\u0027.\u0027, \u0027-\u0027)}` has no statically resolvable wire type"
+      "reason": "TypeScript analyzer: Outgoing value `NITRO-${NitroVersion.RENDERER_VERSION.replaceAll('.', '-')}` has no statically resolvable wire type"
     },
     {
       "name": "SNOWWAR_LOAD_STAGE_READY",


### PR DESCRIPTION
## Summary
- introduce schema v2 registry policy with reserved custom ranges, explicit aliases, and unsupported placeholders
- reject duplicate or non-positive active packet declarations
- preserve public packet fields as deprecated ABI aliases for existing plugin jars
- keep the shared manifest byte-identical with the Nitro Renderer
- preserve every positive wire ID

## Why
The packet registry mixed active headers, unsupported -1 placeholders, and duplicate numeric declarations. This made collisions and cross-project drift difficult to detect while moving fields outright would break plugin binary compatibility. The new policy separates these concerns and validates them automatically.

## Validation
- `./mvnw verify`
- full unit suite, packaging, Spotless, and SpotBugs passed
- 13 Docker-backed integration tests were skipped because Docker is unavailable

Companion Renderer PR: https://github.com/duckietm/Nitro_Render_V3/pull/165