### PR TITLE
Harden housekeeping rank decisions

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingRankPolicy.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingRankPolicy.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.messages.incoming.housekeeping;
+
+final class HousekeepingRankPolicy {
+    private HousekeepingRankPolicy() {}
+
+    static Decision evaluate(int operatorRankId, int targetRankId, int highestConfiguredRankId) {
+        if (operatorRankId <= 0 || targetRankId <= 0 || highestConfiguredRankId <= 0) {
+            return new Decision(false, Reason.INVALID_RANK_CONTEXT);
+        }
+
+        if (targetRankId < operatorRankId) {
+            return new Decision(true, Reason.ALLOWED_LOWER_RANK);
+        }
+
+        if (operatorRankId >= highestConfiguredRankId && targetRankId <= operatorRankId) {
+            return new Decision(true, Reason.ALLOWED_CORE_PEER);
+        }
+
+        return new Decision(false, Reason.TARGET_NOT_LOWER);
+    }
+
+    enum Reason {
+        ALLOWED_LOWER_RANK,
+        ALLOWED_CORE_PEER,
+        INVALID_RANK_CONTEXT,
+        TARGET_NOT_LOWER
+    }
+
+    record Decision(boolean allowed, Reason reason) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingTargetRankGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingTargetRankGuard.java
@@ -4,10 +4,13 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.permissions.Rank;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class HousekeepingTargetRankGuard {
-    private HousekeepingTargetRankGuard() {
-    }
+    private static final Logger LOGGER = LoggerFactory.getLogger(HousekeepingTargetRankGuard.class);
+
+    private HousekeepingTargetRankGuard() {}
 
     static boolean canTargetUser(Habbo operator, int targetUserId) {
         if (operator == null || targetUserId <= 0) {
@@ -19,7 +22,24 @@ final class HousekeepingTargetRankGuard {
             return true;
         }
 
-        return canTargetRank(operator, targetInfo.getRank().getId());
+        int operatorRankId = operator.getHabboInfo().getRank().getId();
+        int targetRankId = targetInfo.getRank().getId();
+        int highestConfiguredRankId = highestConfiguredRankId();
+        HousekeepingRankPolicy.Decision decision =
+                HousekeepingRankPolicy.evaluate(operatorRankId, targetRankId, highestConfiguredRankId);
+
+        if (!decision.allowed()) {
+            LOGGER.warn(
+                    "Housekeeping target rejected: operatorUserId={}, targetUserId={}, operatorRankId={}, targetRankId={}, highestConfiguredRankId={}, reason={}",
+                    operator.getHabboInfo().getId(),
+                    targetUserId,
+                    operatorRankId,
+                    targetRankId,
+                    highestConfiguredRankId,
+                    decision.reason());
+        }
+
+        return decision.allowed();
     }
 
     static boolean canTargetRank(Habbo operator, int targetRankId) {
@@ -28,20 +48,33 @@ final class HousekeepingTargetRankGuard {
         }
 
         int operatorRankId = operator.getHabboInfo().getRank().getId();
+        int highestConfiguredRankId = highestConfiguredRankId();
+        HousekeepingRankPolicy.Decision decision =
+                HousekeepingRankPolicy.evaluate(operatorRankId, targetRankId, highestConfiguredRankId);
 
-        return targetRankId < operatorRankId || isCoreRank(operatorRankId) && targetRankId <= operatorRankId;
+        if (!decision.allowed()) {
+            LOGGER.warn(
+                    "Housekeeping rank rejected: operatorUserId={}, operatorRankId={}, targetRankId={}, highestConfiguredRankId={}, reason={}",
+                    operator.getHabboInfo().getId(),
+                    operatorRankId,
+                    targetRankId,
+                    highestConfiguredRankId,
+                    decision.reason());
+        }
+
+        return decision.allowed();
     }
 
     static boolean canAssignRank(Habbo operator, int rankId) {
         return canTargetRank(operator, rankId);
     }
 
-    private static boolean isCoreRank(int rankId) {
+    private static int highestConfiguredRankId() {
         int highestRankId = 0;
         for (Rank rank : Emulator.getGameEnvironment().getPermissionsManager().getAllRanks()) {
             highestRankId = Math.max(highestRankId, rank.getId());
         }
 
-        return highestRankId > 0 && rankId >= highestRankId;
+        return highestRankId;
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingRankPolicyTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingRankPolicyTest.java
@@ -1,0 +1,49 @@
+package com.eu.habbo.messages.incoming.housekeeping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class HousekeepingRankPolicyTest {
+    @Test
+    void highestConfiguredRankCanTargetAPeer() {
+        HousekeepingRankPolicy.Decision decision = HousekeepingRankPolicy.evaluate(7, 7, 7);
+
+        assertTrue(decision.allowed());
+        assertEquals(HousekeepingRankPolicy.Reason.ALLOWED_CORE_PEER, decision.reason());
+    }
+
+    @Test
+    void regularStaffCannotTargetAPeer() {
+        HousekeepingRankPolicy.Decision decision = HousekeepingRankPolicy.evaluate(6, 6, 7);
+
+        assertFalse(decision.allowed());
+        assertEquals(HousekeepingRankPolicy.Reason.TARGET_NOT_LOWER, decision.reason());
+    }
+
+    @Test
+    void highestConfiguredRankCannotTargetAHigherRank() {
+        HousekeepingRankPolicy.Decision decision = HousekeepingRankPolicy.evaluate(7, 8, 7);
+
+        assertFalse(decision.allowed());
+        assertEquals(HousekeepingRankPolicy.Reason.TARGET_NOT_LOWER, decision.reason());
+    }
+
+    @Test
+    void higherStaffRankCanTargetALowerRank() {
+        HousekeepingRankPolicy.Decision decision = HousekeepingRankPolicy.evaluate(6, 5, 7);
+
+        assertTrue(decision.allowed());
+        assertEquals(HousekeepingRankPolicy.Reason.ALLOWED_LOWER_RANK, decision.reason());
+    }
+
+    @Test
+    void invalidRankContextIsRejected() {
+        HousekeepingRankPolicy.Decision decision = HousekeepingRankPolicy.evaluate(0, 7, 7);
+
+        assertFalse(decision.allowed());
+        assertEquals(HousekeepingRankPolicy.Reason.INVALID_RANK_CONTEXT, decision.reason());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingTargetRankGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingTargetRankGuardContractTest.java
@@ -1,12 +1,11 @@
 package com.eu.habbo.messages.incoming.housekeeping;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class HousekeepingTargetRankGuardContractTest {
     private static final List<String> RANK_GUARDED_HANDLERS = List.of(
@@ -20,24 +19,7 @@ class HousekeepingTargetRankGuardContractTest {
             "HousekeepingResetUserPasswordEvent.java",
             "HousekeepingSetHcSubscriptionEvent.java",
             "HousekeepingTradeLockUserEvent.java",
-            "HousekeepingUnbanUserEvent.java"
-    );
-
-    @Test
-    void privilegedUserActionsRejectPeerRanksUnlessOperatorIsCoreRank() throws Exception {
-        String guard = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingTargetRankGuard.java"));
-
-        assertTrue(guard.contains("static boolean canTargetRank(Habbo operator, int targetRankId)"),
-                "rank comparison should be reusable for online and offline housekeeping targets");
-        assertTrue(guard.contains("static boolean canAssignRank(Habbo operator, int rankId)"),
-                "rank assignment should use the same peer/core ceiling as target moderation");
-        assertTrue(guard.contains("targetRankId < operatorRankId"),
-                "non-core housekeeping operators must only target lower-ranked users");
-        assertTrue(guard.contains("isCoreRank(operatorRankId) && targetRankId <= operatorRankId"),
-                "the highest/core rank should be allowed to target peer ranks");
-        assertTrue(guard.contains("private static boolean isCoreRank(int rankId)"),
-                "core-rank detection should be centralized in the target-rank guard");
-    }
+            "HousekeepingUnbanUserEvent.java");
 
     @Test
     void sensitiveHousekeepingUserActionsUseRankGuard() throws Exception {
@@ -45,22 +27,28 @@ class HousekeepingTargetRankGuardContractTest {
 
         for (String handler : RANK_GUARDED_HANDLERS) {
             String source = Files.readString(base.resolve(handler));
-            assertTrue(source.contains("HousekeepingTargetRankGuard.canTargetUser(this.client.getHabbo(), userId)"),
+            assertTrue(
+                    source.contains("HousekeepingTargetRankGuard.canTargetUser(this.client.getHabbo(), userId)"),
                     handler + " must reject equal or higher-ranked targets before applying privileged user actions");
-            assertTrue(source.contains("housekeeping.error.rank_too_high"),
+            assertTrue(
+                    source.contains("housekeeping.error.rank_too_high"),
                     handler + " must return a rank-ceiling error when the target cannot be managed");
         }
     }
 
     @Test
     void housekeepingRankChangesUseCentralRankCeilings() throws Exception {
-        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingSetUserRankEvent.java"));
+        String source = Files.readString(
+                Path.of("src/main/java/com/eu/habbo/messages/incoming/housekeeping/HousekeepingSetUserRankEvent.java"));
 
-        assertTrue(source.contains("HousekeepingTargetRankGuard.canAssignRank(this.client.getHabbo(), rank.getId())"),
+        assertTrue(
+                source.contains("HousekeepingTargetRankGuard.canAssignRank(this.client.getHabbo(), rank.getId())"),
                 "housekeeping rank assignment must not grant peer-or-higher ranks to non-core operators");
-        assertTrue(source.contains("HousekeepingTargetRankGuard.canTargetRank(this.client.getHabbo(), targetRankId)"),
+        assertTrue(
+                source.contains("HousekeepingTargetRankGuard.canTargetRank(this.client.getHabbo(), targetRankId)"),
                 "housekeeping rank assignment must not modify peer-or-higher ranked targets for non-core operators");
-        assertTrue(source.contains("housekeeping.error.user_not_found"),
+        assertTrue(
+                source.contains("housekeeping.error.user_not_found"),
                 "rank changes must reject missing offline users instead of reporting success for a zero-row update");
     }
 }


### PR DESCRIPTION
## Summary
- centralize housekeeping rank decisions in a small, behavior-tested policy
- allow the highest configured rank to manage a peer while keeping lower staff restricted to lower-ranked targets
- add safe structured warning logs for denied rank decisions
- replace the brittle source-expression assertion with behavior-focused policy tests

## Why
A fresh runtime reproduction confirmed that a rank 7 operator can already manage a rank 7 target. The earlier rejection was consistent with stale runtime or session state rather than the current comparison formula. This change makes the intended rule explicit, protects it with tests, and records the numeric decision context if a denial occurs again.

## Verification
- `./mvnw.cmd -Dtest=*Housekeeping*Test test` — 26 tests passed
- `./mvnw.cmd spotless:check spotbugs:check -DskipTests package` — passed
- Polaris 4.2.69 shaded JAR built successfully

## Scope
No database, packet protocol, plugin ABI, renderer, or UI changes.