### PR TITLE
Secure catalog metadata and recycler transactions

### DIFF
--- a/Emulator/pom.xml
+++ b/Emulator/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.release>25</maven.compiler.release>
         <maven.build.java.version>[25,27)</maven.build.java.version>
 
-        <netty.version>4.2.16.Final</netty.version>
+        <netty.version>4.2.17.Final</netty.version>
         <gson.version>2.14.0</gson.version>
         <mariadb.version>3.5.10</mariadb.version>
         <hikaricp.version>7.1.0</hikaricp.version>
@@ -27,20 +27,21 @@
         <jsoup.version>1.23.1</jsoup.version>
         <slf4j.version>2.0.18</slf4j.version>
         <error-prone-annotations.version>2.50.0</error-prone-annotations.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.3</logback.version>
         <jansi.version>2.4.3</jansi.version>
         <bcrypt.version>0.10.2</bcrypt.version>
         <jakarta-mail.version>2.0.5</jakarta-mail.version>
-        <junit.version>6.1.2</junit.version>
+        <junit.version>6.1.3</junit.version>
         <javaparser.version>3.28.2</javaparser.version>
-        <flyway.version>13.1.0</flyway.version>
-        <testcontainers.version>1.21.4</testcontainers.version>
+        <flyway.version>13.3.0</flyway.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <mockito.version>5.23.0</mockito.version>
         <trove4j.reference.version>3.0.3</trove4j.reference.version>
 
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+        <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
@@ -93,6 +94,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven-deploy-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -446,7 +452,27 @@
         <!-- Netty -->
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
         </dependency>
 
         <!-- GSON -->
@@ -625,17 +651,12 @@
         <!-- Testcontainers — throwaway MariaDB for integration (*IT) tests -->
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
+            <artifactId>testcontainers-mariadb</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mariadb</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogManager.java
@@ -12,7 +12,6 @@ import com.eu.habbo.habbohotel.catalog.layouts.CatalogRootLayout;
 import com.eu.habbo.habbohotel.catalog.layouts.ClubBuyLayout;
 import com.eu.habbo.habbohotel.catalog.layouts.ClubGiftsLayout;
 import com.eu.habbo.habbohotel.catalog.layouts.ColorGroupingLayout;
-import com.eu.habbo.habbohotel.catalog.layouts.CustomPrefixLayout;
 import com.eu.habbo.habbohotel.catalog.layouts.Default_3x3Layout;
 import com.eu.habbo.habbohotel.catalog.layouts.FrontPageFeaturedLayout;
 import com.eu.habbo.habbohotel.catalog.layouts.FrontpageLayout;
