### PR TITLE
fix(economy): make ledger authoritative for wallet persistence

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboInfo.java
@@ -14,7 +14,6 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomTile;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserStatusComposer;
-import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -59,10 +58,8 @@ public class HabboInfo implements Runnable {
     private RideablePet riding;
     private Class<? extends Game> currentGame;
     private Int2IntOpenHashMap currencies;
-    // Serializes credits + currencies read-modify-write and the saveCurrencies
-    // snapshot so the credit-roller thread and purchase/trade handler threads
-    // can't lose updates or rehash the Trove map mid-iteration. Never held
-    // across run()'s DB I/O.
+    // Serializes in-memory wallet reads and writes. Durable wallet changes are
+    // committed through EconomyLedger and then published to this snapshot.
     private final Object currencyLock = new Object();
     private final Object ledgerMutationLock = new Object();
     private GamePlayer gamePlayer;
@@ -139,32 +136,6 @@ public class HabboInfo implements Runnable {
                     this.id);
         } catch (SqlQueries.DataAccessException e) {
             LOGGER.error("Caught SQL exception", e);
-        }
-    }
-
-    private void saveCurrencies() {
-        // Snapshot under the lock so a concurrent adjustOrPutValue/put can't
-        // rehash the Trove map while we iterate; do the DB batch off-lock.
-        List<int[]> entries;
-        synchronized (this.currencyLock) {
-            entries = new ArrayList<>(this.currencies.size());
-            for (Int2IntMap.Entry entry : this.currencies.int2IntEntrySet()) {
-                entries.add(new int[] {entry.getIntKey(), entry.getIntValue()});
-            }
-        }
-
-        try {
-            SqlQueries.batchUpdate(
-                    "INSERT INTO users_currency (user_id, type, amount) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE amount = ?",
-                    entries,
-                    (ps, e) -> {
-                        ps.setInt(1, this.id);
-                        ps.setInt(2, e[0]);
-                        ps.setInt(3, e[1]);
-                        ps.setInt(4, e[1]);
-                    });
-        } catch (SqlQueries.DataAccessException ex) {
-            LOGGER.error("Caught SQL exception", ex);
         }
     }
 
@@ -796,23 +767,13 @@ public class HabboInfo implements Runnable {
 
     @Override
     public void run() {
-        this.saveCurrencies();
-
-        // Read credits under the lock so the persisted value is consistent with
-        // concurrent addCredits/setCredits (matches the currencyLock invariant).
-        final int creditsForSave;
-        synchronized (this.currencyLock) {
-            creditsForSave = this.credits;
-        }
-
         try {
             SqlQueries.update(
-                    "UPDATE users SET motto = ?, online = ?, look = ?, gender = ?, credits = ?, last_login = ?, last_online = ?, home_room = ?, ip_current = ?, `rank` = ?, machine_id = ?, username = ?, background_id = ?, background_stand_id = ?, background_overlay_id = ?, background_card_id = ?, background_border_id = ? WHERE id = ?",
+                    "UPDATE users SET motto = ?, online = ?, look = ?, gender = ?, last_login = ?, last_online = ?, home_room = ?, ip_current = ?, `rank` = ?, machine_id = ?, username = ?, background_id = ?, background_stand_id = ?, background_overlay_id = ?, background_card_id = ?, background_border_id = ? WHERE id = ?",
                     this.motto,
                     this.online ? "1" : "0",
                     this.look,
                     this.gender.name(),
-                    creditsForSave,
                     Emulator.getIntUnixTimestamp(),
                     this.lastOnline,
                     this.homeRoom,

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/economy/EconomyAuditCoverageContractTest.java
@@ -13,7 +13,7 @@ class EconomyAuditCoverageContractTest {
     private static final Path SOURCES = Path.of("src/main/java");
 
     @Test
-    void durableWalletSqlIsCentralizedInLedgerSnapshotAndAccountBootstrap() throws Exception {
+    void durableWalletSqlIsCentralizedInLedgerAndAccountBootstrap() throws Exception {
         Set<String> owners = new HashSet<>();
         try (var paths = Files.walk(SOURCES)) {
             for (Path path :
@@ -28,9 +28,9 @@ class EconomyAuditCoverageContractTest {
         }
 
         assertEquals(
-                Set.of("EconomyLedger.java", "HabboInfo.java", "RegistrationSupport.java"),
+                Set.of("EconomyLedger.java", "RegistrationSupport.java"),
                 owners,
-                "new durable wallet mutations must use EconomyLedger; only snapshot persistence and account bootstrap bypass it");
+                "durable wallet mutations must use EconomyLedger; only account bootstrap may initialize balances directly");
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/HabboInfoProfilePersistenceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/HabboInfoProfilePersistenceTest.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.habbohotel.users;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.database.Database;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+class HabboInfoProfilePersistenceTest {
+    @Test
+    void profileSnapshotNeverPersistsWalletBalances() throws Exception {
+        Database database = mock(Database.class);
+        HikariDataSource dataSource = mock(HikariDataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        when(database.getDataSource()).thenReturn(dataSource);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(statement);
+
+        HabboInfo info = new HabboInfo(42, 100);
+        info.applyPersistedCurrencyAmount(5, 200);
+
+        try (MockedStatic<Emulator> emulator = mockStatic(Emulator.class)) {
+            emulator.when(Emulator::getDatabase).thenReturn(database);
+            emulator.when(Emulator::getIntUnixTimestamp).thenReturn(1_700_000_000);
+            info.run();
+        }
+
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+        verify(connection, times(1)).prepareStatement(sql.capture());
+        List<String> statements = sql.getAllValues();
+
+        assertEquals(1, statements.size());
+        assertTrue(statements.getFirst().startsWith("UPDATE users SET motto = ?"));
+        assertFalse(statements.getFirst().contains("credits"));
+        assertFalse(statements.stream().anyMatch(query -> query.contains("users_currency")));
+    }
+}


### PR DESCRIPTION
## Summary
- stop generic profile persistence from writing credits and currencies
- keep `EconomyLedger` as the sole durable wallet writer after account bootstrap
- add regression coverage preventing wallet SQL from returning to `HabboInfo`

## Root cause
The generic user profile snapshot still persisted wallet balances independently from the transactional economy ledger. A delayed profile save could therefore overwrite a newer authoritative balance.

## Verification
- `./mvnw.cmd -Dtest=HabboInfoProfilePersistenceTest,EconomyAuditCoverageContractTest,HabboInfoCreditCompatibilityTest,LedgerWalletMutationCoordinationTest,WalletMutationContractTest test`
- `./mvnw.cmd test` — 1469 tests, 0 failures, 0 errors, 7 skipped
- `./mvnw.cmd spotless:check`