### PR TITLE
Align catalog index offer limits with the renderer

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 public class CatalogPagesListComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogPagesListComposer.class);
 
+    private static final int MAX_OFFERS = 1000;
     private static final int MAX_CHILDREN = 500;
     private static final int MAX_DEPTH = 20;
 
@@ -86,8 +87,17 @@ public class CatalogPagesListComposer extends MessageComposer {
             if (offerId > 0 && seenOfferIds.add(offerId)) offerIds.add(offerId);
         }
 
-        this.response.appendInt(offerIds.size());
-        for (int idx = 0; idx < offerIds.size(); idx++) {
+        int offerCount = Math.min(offerIds.size(), MAX_OFFERS);
+        if (offerIds.size() > MAX_OFFERS) {
+            LOGGER.warn(
+                    "Catalog page {} has {} offers; limiting the index packet to {}",
+                    category.getId(),
+                    offerIds.size(),
+                    MAX_OFFERS);
+        }
+
+        this.response.appendInt(offerCount);
+        for (int idx = 0; idx < offerCount; idx++) {
             this.response.appendInt(offerIds.getInt(idx));
         }
 

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListOfferIndexTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListOfferIndexTest.java
@@ -65,6 +65,49 @@ class CatalogPagesListOfferIndexTest {
         }
     }
 
+    @Test
+    void indexCapsOffersAtRendererProtocolLimitWithoutCorruptingSuffix() {
+        Habbo habbo = mock(Habbo.class);
+        GameEnvironment environment = mock(GameEnvironment.class);
+        CatalogManager catalogManager = mock(CatalogManager.class);
+        CatalogPage page = mock(CatalogPage.class);
+        int[] offers = new int[1005];
+        for (int index = 0; index < offers.length; index++) offers[index] = index + 1;
+
+        when(environment.getCatalogManager()).thenReturn(catalogManager);
+        when(catalogManager.getCatalogPages(-1, habbo, CatalogPageType.NORMAL)).thenReturn(List.of(page));
+        when(catalogManager.getCatalogPages(42, habbo, CatalogPageType.NORMAL)).thenReturn(List.of());
+        when(page.isVisible()).thenReturn(true);
+        when(page.isEnabled()).thenReturn(true);
+        when(page.getIconImage()).thenReturn(7);
+        when(page.getId()).thenReturn(42);
+        when(page.getParentId()).thenReturn(-1);
+        when(page.getPageName()).thenReturn("chairs");
+        when(page.getCaption()).thenReturn("Chairs");
+        when(page.getOfferIds()).thenReturn(new IntArrayList(offers));
+
+        try (MockedStatic<Emulator> emulator = mockStatic(Emulator.class)) {
+            emulator.when(Emulator::getGameEnvironment).thenReturn(environment);
+
+            ByteBuf packet =
+                    new CatalogPagesListComposer(habbo, "NORMAL").compose().get();
+            packet.skipBytes(Integer.BYTES + Short.BYTES);
+
+            skipNodeHeader(packet);
+            assertEquals(0, packet.readInt());
+            assertEquals(1, packet.readInt());
+
+            skipNodeHeader(packet);
+            assertEquals(1000, packet.readInt());
+            for (int offerId = 1; offerId <= 1000; offerId++) assertEquals(offerId, packet.readInt());
+            assertEquals(0, packet.readInt());
+
+            assertFalse(packet.readBoolean());
+            assertEquals("NORMAL", readString(packet));
+            assertFalse(packet.isReadable());
+        }
+    }
+
     private static void skipNodeHeader(ByteBuf packet) {
         packet.readBoolean();
         packet.readInt();


### PR DESCRIPTION
## Summary
- cap each catalog index page at the renderer protocol limit of 1,000 distinct positive offer IDs
- write the capped count and exactly the same number of IDs so the following child count remains aligned
- emit a warning with the offending page ID when a page exceeds the protocol limit
- add a binary regression test that verifies the child count and `NORMAL` suffix after a 1,005-offer input

## Root cause
The renderer accepts at most 1,000 offer IDs per catalog node. The composer could declare and write more than that, leaving extra integers in the packet. Those integers were then interpreted as recursive child metadata, eventually causing an out-of-bounds `DataView` read and an empty catalog.

## Impact
Normal catalog index packets remain structurally valid even when imported or Catalog Studio data creates an oversized page. Offers are deduplicated and filtered as before.

Companion renderer PR: https://github.com/duckietm/Nitro_Render_V3/pull/168

## Validation
- `mvn spotless:check`
- `mvn clean package` (1,458 tests, 0 failures, 0 errors, 7 skipped)