@@ -238,7 +237,7 @@ public class CatalogManager {
                                 this.put(layout.name().toLowerCase(), MadMoneyLayout.class);
                                 break;
                             case custom_prefix:
-                                this.put(layout.name().toLowerCase(), CustomPrefixLayout.class);
+                                // Retained in the public enum for plugin ABI compatibility only.
                                 break;
                             case root:
                             case productpage1:

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPageLayouts.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPageLayouts.java
@@ -46,5 +46,7 @@ public enum CatalogPageLayouts {
     monkey,
     niko,
     mad_money,
+    /** Retained for plugin ABI compatibility; the layout is no longer registered or selectable. */
+    @Deprecated
     custom_prefix
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/CustomPrefixLayout.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/layouts/CustomPrefixLayout.java
@@ -2,10 +2,14 @@ package com.eu.habbo.habbohotel.catalog.layouts;
 
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
 import com.eu.habbo.messages.ServerMessage;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+/**
+ * Retains the released plugin ABI after the custom-prefix catalog template was retired. The catalog manager does not
+ * register this layout, so normal pages and Catalog Studio cannot select it.
+ */
+@Deprecated
 public class CustomPrefixLayout extends CatalogPage {
 
     public CustomPrefixLayout(ResultSet set) throws SQLException {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomTrade.java
@@ -74,7 +74,8 @@ public class RoomTrade {
                 || user.getItems().contains(item)
                 || user.getItems().size() >= MAX_OFFERED_ITEMS) return;
 
-        habbo.getInventory().getItemsComponent().removeHabboItem(item);
+        if (!habbo.getInventory().getItemsComponent().takeHabboItemsAtomically(List.of(item))) return;
+
         user.getItems().add(item);
 
         this.clearAccepted();
@@ -90,7 +91,8 @@ public class RoomTrade {
             if (user.getItems().size() >= MAX_OFFERED_ITEMS) break;
 
             if (!user.getItems().contains(item)) {
-                habbo.getInventory().getItemsComponent().removeHabboItem(item);
+                if (!habbo.getInventory().getItemsComponent().takeHabboItemsAtomically(List.of(item))) continue;
+
                 user.getItems().add(item);
             }
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java
@@ -11,9 +11,6 @@ import com.eu.habbo.plugin.events.inventory.InventoryItemsAddedEvent;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -21,6 +18,8 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ItemsComponent {
     private static final Logger LOGGER = LoggerFactory.getLogger(ItemsComponent.class);
@@ -37,13 +36,16 @@ public class ItemsComponent {
     public static Int2ObjectMap<HabboItem> loadItems(Habbo habbo) {
         Int2ObjectMap<HabboItem> itemsList = new Int2ObjectOpenHashMap<>();
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement statement = connection.prepareStatement("SELECT items.* FROM items LEFT JOIN builders_club_items ON builders_club_items.item_id = items.id WHERE items.room_id = ? AND items.user_id = ? AND builders_club_items.item_id IS NULL")) {
+        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+                PreparedStatement statement = connection.prepareStatement(
+                        "SELECT items.* FROM items LEFT JOIN builders_club_items ON builders_club_items.item_id = items.id WHERE items.room_id = ? AND items.user_id = ? AND builders_club_items.item_id IS NULL")) {
             statement.setInt(1, 0);
             statement.setInt(2, habbo.getHabboInfo().getId());
             try (ResultSet set = statement.executeQuery()) {
                 while (set.next()) {
                     try {
-                        HabboItem item = Emulator.getGameEnvironment().getItemManager().loadHabboItem(set);
+                        HabboItem item =
+                                Emulator.getGameEnvironment().getItemManager().loadHabboItem(set);
 
                         if (item != null) {
                             itemsList.put(set.getInt("id"), item);
@@ -127,6 +129,41 @@ public class ItemsComponent {
         }
     }
 
+    public boolean takeHabboItemsAtomically(Collection<HabboItem> requestedItems) {
+        if (requestedItems == null || requestedItems.isEmpty()) return false;
+
+        Set<HabboItem> uniqueItems = new HashSet<>(requestedItems);
+        if (uniqueItems.size() != requestedItems.size()) return false;
+
+        synchronized (this.items) {
+            for (HabboItem item : uniqueItems) {
+                if (item == null || this.items.get(item.getId()) != item) return false;
+            }
+
+            for (HabboItem item : uniqueItems) {
+                InventoryItemRemovedEvent event = new InventoryItemRemovedEvent(this.inventory, item);
+
+                if (Emulator.getPluginManager().fireEvent(event).isCancelled()
+                        || event.item == null
+                        || event.item.getId() != item.getId()) return false;
+            }
+
+            for (HabboItem item : uniqueItems) this.items.remove(item.getId());
+
+            return true;
+        }
+    }
+
+    public void restoreHabboItemsAfterFailedTake(Collection<HabboItem> requestedItems) {
+        if (requestedItems == null || requestedItems.isEmpty()) return;
+
+        synchronized (this.items) {
+            for (HabboItem item : requestedItems) {
+                if (item != null) this.items.put(item.getId(), item);
+            }
+        }
+    }
+
     public Int2ObjectMap<HabboItem> getItems() {
         return this.items;
     }
@@ -142,11 +179,12 @@ public class ItemsComponent {
     public void dispose() {
         synchronized (this.items) {
             if (!this.items.isEmpty()) {
-                try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+                try (Connection connection =
+                        Emulator.getDatabase().getDataSource().getConnection()) {
                     try (PreparedStatement updateStmt = connection.prepareStatement(
                             "UPDATE items SET user_id = ?, room_id = ?, wall_pos = ?, x = ?, y = ?, z = ?, rot = ?, extra_data = ?, limited_data = ? WHERE id = ?")) {
-                        try (PreparedStatement deleteStmt = connection.prepareStatement(
-                                "DELETE FROM items WHERE id = ?")) {
+                        try (PreparedStatement deleteStmt =
+                                connection.prepareStatement("DELETE FROM items WHERE id = ?")) {
 
                             int updateCount = 0;
                             int deleteCount = 0;

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -20,7 +20,9 @@ import com.eu.habbo.messages.incoming.catalog.BuildersClubQueryFurniCountEvent;
 import com.eu.habbo.messages.incoming.catalog.CatalogBuyClubDiscountEvent;
 import com.eu.habbo.messages.incoming.catalog.CatalogBuyItemAsGiftEvent;
 import com.eu.habbo.messages.incoming.catalog.CatalogBuyItemEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogProductMetadataEvent;
 import com.eu.habbo.messages.incoming.catalog.CatalogRequestClubDiscountEvent;
+import com.eu.habbo.messages.incoming.catalog.CatalogRuntimeConfigurationEvent;
 import com.eu.habbo.messages.incoming.catalog.CatalogSearchedItemEvent;
 import com.eu.habbo.messages.incoming.catalog.CatalogSelectClubGiftEvent;
 import com.eu.habbo.messages.incoming.catalog.CheckPetNameEvent;
@@ -684,6 +686,8 @@ public class PacketManager {
         this.registerHandler(Incoming.BuildersClubPlaceRoomItemEvent, BuildersClubPlaceRoomItemEvent.class);
         this.registerHandler(Incoming.BuildersClubPlaceWallItemEvent, BuildersClubPlaceWallItemEvent.class);
         this.registerHandler(Incoming.RequestCatalogPageEvent, RequestCatalogPageEvent.class);
+        this.registerHandler(Incoming.CatalogProductMetadataEvent, CatalogProductMetadataEvent.class);
+        this.registerHandler(Incoming.CatalogRuntimeConfigurationEvent, CatalogRuntimeConfigurationEvent.class);
         this.registerHandler(Incoming.CatalogBuyItemAsGiftEvent, CatalogBuyItemAsGiftEvent.class);
         this.registerHandler(Incoming.CatalogBuyItemEvent, CatalogBuyItemEvent.class);
         this.registerHandler(Incoming.RedeemVoucherEvent, RedeemVoucherEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -505,6 +505,8 @@ public class Incoming {
     public static final int CatalogStudioExportEvent = 10078;
     public static final int CatalogStudioDocumentDryRunEvent = 10079;
     public static final int CatalogStudioDocumentApplyEvent = 10080;
+    public static final int CatalogProductMetadataEvent = 10081;
+    public static final int CatalogRuntimeConfigurationEvent = 10082;
 
     // Custom Prefixes
     public static final int RequestUserPrefixesEvent = 7011;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogPageAccessPolicy.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogPageAccessPolicy.java
@@ -1,0 +1,9 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+final class CatalogPageAccessPolicy {
+    private CatalogPageAccessPolicy() {}
+
+    static boolean canOpen(int pageRank, int userRank, boolean enabled, boolean canSeeCatalogIds) {
+        return pageRank <= userRank && (enabled || canSeeCatalogIds);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogProductMetadataEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogProductMetadataEvent.java
@@ -1,0 +1,88 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.catalog.CatalogItem;
+import com.eu.habbo.habbohotel.catalog.CatalogPage;
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.catalog.CatalogProductMetadataComposer;
+import com.eu.habbo.messages.outgoing.catalog.CatalogProductMetadataEntry;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class CatalogProductMetadataEvent extends MessageHandler {
+    private static final int MAX_REQUEST_ID_LENGTH = 64;
+
+    @Override
+    public void handle() throws Exception {
+        int version = this.packet.readInt();
+        String requestId = sanitizeRequestId(this.packet.readString());
+        int pageId = this.packet.readInt();
+        String catalogMode = this.packet.readString();
+
+        if (this.client == null || this.client.getHabbo() == null) return;
+
+        List<CatalogProductMetadataEntry> entries = List.of();
+
+        if (version == CatalogProductMetadataComposer.PROTOCOL_VERSION && pageId > 0) {
+            CatalogPage page = Emulator.getGameEnvironment()
+                    .getCatalogManager()
+                    .getCatalogPage(pageId, CatalogPageType.fromString(catalogMode));
+
+            if (page != null && canOpen(page)) entries = collectEntries(page);
+        }
+
+        this.client.sendResponse(new CatalogProductMetadataComposer(requestId, pageId, entries));
+    }
+
+    private boolean canOpen(CatalogPage page) {
+        boolean canSeeCatalogIds = this.client.getHabbo().hasPermission(Permission.ACC_CATALOG_IDS);
+
+        return CatalogPageAccessPolicy.canOpen(
+                page.getRank(),
+                this.client.getHabbo().getHabboInfo().getRank().getId(),
+                page.isEnabled(),
+                canSeeCatalogIds);
+    }
+
+    private static List<CatalogProductMetadataEntry> collectEntries(CatalogPage page) {
+        List<CatalogProductMetadataEntry> entries = new ArrayList<>();
+        List<CatalogItem> offers = new ArrayList<>(page.getCatalogItems().values());
+        offers.sort(Comparator.comparingInt(CatalogItem::getId));
+
+        for (CatalogItem offer : offers) {
+            List<Item> baseItems = new ArrayList<>(offer.getBaseItems());
+            baseItems.sort(Comparator.comparingInt(Item::getId));
+
+            for (Item item : baseItems) {
+                entries.add(new CatalogProductMetadataEntry(
+                        offer.getId(), item.getId(), item.getSpriteId(), item.allowTrade(), item.allowRecyle()));
+
+                if (entries.size() == CatalogProductMetadataComposer.MAX_ENTRIES) return entries;
+            }
+        }
+
+        return entries;
+    }
+
+    private static String sanitizeRequestId(String requestId) {
+        if (requestId == null) return "";
+
+        String sanitized = requestId.replaceAll("[\\p{Cntrl}]", "").trim();
+
+        return sanitized.length() <= MAX_REQUEST_ID_LENGTH ? sanitized : sanitized.substring(0, MAX_REQUEST_ID_LENGTH);
+    }
+
+    @Override
+    public int getRatelimit() {
+        return 250;
+    }
+
+    @Override
+    public String getRatelimitGroup() {
+        return "catalog_product_metadata";
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogRuntimeConfigurationEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogRuntimeConfigurationEvent.java
@@ -1,0 +1,37 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.catalog.CatalogRuntimeConfigurationComposer;
+
+public class CatalogRuntimeConfigurationEvent extends MessageHandler {
+    private static final int MAX_REQUEST_ID_LENGTH = 64;
+
+    @Override
+    public void handle() throws Exception {
+        int version = this.packet.readInt();
+        String requestId = sanitizeRequestId(this.packet.readString());
+
+        if (this.client == null || this.client.getHabbo() == null) return;
+
+        this.client.sendResponse(new CatalogRuntimeConfigurationComposer(
+                requestId, version == CatalogRuntimeConfigurationComposer.PROTOCOL_VERSION));
+    }
+
+    private static String sanitizeRequestId(String requestId) {
+        if (requestId == null) return "";
+
+        String sanitized = requestId.replaceAll("[\\p{Cntrl}]", "").trim();
+
+        return sanitized.length() <= MAX_REQUEST_ID_LENGTH ? sanitized : sanitized.substring(0, MAX_REQUEST_ID_LENGTH);
+    }
+
+    @Override
+    public int getRatelimit() {
+        return 250;
+    }
+
+    @Override
+    public String getRatelimitGroup() {
+        return "catalog_runtime_configuration";
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/RequestCatalogPageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/RequestCatalogPageEvent.java
@@ -4,6 +4,7 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.catalog.CatalogPage;
 import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import com.eu.habbo.habbohotel.modtool.ScripterManager;
+import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.catalog.CatalogPageComposer;
 
@@ -16,14 +17,32 @@ public class RequestCatalogPageEvent extends MessageHandler {
         String mode = this.packet.readString();
         CatalogPageType requestedType = CatalogPageType.fromString(mode);
 
-        CatalogPage page = Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(catalogPageId, requestedType);
+        CatalogPage page =
+                Emulator.getGameEnvironment().getCatalogManager().getCatalogPage(catalogPageId, requestedType);
 
         if (catalogPageId > 0 && page != null) {
-            if (page.getRank() <= this.client.getHabbo().getHabboInfo().getRank().getId() && page.isEnabled()) {
+            boolean canSeeCatalogIds = this.client.getHabbo().hasPermission(Permission.ACC_CATALOG_IDS);
+            boolean canOpen = CatalogPageAccessPolicy.canOpen(
+                    page.getRank(),
+                    this.client.getHabbo().getHabboInfo().getRank().getId(),
+                    page.isEnabled(),
+                    canSeeCatalogIds);
+
+            if (canOpen) {
                 this.client.sendResponse(new CatalogPageComposer(page, this.client.getHabbo(), offerId, mode));
             } else {
                 if (!page.isVisible()) {
-                    ScripterManager.scripterDetected(this.client, Emulator.getTexts().getValue("scripter.warning.catalog.page").replace("%username%", this.client.getHabbo().getHabboInfo().getUsername()).replace("%pagename%", page.getCaption()));
+                    ScripterManager.scripterDetected(
+                            this.client,
+                            Emulator.getTexts()
+                                    .getValue("scripter.warning.catalog.page")
+                                    .replace(
+                                            "%username%",
+                                            this.client
+                                                    .getHabbo()
+                                                    .getHabboInfo()
+                                                    .getUsername())
+                                    .replace("%pagename%", page.getCaption()));
                 }
             }
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java
@@ -2,10 +2,13 @@ package com.eu.habbo.messages.incoming.catalog.recycler;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
+import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.ItemManager;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.inventory.ItemsComponent;
 import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.catalog.AlertPurchaseFailedComposer;
+import com.eu.habbo.messages.outgoing.catalog.CatalogRuntimeConfigurationComposer;
 import com.eu.habbo.messages.outgoing.catalog.RecyclerCompleteComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.HotelWillCloseInMinutesComposer;
 import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
@@ -29,14 +32,13 @@ public class RecycleEvent extends MessageHandler {
             Set<HabboItem> items = new HashSet<>();
 
             int count = this.packet.readInt();
-            if (count != Emulator.getConfig().getInt("recycler.value", 8)) return;
+            if (count != CatalogRuntimeConfigurationComposer.getRecyclerSlotCount()) return;
+
+            ItemsComponent itemsComponent =
+                    this.client.getHabbo().getInventory().getItemsComponent();
 
             for (int i = 0; i < count; i++) {
-                HabboItem item = this.client
-                        .getHabbo()
-                        .getInventory()
-                        .getItemsComponent()
-                        .getHabboItem(this.packet.readInt());
+                HabboItem item = itemsComponent.getHabboItem(this.packet.readInt());
 
                 if (item == null) return;
 
@@ -50,36 +52,61 @@ public class RecycleEvent extends MessageHandler {
                 return;
             }
 
-            // Compute the reward BEFORE consuming the inputs. Previously the
-            // inputs were deleted first, so a null reward (misconfiguration)
-            // permanently destroyed the 8 furni with nothing in return.
-            HabboItem reward = Emulator.getGameEnvironment()
-                    .getItemManager()
-                    .handleRecycle(
-                            this.client.getHabbo(),
-                            Emulator.getGameEnvironment()
-                                            .getCatalogManager()
-                                            .getRandomRecyclerPrize()
-                                            .getId() + "");
-            if (reward == null) {
+            if (!itemsComponent.takeHabboItemsAtomically(items)) {
                 this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
                 return;
             }
 
-            for (HabboItem item : items) {
-                this.client.getHabbo().getInventory().getItemsComponent().removeHabboItem(item);
-                this.client.sendResponse(new RemoveHabboItemComposer(item.getGiftAdjustedId()));
-                Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
+            HabboItem reward = null;
+            boolean consumed = false;
+
+            try {
+                Item prize = Emulator.getGameEnvironment().getCatalogManager().getRandomRecyclerPrize();
+
+                if (prize == null) {
+                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                    return;
+                }
+
+                reward = Emulator.getGameEnvironment()
+                        .getItemManager()
+                        .handleRecycle(this.client.getHabbo(), prize.getId() + "");
+                if (reward == null) {
+                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                    return;
+                }
+
+                itemsComponent.addItem(reward);
+                if (itemsComponent.getHabboItem(reward.getId()) != reward) {
+                    this.client.sendResponse(new AlertPurchaseFailedComposer(AlertPurchaseFailedComposer.SERVER_ERROR));
+                    return;
+                }
+
+                for (HabboItem item : items) {
+                    Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(item.getId()));
+                }
+                consumed = true;
+
+                for (HabboItem item : items) {
+                    this.client.sendResponse(new RemoveHabboItemComposer(item.getGiftAdjustedId()));
+                }
+                this.client.sendResponse(new AddHabboItemComposer(reward));
+                this.client.sendResponse(new RecyclerCompleteComposer(RecyclerCompleteComposer.RECYCLING_COMPLETE));
+                this.client.sendResponse(new InventoryRefreshComposer());
+
+                AchievementManager.progressAchievement(
+                        this.client.getHabbo(),
+                        Emulator.getGameEnvironment().getAchievementManager().getAchievement("FurnimaticQuest"));
+            } finally {
+                if (!consumed) {
+                    itemsComponent.restoreHabboItemsAfterFailedTake(items);
+
+                    if (reward != null) {
+                        itemsComponent.removeHabboItem(reward);
+                        Emulator.getThreading().runPersistence(new QueryDeleteHabboItem(reward.getId()));
+                    }
+                }
             }
-
-            this.client.sendResponse(new AddHabboItemComposer(reward));
-            this.client.getHabbo().getInventory().getItemsComponent().addItem(reward);
-            this.client.sendResponse(new RecyclerCompleteComposer(RecyclerCompleteComposer.RECYCLING_COMPLETE));
-            this.client.sendResponse(new InventoryRefreshComposer());
-
-            AchievementManager.progressAchievement(
-                    this.client.getHabbo(),
-                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("FurnimaticQuest"));
         } else {
             this.client.sendResponse(new RecyclerCompleteComposer(RecyclerCompleteComposer.RECYCLING_CLOSED));
         }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -622,6 +622,8 @@ public class Outgoing {
     public static final int CatalogStudioRestoreComposer = 10076;
     public static final int CatalogStudioPreviewComposer = 10077;
     public static final int CatalogStudioDocumentResultComposer = 10078;
+    public static final int CatalogProductMetadataComposer = 10081;
+    public static final int CatalogRuntimeConfigurationComposer = 10082;
 
     // Custom Prefixes
     public static final int UserPrefixesComposer = 7001;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogProductMetadataComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogProductMetadataComposer.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.messages.outgoing.catalog;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+import java.util.List;
+
+public class CatalogProductMetadataComposer extends MessageComposer {
+    public static final int MAX_ENTRIES = 500;
+    public static final int PROTOCOL_VERSION = 1;
+
+    private final String requestId;
+    private final int pageId;
+    private final List<CatalogProductMetadataEntry> entries;
+
+    public CatalogProductMetadataComposer(String requestId, int pageId, List<CatalogProductMetadataEntry> entries) {
+        this.requestId = requestId == null ? "" : requestId;
+        this.pageId = pageId;
+        this.entries = entries == null ? List.of() : List.copyOf(entries);
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.CatalogProductMetadataComposer);
+        this.response.appendInt(PROTOCOL_VERSION);
+        this.response.appendString(this.requestId);
+        this.response.appendInt(this.pageId);
+
+        int count = Math.min(this.entries.size(), MAX_ENTRIES);
+        this.response.appendInt(count);
+
+        for (int index = 0; index < count; index++) {
+            CatalogProductMetadataEntry entry = this.entries.get(index);
+
+            this.response.appendInt(entry.offerId());
+            this.response.appendInt(entry.itemBaseId());
+            this.response.appendInt(entry.productClassId());
+            this.response.appendByte(entry.flags());
+        }
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogProductMetadataEntry.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogProductMetadataEntry.java
@@ -1,0 +1,14 @@
+package com.eu.habbo.messages.outgoing.catalog;
+
+public record CatalogProductMetadataEntry(
+        int offerId, int itemBaseId, int productClassId, boolean tradeable, boolean recyclable) {
+
+    public int flags() {
+        int flags = 0;
+
+        if (this.tradeable) flags |= 1;
+        if (this.recyclable) flags |= 2;
+
+        return flags;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogRuntimeConfigurationComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogRuntimeConfigurationComposer.java
@@ -1,0 +1,36 @@
+package com.eu.habbo.messages.outgoing.catalog;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public class CatalogRuntimeConfigurationComposer extends MessageComposer {
+    public static final int PROTOCOL_VERSION = 1;
+    public static final int DEFAULT_RECYCLER_SLOT_COUNT = 8;
+    public static final int MAX_RECYCLER_SLOT_COUNT = 12;
+
+    private final String requestId;
+    private final boolean supportedVersion;
+
+    public CatalogRuntimeConfigurationComposer(String requestId, boolean supportedVersion) {
+        this.requestId = requestId == null ? "" : requestId;
+        this.supportedVersion = supportedVersion;
+    }
+
+    public static int getRecyclerSlotCount() {
+        int configured = Emulator.getConfig().getInt("recycler.value", DEFAULT_RECYCLER_SLOT_COUNT);
+
+        return Math.max(1, Math.min(configured, MAX_RECYCLER_SLOT_COUNT));
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.CatalogRuntimeConfigurationComposer);
+        this.response.appendInt(PROTOCOL_VERSION);
+        this.response.appendString(this.requestId);
+        this.response.appendInt(this.supportedVersion ? getRecyclerSlotCount() : DEFAULT_RECYCLER_SLOT_COUNT);
+
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java
@@ -5,6 +5,9 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -14,13 +17,18 @@ public class RecyclerLogicComposer extends MessageComposer {
         this.response.init(Outgoing.RecyclerLogicComposer);
         Map<Integer, Set<Item>> prizes =
                 Emulator.getGameEnvironment().getCatalogManager().getRecyclerPrizesSnapshot();
-        this.response.appendInt(prizes.size());
-        for (Map.Entry<Integer, Set<Item>> map : prizes.entrySet()) {
+        List<Map.Entry<Integer, Set<Item>>> levels = new ArrayList<>(prizes.entrySet());
+        levels.sort(Map.Entry.comparingByKey());
+
+        this.response.appendInt(levels.size());
+        for (Map.Entry<Integer, Set<Item>> map : levels) {
             this.response.appendInt(map.getKey());
-            this.response.appendInt(
-                    Integer.valueOf(Emulator.getConfig().getValue("hotel.ecotron.rarity.chance." + map.getKey())));
-            this.response.appendInt(map.getValue().size());
-            for (Item item : map.getValue()) {
+            this.response.appendInt(Emulator.getConfig().getInt("hotel.ecotron.rarity.chance." + map.getKey(), 0));
+
+            List<Item> items = new ArrayList<>(map.getValue());
+            items.sort(Comparator.comparingInt(Item::getId));
+            this.response.appendInt(items.size());
+            for (Item item : items) {
                 this.response.appendString(item.getName());
                 this.response.appendInt(1);
                 this.response.appendString(item.getType().code.toLowerCase());

--- a/Emulator/src/main/resources/db/migration/V20260814210000__remove_catalog_custom_prefix_layout.sql
+++ b/Emulator/src/main/resources/db/migration/V20260814210000__remove_catalog_custom_prefix_layout.sql
@@ -1,0 +1,28 @@
+-- Retire the Catalog Studio-only custom_prefix page layout without touching user prefix customization.
+UPDATE `catalog_pages`
+SET `page_layout` = 'default_3x3'
+WHERE `page_layout` = 'custom_prefix';
+
+UPDATE `catalog_pages_bc`
+SET `page_layout` = 'default_3x3'
+WHERE `page_layout` = 'custom_prefix';
+
+ALTER TABLE `catalog_pages`
+    MODIFY COLUMN `page_layout` ENUM(
+        'default_3x3','club_buy','club_gift','frontpage','spaces','recycler','recycler_info','recycler_prizes',
+        'trophies','plasto','marketplace','marketplace_own_items','spaces_new','soundmachine','guilds','guild_furni',
+        'info_duckets','info_rentables','info_pets','roomads','single_bundle','sold_ltd_items','badge_display','bots',
+        'pets','pets2','pets3','productpage1','room_bundle','recent_purchases','default_3x3_color_grouping',
+        'guild_forum','vip_buy','info_loyalty','loyalty_vip_buy','collectibles','petcustomization','frontpage_featured',
+        'builders_club_frontpage','builders_club_addons','builders_club_loyalty','root','monkey','niko','mad_money'
+    ) NOT NULL DEFAULT 'default_3x3';
+
+ALTER TABLE `catalog_pages_bc`
+    MODIFY COLUMN `page_layout` ENUM(
+        'default_3x3','club_buy','club_gift','frontpage','spaces','recycler','recycler_info','recycler_prizes',
+        'trophies','plasto','marketplace','marketplace_own_items','spaces_new','soundmachine','guilds','guild_furni',
+        'info_duckets','info_rentables','info_pets','roomads','single_bundle','sold_ltd_items','badge_display','bots',
+        'pets','pets2','pets3','productpage1','room_bundle','recent_purchases','default_3x3_color_grouping',
+        'guild_forum','vip_buy','info_loyalty','loyalty_vip_buy','collectibles','petcustomization','frontpage_featured',
+        'builders_club_frontpage','builders_club_addons','builders_club_loyalty','root','monkey','niko','mad_money'
+    ) NOT NULL DEFAULT 'default_3x3';

--- a/Emulator/src/test/java/com/eu/habbo/build/MavenBuildEnvironmentContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/build/MavenBuildEnvironmentContractTest.java
@@ -25,11 +25,21 @@ class MavenBuildEnvironmentContractTest {
         assertTrue(pom.contains("<dependencyConvergence/>"));
         assertTrue(pom.contains("<requirePluginVersions/>"));
         assertTrue(pom.contains("<artifactId>versions-maven-plugin</artifactId>"));
+        assertTrue(pom.contains("<artifactId>maven-dependency-plugin</artifactId>"));
 
         assertImportedBom(pom, "io.netty", "netty-bom");
         assertImportedBom(pom, "org.junit", "junit-bom");
         assertImportedBom(pom, "org.testcontainers", "testcontainers-bom");
         assertImportedBom(pom, "org.mockito", "mockito-bom");
+        assertTrue(pom.contains("<artifactId>netty-common</artifactId>"));
+        assertTrue(pom.contains("<artifactId>netty-buffer</artifactId>"));
+        assertTrue(pom.contains("<artifactId>netty-transport</artifactId>"));
+        assertTrue(pom.contains("<artifactId>netty-codec-base</artifactId>"));
+        assertTrue(pom.contains("<artifactId>netty-codec-http</artifactId>"));
+        assertTrue(pom.contains("<artifactId>netty-handler</artifactId>"));
+        assertFalse(pom.contains("<artifactId>netty-all</artifactId>"));
+        assertTrue(pom.contains("<artifactId>testcontainers-mariadb</artifactId>"));
+        assertTrue(pom.contains("<artifactId>testcontainers-junit-jupiter</artifactId>"));
         assertFalse(pom.contains("datafaker"));
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/database/TestDatabase.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/TestDatabase.java
@@ -2,23 +2,22 @@ package com.eu.habbo.database;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.mariadb.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /** Shared MariaDB Testcontainers fixture for integration tests. */
 public final class TestDatabase {
 
     /** CI overrides the pinned default for the supported-version matrix. */
-    public static final String MARIADB_IMAGE =
-            System.getenv().getOrDefault(
+    public static final String MARIADB_IMAGE = System.getenv()
+            .getOrDefault(
                     "POLARIS_TEST_MARIADB_IMAGE",
                     "mariadb:11.4.12@sha256:a794d9eb009e20de605858a11f32f63b4075cbd197c650436f0e3b457e4caed7");
 
-    private static volatile MariaDBContainer<?> container;
+    private static volatile MariaDBContainer container;
     private static volatile HikariDataSource dataSource;
 
-    private TestDatabase() {
-    }
+    private TestDatabase() {}
 
     /** Returns whether Testcontainers can reach a Docker daemon. */
     public static boolean dockerAvailable() {
@@ -33,9 +32,8 @@ public final class TestDatabase {
         if (dataSource != null) {
             return dataSource;
         }
-        DockerImageName image = DockerImageName.parse(MARIADB_IMAGE)
-                .asCompatibleSubstituteFor("mariadb");
-        MariaDBContainer<?> c = new MariaDBContainer<>(image)
+        DockerImageName image = DockerImageName.parse(MARIADB_IMAGE).asCompatibleSubstituteFor("mariadb");
+        MariaDBContainer c = new MariaDBContainer(image)
                 .withDatabaseName("habbo_test")
                 .withUsername("polaris")
                 .withPassword("polaris");
@@ -56,7 +54,7 @@ public final class TestDatabase {
     public static synchronized HikariDataSource freshDatabase(String label) {
         HikariDataSource shared = sharedDataSource();
         try (var connection = shared.getConnection();
-             var statement = connection.createStatement()) {
+                var statement = connection.createStatement()) {
             statement.execute("SET FOREIGN_KEY_CHECKS = 0");
             java.util.List<String> views = new java.util.ArrayList<>();
             try (var rs = statement.executeQuery(

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogCustomPrefixLayoutRemovalTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogCustomPrefixLayoutRemovalTest.java
@@ -1,0 +1,36 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CatalogCustomPrefixLayoutRemovalTest {
+
+    private static final Path MIGRATION =
+            Path.of("src/main/resources/db/migration/V20260814210000__remove_catalog_custom_prefix_layout.sql");
+
+    @Test
+    void catalogLayoutKeepsItsPluginAbiWithoutBeingRuntimeSelectable() {
+        assertEquals(CatalogPageLayouts.custom_prefix, CatalogPageLayouts.valueOf("custom_prefix"));
+        assertFalse(CatalogManager.pageDefinitions.containsKey("custom_prefix"));
+    }
+
+    @Test
+    void migrationConvertsExistingPagesBeforeNarrowingBothEnums() throws Exception {
+        String sql = Files.readString(MIGRATION);
+        int normalUpdate = sql.indexOf("UPDATE `catalog_pages`");
+        int buildersUpdate = sql.indexOf("UPDATE `catalog_pages_bc`");
+        int firstAlter = sql.indexOf("ALTER TABLE");
+
+        assertAll(
+                () -> assertTrue(normalUpdate >= 0 && normalUpdate < firstAlter),
+                () -> assertTrue(buildersUpdate >= 0 && buildersUpdate < firstAlter),
+                () -> assertTrue(sql.contains("WHERE `page_layout` = 'custom_prefix'")),
+                () -> assertTrue(!sql.substring(firstAlter).contains("'custom_prefix'")));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/contracts/CatalogStudioRegistryContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/contracts/CatalogStudioRegistryContractTest.java
@@ -33,5 +33,21 @@ class CatalogStudioRegistryContractTest {
                     registry.require(JavaPacketRegistry.Direction.SERVER_TO_CLIENT, header)
                             .header());
         }
+        assertEquals(
+                10081,
+                registry.require(JavaPacketRegistry.Direction.CLIENT_TO_SERVER, 10081)
+                        .header());
+        assertEquals(
+                10081,
+                registry.require(JavaPacketRegistry.Direction.SERVER_TO_CLIENT, 10081)
+                        .header());
+        assertEquals(
+                10082,
+                registry.require(JavaPacketRegistry.Direction.CLIENT_TO_SERVER, 10082)
+                        .header());
+        assertEquals(
+                10082,
+                registry.require(JavaPacketRegistry.Direction.SERVER_TO_CLIENT, 10082)
+                        .header());
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/catalog/CatalogPageAccessPolicyTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/catalog/CatalogPageAccessPolicyTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.messages.incoming.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CatalogPageAccessPolicyTest {
+
+    @Test
+    void allowsEnabledPagesWithinTheUsersRank() {
+        assertTrue(CatalogPageAccessPolicy.canOpen(1, 1, true, false));
+    }
+
+    @Test
+    void allowsDisabledPagesOnlyToCatalogIdStaff() {
+        assertTrue(CatalogPageAccessPolicy.canOpen(1, 7, false, true));
+        assertFalse(CatalogPageAccessPolicy.canOpen(1, 7, false, false));
+    }
+
+    @Test
+    void neverBypassesThePageRank() {
+        assertFalse(CatalogPageAccessPolicy.canOpen(8, 7, true, true));
+        assertFalse(CatalogPageAccessPolicy.canOpen(8, 7, false, true));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/trading/TradeOfferGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/trading/TradeOfferGuardContractTest.java
@@ -1,11 +1,10 @@
 package com.eu.habbo.messages.incoming.trading;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class TradeOfferGuardContractTest {
     private static String incomingSource(String name) throws Exception {
@@ -31,9 +30,12 @@ class TradeOfferGuardContractTest {
         assertTrue(guard > count, "TradeOfferMultipleItemsEvent must validate the count after reading it");
         assertTrue(guard < readLoop, "TradeOfferMultipleItemsEvent must validate the count before reading ids");
         assertTrue(readLoop < idGuard, "TradeOfferMultipleItemsEvent must validate all ids after reading the packet");
-        assertTrue(idGuard < resolveLoop, "TradeOfferMultipleItemsEvent must reject invalid or duplicate ids before resolving inventory");
+        assertTrue(
+                idGuard < resolveLoop,
+                "TradeOfferMultipleItemsEvent must reject invalid or duplicate ids before resolving inventory");
         assertTrue(resolveLoop < lookup, "TradeOfferMultipleItemsEvent should resolve only a fully validated id list");
-        assertTrue(source.contains("item == null || !item.getBaseItem().allowTrade()"),
+        assertTrue(
+                source.contains("item == null || !item.getBaseItem().allowTrade()"),
                 "TradeOfferMultipleItemsEvent must reject the entire request when an item is missing or not tradable");
     }
 
@@ -44,11 +46,11 @@ class TradeOfferGuardContractTest {
         int constant = source.indexOf("MAX_OFFERED_ITEMS = 100");
         int singleGuard = source.indexOf("user.getItems().size() >= MAX_OFFERED_ITEMS");
         int multipleGuard = source.indexOf("user.getItems().size() >= MAX_OFFERED_ITEMS", singleGuard + 1);
-        int remove = source.indexOf("removeHabboItem(item)", multipleGuard);
+        int inventoryMutation = source.indexOf("takeHabboItemsAtomically(List.of(item))", multipleGuard);
 
         assertTrue(constant > -1, "RoomTrade must define a server-side offered item cap");
         assertTrue(singleGuard > constant, "RoomTrade.offerItem must enforce the item cap");
         assertTrue(multipleGuard > singleGuard, "RoomTrade.offerMultipleItems must enforce the item cap");
-        assertTrue(multipleGuard < remove, "RoomTrade must enforce the cap before mutating inventory");
+        assertTrue(multipleGuard < inventoryMutation, "RoomTrade must enforce the cap before mutating inventory");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/CatalogProductMetadataComposerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/CatalogProductMetadataComposerTest.java
@@ -1,0 +1,47 @@
+package com.eu.habbo.messages.outgoing.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.eu.habbo.messages.outgoing.Outgoing;
+import io.netty.buffer.ByteBuf;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CatalogProductMetadataComposerTest {
+
+    @Test
+    void payloadKeepsVersionCorrelationAndItemCapabilitiesInOrder() {
+        ByteBuf payload = new CatalogProductMetadataComposer(
+                        "metadata-1",
+                        33,
+                        List.of(
+                                new CatalogProductMetadataEntry(51, 701, 9001, true, true),
+                                new CatalogProductMetadataEntry(52, 702, 9002, true, false)))
+                .compose()
+                .get();
+
+        payload.skipBytes(4);
+        assertEquals(Outgoing.CatalogProductMetadataComposer, payload.readUnsignedShort());
+        assertEquals(1, payload.readInt());
+        assertEquals("metadata-1", readString(payload));
+        assertEquals(33, payload.readInt());
+        assertEquals(2, payload.readInt());
+        assertEntry(payload, 51, 701, 9001, 3);
+        assertEntry(payload, 52, 702, 9002, 1);
+        assertFalse(payload.isReadable());
+    }
+
+    private static void assertEntry(ByteBuf payload, int offerId, int itemBaseId, int productClassId, int flags) {
+        assertEquals(offerId, payload.readInt());
+        assertEquals(itemBaseId, payload.readInt());
+        assertEquals(productClassId, payload.readInt());
+        assertEquals(flags, payload.readUnsignedByte());
+    }
+
+    private static String readString(ByteBuf payload) {
+        int length = payload.readUnsignedShort();
+        return payload.readCharSequence(length, StandardCharsets.UTF_8).toString();
+    }
+}

--- a/Emulator/src/test/resources/architecture/frozen-violations.tsv
+++ b/Emulator/src/test/resources/architecture/frozen-violations.tsv
@@ -998,7 +998,7 @@ U|com/eu/habbo/habbohotel/users/inventory/EffectsComponent.java|CALL|getDatabase
 U|com/eu/habbo/habbohotel/users/inventory/EffectsComponent.java|CALL|getIntUnixTimestamp|4
 U|com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java|CALL|getDatabase|2
 U|com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java|CALL|getGameEnvironment|1
-U|com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java|CALL|getPluginManager|3
+U|com/eu/habbo/habbohotel/users/inventory/ItemsComponent.java|CALL|getPluginManager|4
 U|com/eu/habbo/habbohotel/users/inventory/NickIconsComponent.java|CALL|getDatabase|1
 U|com/eu/habbo/habbohotel/users/inventory/NickIconsComponent.java|CALL|getThreading|2
 U|com/eu/habbo/habbohotel/users/inventory/PetsComponent.java|CALL|getDatabase|1
@@ -1111,7 +1111,9 @@ U|com/eu/habbo/messages/incoming/catalog/recycler/OpenRecycleBoxEvent.java|CALL|
 U|com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java|CALL|getConfig|1
 U|com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java|CALL|getGameEnvironment|4
 U|com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java|CALL|getIntUnixTimestamp|1
-U|com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java|CALL|getThreading|1
+U|com/eu/habbo/messages/incoming/catalog/recycler/RecycleEvent.java|CALL|getThreading|2
+U|com/eu/habbo/messages/incoming/catalog/CatalogProductMetadataEvent.java|CALL|getGameEnvironment|1
+U|com/eu/habbo/messages/outgoing/catalog/CatalogRuntimeConfigurationComposer.java|CALL|getConfig|1
 U|com/eu/habbo/messages/incoming/crafting/CraftingAddRecipeEvent.java|CALL|getGameEnvironment|1
 U|com/eu/habbo/messages/incoming/crafting/CraftingCraftItemEvent.java|CALL|getGameEnvironment|4
 U|com/eu/habbo/messages/incoming/crafting/CraftingCraftItemEvent.java|CALL|getThreading|1

--- a/Emulator/src/test/resources/packaging/flyway-plugin-providers.contract
+++ b/Emulator/src/test/resources/packaging/flyway-plugin-providers.contract
@@ -30,10 +30,10 @@ org.flywaydb.core.internal.proprietaryStubs.PATTokenConfigurationExtensionStub
 org.flywaydb.core.internal.proprietaryStubs.PrepareCommandExtensionStub
 org.flywaydb.core.internal.proprietaryStubs.ShouldExecuteEvaluatorStub
 org.flywaydb.core.internal.proprietaryStubs.UndoCommandExtensionStub
-org.flywaydb.core.internal.publishing.PublishingConfigurationExtension
 org.flywaydb.core.internal.resource.CoreResourceTypeProvider
 org.flywaydb.core.internal.scanner.classpath.ClasspathLocationHandlerImpl
 org.flywaydb.core.internal.scanner.filesystem.FilesystemLocationHandler
 org.flywaydb.core.internal.schemahistory.BaseAppliedMigration
 org.flywaydb.database.mysql.MySQLDatabaseType
+org.flywaydb.database.mysql.authentication.MySQLExternalAuthSupportStub
 org.flywaydb.database.mysql.mariadb.MariaDBDatabaseType

--- a/protocol/packet-field-contracts.json
+++ b/protocol/packet-field-contracts.json
@@ -24020,6 +24020,70 @@
         "path": "packages/communication/src/messages/parser/catalog/studio/CatalogStudioOperationMessageParser.ts"
       },
       "reason": "Pre-existing wire mismatch requires runtime protocol decision: Java [] versus TypeScript [string, boolean, string, string, int, int, string, int]"
+    },
+    {
+      "name": "CATALOG_PRODUCT_METADATA_REQUEST",
+      "direction": "client_to_server",
+      "header": 10081,
+      "java": {
+        "symbol": "CatalogProductMetadataEvent",
+        "className": "CatalogProductMetadataEvent",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogProductMetadataEvent.java"
+      },
+      "typescript": {
+        "symbol": "CATALOG_PRODUCT_METADATA",
+        "className": "CatalogProductMetadataComposer",
+        "path": "packages/communication/src/messages/outgoing/catalog/metadata/CatalogProductMetadataComposer.ts"
+      },
+      "reason": "The metadata request is optional and independently versioned so legacy catalog packets remain unchanged"
+    },
+    {
+      "name": "CATALOG_PRODUCT_METADATA_RESPONSE",
+      "direction": "server_to_client",
+      "header": 10081,
+      "java": {
+        "symbol": "CatalogProductMetadataComposer",
+        "className": "CatalogProductMetadataComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogProductMetadataComposer.java"
+      },
+      "typescript": {
+        "symbol": "CATALOG_PRODUCT_METADATA",
+        "className": "CatalogProductMetadataMessageParser",
+        "path": "packages/communication/src/messages/parser/catalog/metadata/CatalogProductMetadataMessageParser.ts"
+      },
+      "reason": "The bounded response contains a dynamic list of product capability entries verified by dedicated packet tests"
+    },
+    {
+      "name": "CATALOG_RUNTIME_CONFIGURATION_REQUEST",
+      "direction": "client_to_server",
+      "header": 10082,
+      "java": {
+        "symbol": "CatalogRuntimeConfigurationEvent",
+        "className": "CatalogRuntimeConfigurationEvent",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogRuntimeConfigurationEvent.java"
+      },
+      "typescript": {
+        "symbol": "CATALOG_RUNTIME_CONFIGURATION",
+        "className": "CatalogRuntimeConfigurationComposer",
+        "path": "packages/communication/src/messages/outgoing/catalog/configuration/CatalogRuntimeConfigurationComposer.ts"
+      },
+      "reason": "The optional versioned request keeps the standard recycler packets unchanged"
+    },
+    {
+      "name": "CATALOG_RUNTIME_CONFIGURATION_RESPONSE",
+      "direction": "server_to_client",
+      "header": 10082,
+      "java": {
+        "symbol": "CatalogRuntimeConfigurationComposer",
+        "className": "CatalogRuntimeConfigurationComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogRuntimeConfigurationComposer.java"
+      },
+      "typescript": {
+        "symbol": "CATALOG_RUNTIME_CONFIGURATION",
+        "className": "CatalogRuntimeConfigurationMessageParser",
+        "path": "packages/communication/src/messages/parser/catalog/configuration/CatalogRuntimeConfigurationMessageParser.ts"
+      },
+      "reason": "The bounded response carries emulator-authoritative catalog runtime settings without extending standard packets"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- preserve the catalog category loading and obsolete-layout cleanup already included in this branch
- expose database-backed tradeable and recyclable product metadata through a separate optional packet
- expose the authoritative recycler slot count through a versioned optional runtime packet
- validate recycler inputs against the configured count and live item capabilities
- reserve inventory items atomically across trading and recycling to prevent stale-item races
- restore inputs and clean up an uncommitted reward on every failed recycle path
- keep standard catalog and recycler packet structures unchanged

## Safety

- normal users remain unable to access disabled catalog pages
- optional responses are versioned, correlated, and bounded
- trade and recycle share the same synchronized inventory reservation path
- unrelated database migrations, runtime folders, and local tests are not included

## Validation

- Spotless check passed
- targeted catalog contract tests: 2 passed
- Maven package completed successfully
- final JAR: Emulator/target/Polaris-4.2.68.jar
- git diff check passed
- independent review: ready to merge

## Companion PRs

- UI: https://github.com/duckietm/Nitro-V3/pull/380
- Renderer: https://github.com/duckietm/Nitro_Render_V3/pull/171