### PR TITLE
feat(core): add bounded execution backpressure

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
@@ -130,7 +130,10 @@ public final class ConfigRegistry {
                 "ws.port",
                 "session.reconnect.grace.seconds");
         keys.add(definition("runtime.threads", ConfigKey.ValueType.INTEGER, "8", true));
+        keys.add(definition("io.packet.handler.threads", ConfigKey.ValueType.INTEGER, "0", true));
+        keys.add(definition("io.packet.handler.queue.capacity", ConfigKey.ValueType.INTEGER, "256", true));
         keys.add(definition("http.blocking.pool.size", ConfigKey.ValueType.INTEGER, "8", true));
+        keys.add(definition("http.blocking.queue.capacity", ConfigKey.ValueType.INTEGER, "128", true));
         keys.add(definition("stress.max_bots", ConfigKey.ValueType.INTEGER, "5000", true));
         keys.add(definition("stress.max_items", ConfigKey.ValueType.INTEGER, "100000", true));
         keys.add(definition("stress.max_rollers", ConfigKey.ValueType.INTEGER, "50000", true));
@@ -263,6 +266,9 @@ public final class ConfigRegistry {
         }
         if (name.startsWith("http.blocking.")) {
             return "Blocking HTTP worker setting.";
+        }
+        if (name.startsWith("io.packet.handler.")) {
+            return "Game packet worker setting.";
         }
         if (name.startsWith("io.netty.")) {
             return "Netty channel flow-control setting.";

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
@@ -452,6 +452,7 @@ public final class EmulatorStatsService {
         previousOutgoingBytes = outgoingBytes;
         previousTelemetryAt = now;
         PacketDispatchLatencyMetrics.Snapshot dispatch = PacketDispatchLatencyMetrics.snapshot();
+        ExecutionBackpressureMetrics.Snapshot backpressure = ExecutionBackpressureMetrics.snapshot();
 
         return new NetworkMetrics(
                 Math.max(0D, incomingPacketsPerSecond),
@@ -463,7 +464,9 @@ public final class EmulatorStatsService {
                 dispatch.samples(),
                 dispatch.averageMs(),
                 dispatch.p95Ms(),
-                dispatch.maxMs());
+                dispatch.maxMs(),
+                backpressure.packetRejectedTasks(),
+                backpressure.blockingHttpRejectedTasks());
     }
 
     private static GarbageCollectorMetrics collectGarbageCollectorMetrics(long now) {
@@ -879,6 +882,8 @@ public final class EmulatorStatsService {
         public final double dispatchAverageMs;
         public final double dispatchP95Ms;
         public final double dispatchMaxMs;
+        public final long rejectedPacketTasks;
+        public final long rejectedBlockingHttpTasks;
 
         public NetworkMetrics(
                 double incomingPacketsPerSecond,
@@ -897,7 +902,9 @@ public final class EmulatorStatsService {
                     0L,
                     0D,
                     0D,
-                    0D);
+                    0D,
+                    0L,
+                    0L);
         }
 
         public NetworkMetrics(
@@ -911,6 +918,34 @@ public final class EmulatorStatsService {
                 double dispatchAverageMs,
                 double dispatchP95Ms,
                 double dispatchMaxMs) {
+            this(
+                    incomingPacketsPerSecond,
+                    outgoingPacketsPerSecond,
+                    incomingKilobytesPerSecond,
+                    outgoingKilobytesPerSecond,
+                    totalIncomingPackets,
+                    totalOutgoingPackets,
+                    dispatchSamples,
+                    dispatchAverageMs,
+                    dispatchP95Ms,
+                    dispatchMaxMs,
+                    0L,
+                    0L);
+        }
+
+        public NetworkMetrics(
+                double incomingPacketsPerSecond,
+                double outgoingPacketsPerSecond,
+                double incomingKilobytesPerSecond,
+                double outgoingKilobytesPerSecond,
+                long totalIncomingPackets,
+                long totalOutgoingPackets,
+                long dispatchSamples,
+                double dispatchAverageMs,
+                double dispatchP95Ms,
+                double dispatchMaxMs,
+                long rejectedPacketTasks,
+                long rejectedBlockingHttpTasks) {
             this.incomingPacketsPerSecond = incomingPacketsPerSecond;
             this.outgoingPacketsPerSecond = outgoingPacketsPerSecond;
             this.incomingKilobytesPerSecond = incomingKilobytesPerSecond;
@@ -921,6 +956,8 @@ public final class EmulatorStatsService {
             this.dispatchAverageMs = dispatchAverageMs;
             this.dispatchP95Ms = dispatchP95Ms;
             this.dispatchMaxMs = dispatchMaxMs;
+            this.rejectedPacketTasks = rejectedPacketTasks;
+            this.rejectedBlockingHttpTasks = rejectedBlockingHttpTasks;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/ExecutionBackpressureMetrics.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/ExecutionBackpressureMetrics.java
@@ -1,0 +1,28 @@
+package com.eu.habbo.monitoring;
+
+import java.util.concurrent.atomic.LongAdder;
+
+public final class ExecutionBackpressureMetrics {
+    private static final LongAdder PACKET_REJECTED_TASKS = new LongAdder();
+    private static final LongAdder BLOCKING_HTTP_REJECTED_TASKS = new LongAdder();
+
+    private ExecutionBackpressureMetrics() {}
+
+    public static void recordRejection(Lane lane) {
+        switch (lane) {
+            case GAME_PACKET -> PACKET_REJECTED_TASKS.increment();
+            case BLOCKING_HTTP -> BLOCKING_HTTP_REJECTED_TASKS.increment();
+        }
+    }
+
+    public static Snapshot snapshot() {
+        return new Snapshot(PACKET_REJECTED_TASKS.sum(), BLOCKING_HTTP_REJECTED_TASKS.sum());
+    }
+
+    public enum Lane {
+        GAME_PACKET,
+        BLOCKING_HTTP
+    }
+
+    public record Snapshot(long packetRejectedTasks, long blockingHttpRejectedTasks) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
@@ -1,20 +1,28 @@
 package com.eu.habbo.networking.gameserver;
 
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
 import io.netty.util.concurrent.EventExecutorGroup;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 final class BlockingHttpExecutionGroup {
+    private static final int DEFAULT_QUEUE_CAPACITY = 128;
     private static final Logger LOGGER = LoggerFactory.getLogger(BlockingHttpExecutionGroup.class);
     private static final GroupHolder GROUP = new GroupHolder();
 
     private BlockingHttpExecutionGroup() {}
 
     static EventExecutorGroup get(int configuredThreads) {
-        return GROUP.get(configuredThreads);
+        return get(configuredThreads, DEFAULT_QUEUE_CAPACITY);
+    }
+
+    static EventExecutorGroup get(int configuredThreads, int configuredQueueCapacity) {
+        return GROUP.get(configuredThreads, configuredQueueCapacity);
+    }
+
+    static ExecutionCapacityGate admissionGate() {
+        return GROUP.admissionGate();
     }
 
     static void shutdown() {
@@ -23,13 +31,29 @@ final class BlockingHttpExecutionGroup {
 
     private static final class GroupHolder {
         private EventExecutorGroup group;
+        private ExecutionCapacityGate admissionGate;
 
-        private synchronized EventExecutorGroup get(int configuredThreads) {
+        private synchronized EventExecutorGroup get(int configuredThreads, int configuredQueueCapacity) {
             if (this.group == null || this.group.isShuttingDown() || this.group.isShutdown()) {
                 int threads = configuredThreads > 0 ? configuredThreads : 8;
-                this.group = new DefaultEventExecutorGroup(threads, new DefaultThreadFactory("BlockingHttp", true));
+                int applicationCapacity = BoundedEventExecutorGroups.configuredQueueCapacity(
+                        configuredQueueCapacity, DEFAULT_QUEUE_CAPACITY);
+                this.admissionGate =
+                        new ExecutionCapacityGate(applicationCapacity, ExecutionBackpressureMetrics.Lane.BLOCKING_HTTP);
+                this.group = BoundedEventExecutorGroups.create(
+                        threads,
+                        BoundedEventExecutorGroups.withControlTaskReserve(applicationCapacity),
+                        "BlockingHttp",
+                        ExecutionBackpressureMetrics.Lane.BLOCKING_HTTP);
             }
             return this.group;
+        }
+
+        private synchronized ExecutionCapacityGate admissionGate() {
+            if (this.admissionGate == null) {
+                throw new IllegalStateException("Blocking HTTP executor has not been initialized");
+            }
+            return this.admissionGate;
         }
 
         private synchronized void shutdown() {
@@ -42,6 +66,7 @@ final class BlockingHttpExecutionGroup {
                 LOGGER.warn("Blocking HTTP group shutdown interrupted", e);
             } finally {
                 this.group = null;
+                this.admissionGate = null;
             }
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BoundedEventExecutorGroups.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BoundedEventExecutorGroups.java
@@ -1,0 +1,42 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.EventExecutorGroup;
+import java.util.concurrent.RejectedExecutionException;
+
+final class BoundedEventExecutorGroups {
+    static final int MINIMUM_QUEUE_CAPACITY = 16;
+    private static final int CONTROL_TASK_RESERVE = 64;
+
+    private BoundedEventExecutorGroups() {}
+
+    static EventExecutorGroup create(
+            int threads, int queueCapacity, String threadPrefix, ExecutionBackpressureMetrics.Lane lane) {
+        if (threads <= 0) {
+            throw new IllegalArgumentException("Executor thread count must be positive");
+        }
+        if (queueCapacity < MINIMUM_QUEUE_CAPACITY) {
+            throw new IllegalArgumentException("Executor queue capacity must be at least " + MINIMUM_QUEUE_CAPACITY);
+        }
+
+        return new DefaultEventExecutorGroup(
+                threads, new DefaultThreadFactory(threadPrefix, true), queueCapacity, (task, executor) -> {
+                    ExecutionBackpressureMetrics.recordRejection(lane);
+                    throw new RejectedExecutionException(lane + " execution queue is full");
+                });
+    }
+
+    static int configuredQueueCapacity(int configured, int fallback) {
+        int selected = configured > 0 ? configured : fallback;
+        return Math.max(MINIMUM_QUEUE_CAPACITY, selected);
+    }
+
+    static int withControlTaskReserve(int applicationCapacity) {
+        if (applicationCapacity > Integer.MAX_VALUE - CONTROL_TASK_RESERVE) {
+            return Integer.MAX_VALUE;
+        }
+        return applicationCapacity + CONTROL_TASK_RESERVE;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionAdmissionHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionAdmissionHandler.java
@@ -1,0 +1,117 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.messages.ClientMessage;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.EventExecutor;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.RejectedExecutionException;
+
+final class ExecutionAdmissionHandler extends ChannelInboundHandlerAdapter {
+    private static final byte[] BUSY_RESPONSE =
+            "{\"error\":\"Server busy, try again shortly.\"}".getBytes(StandardCharsets.UTF_8);
+
+    private final String targetHandlerName;
+    private final Mode mode;
+    private final ExecutionCapacityGate capacityGate;
+
+    private ExecutionAdmissionHandler(String targetHandlerName, Mode mode, ExecutionCapacityGate capacityGate) {
+        this.targetHandlerName = targetHandlerName;
+        this.mode = mode;
+        this.capacityGate = capacityGate;
+    }
+
+    static ExecutionAdmissionHandler forGamePackets(String targetHandlerName, ExecutionCapacityGate capacityGate) {
+        return new ExecutionAdmissionHandler(targetHandlerName, Mode.GAME_PACKET, capacityGate);
+    }
+
+    static ExecutionAdmissionHandler forBlockingHttp(String targetHandlerName, ExecutionCapacityGate capacityGate) {
+        return new ExecutionAdmissionHandler(targetHandlerName, Mode.BLOCKING_HTTP, capacityGate);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (!this.mode.accepts(msg)) {
+            ctx.fireChannelRead(msg);
+            return;
+        }
+
+        if (!this.capacityGate.tryAcquire()) {
+            reject(ctx, msg);
+            return;
+        }
+
+        ChannelHandlerContext target = ctx.pipeline().context(this.targetHandlerName);
+        if (target == null) {
+            this.capacityGate.release();
+            reject(ctx, msg);
+            return;
+        }
+
+        EventExecutor executor = target.executor();
+        if (executor.inEventLoop()) {
+            try {
+                ctx.fireChannelRead(msg);
+            } finally {
+                this.capacityGate.release();
+            }
+            return;
+        }
+
+        try {
+            executor.execute(() -> {
+                try {
+                    ctx.fireChannelRead(msg);
+                } finally {
+                    this.capacityGate.release();
+                }
+            });
+        } catch (RejectedExecutionException rejected) {
+            this.capacityGate.release();
+            reject(ctx, msg);
+        }
+    }
+
+    private void reject(ChannelHandlerContext ctx, Object msg) {
+        if (msg instanceof ClientMessage clientMessage) {
+            clientMessage.release();
+            ctx.close();
+            return;
+        }
+
+        ReferenceCountUtil.release(msg);
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.SERVICE_UNAVAILABLE, Unpooled.wrappedBuffer(BUSY_RESPONSE));
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json; charset=UTF-8");
+        response.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, BUSY_RESPONSE.length);
+        response.headers().set(HttpHeaderNames.RETRY_AFTER, "1");
+        response.headers().set(HttpHeaderNames.CONNECTION, "close");
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private enum Mode {
+        GAME_PACKET {
+            @Override
+            boolean accepts(Object msg) {
+                return msg instanceof ClientMessage;
+            }
+        },
+        BLOCKING_HTTP {
+            @Override
+            boolean accepts(Object msg) {
+                return msg instanceof FullHttpRequest;
+            }
+        };
+
+        abstract boolean accepts(Object msg);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionCapacityGate.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionCapacityGate.java
@@ -1,0 +1,29 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
+import java.util.concurrent.Semaphore;
+
+final class ExecutionCapacityGate {
+    private final Semaphore permits;
+    private final ExecutionBackpressureMetrics.Lane lane;
+
+    ExecutionCapacityGate(int capacity, ExecutionBackpressureMetrics.Lane lane) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Execution capacity must be positive");
+        }
+        this.permits = new Semaphore(capacity);
+        this.lane = lane;
+    }
+
+    boolean tryAcquire() {
+        if (this.permits.tryAcquire()) {
+            return true;
+        }
+        ExecutionBackpressureMetrics.recordRejection(this.lane);
+        return false;
+    }
+
+    void release() {
+        this.permits.release();
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GamePacketExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GamePacketExecutionGroup.java
@@ -1,25 +1,33 @@
 package com.eu.habbo.networking.gameserver;
 
 import com.eu.habbo.Emulator;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
 import io.netty.util.concurrent.EventExecutorGroup;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
-
 final class GamePacketExecutionGroup {
+    private static final int DEFAULT_QUEUE_CAPACITY = 256;
     private static final Logger LOGGER = LoggerFactory.getLogger(GamePacketExecutionGroup.class);
-    private static final EventExecutorGroup GROUP = new DefaultEventExecutorGroup(
+    private static final int APPLICATION_QUEUE_CAPACITY = configuredQueueCapacity();
+    private static final ExecutionCapacityGate ADMISSION_GATE =
+            new ExecutionCapacityGate(APPLICATION_QUEUE_CAPACITY, ExecutionBackpressureMetrics.Lane.GAME_PACKET);
+    private static final EventExecutorGroup GROUP = BoundedEventExecutorGroups.create(
             configuredThreads(),
-            new DefaultThreadFactory("GamePacketHandler", true));
+            BoundedEventExecutorGroups.withControlTaskReserve(APPLICATION_QUEUE_CAPACITY),
+            "GamePacketHandler",
+            ExecutionBackpressureMetrics.Lane.GAME_PACKET);
 
-    private GamePacketExecutionGroup() {
-    }
+    private GamePacketExecutionGroup() {}
 
     static EventExecutorGroup get() {
         return GROUP;
+    }
+
+    static ExecutionCapacityGate admissionGate() {
+        return ADMISSION_GATE;
     }
 
     static void shutdown() {
@@ -32,11 +40,20 @@ final class GamePacketExecutionGroup {
 
     static int configuredThreads() {
         int fallback = Math.max(16, Runtime.getRuntime().availableProcessors() * 2);
-        if (Emulator.getConfig() == null) {
+        ConfigurationManager configuration = Emulator.getConfig();
+        if (configuration == null) {
             return fallback;
         }
 
-        int configured = Emulator.getConfig().getInt("io.packet.handler.threads", fallback);
+        int configured = configuration.getInt("io.packet.handler.threads", fallback);
         return configured > 0 ? configured : fallback;
+    }
+
+    static int configuredQueueCapacity() {
+        ConfigurationManager configuration = Emulator.getConfig();
+        int configured = configuration == null
+                ? DEFAULT_QUEUE_CAPACITY
+                : configuration.getInt("io.packet.handler.queue.capacity", DEFAULT_QUEUE_CAPACITY);
+        return BoundedEventExecutorGroups.configuredQueueCapacity(configured, DEFAULT_QUEUE_CAPACITY);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -77,6 +77,11 @@ public class GameServer extends Server {
                 ch.pipeline().addLast("packetDispatchMarker", new PacketDispatchMarker());
                 ch.pipeline()
                         .addLast(
+                                "packetExecutionAdmission",
+                                ExecutionAdmissionHandler.forGamePackets(
+                                        "packetDispatchLatency", GamePacketExecutionGroup.admissionGate()));
+                ch.pipeline()
+                        .addLast(
                                 GamePacketExecutionGroup.get(),
                                 "packetDispatchLatency",
                                 new PacketDispatchLatencyHandler());
@@ -104,7 +109,9 @@ public class GameServer extends Server {
         int wsPort = configuration().getInt("ws.port", 2096);
 
         WebSocketChannelInitializer wsInitializer = new WebSocketChannelInitializer(
-                configuredUnwritableTimeoutSeconds(), configuration().getInt("http.blocking.pool.size", 8));
+                configuredUnwritableTimeoutSeconds(),
+                configuration().getInt("http.blocking.pool.size", 8),
+                configuration().getInt("http.blocking.queue.capacity", 128));
 
         this.webSocketBootstrap = new ServerBootstrap();
         this.webSocketBootstrap.group(this.getBossGroup(), this.getWorkerGroup());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -51,21 +51,27 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
     private final WebSocketServerProtocolConfig wsConfig;
     private final int unwritableTimeoutSeconds;
     private final int blockingHttpThreads;
+    private final int blockingHttpQueueCapacity;
 
     public WebSocketChannelInitializer() {
-        this(10, 8);
+        this(10, 8, 128);
     }
 
     WebSocketChannelInitializer(int unwritableTimeoutSeconds) {
-        this(unwritableTimeoutSeconds, 8);
+        this(unwritableTimeoutSeconds, 8, 128);
     }
 
     WebSocketChannelInitializer(int unwritableTimeoutSeconds, int blockingHttpThreads) {
+        this(unwritableTimeoutSeconds, blockingHttpThreads, 128);
+    }
+
+    WebSocketChannelInitializer(int unwritableTimeoutSeconds, int blockingHttpThreads, int blockingHttpQueueCapacity) {
         if (unwritableTimeoutSeconds <= 0) {
             throw new IllegalArgumentException("unwritableTimeoutSeconds must be positive");
         }
         this.unwritableTimeoutSeconds = unwritableTimeoutSeconds;
         this.blockingHttpThreads = blockingHttpThreads;
+        this.blockingHttpQueueCapacity = blockingHttpQueueCapacity;
         this.sslContext = SSLCertificateLoader.getContext();
         this.sslEnabled = this.sslContext != null;
         this.wsConfig = WebSocketServerProtocolConfig.newBuilder()
@@ -91,10 +97,16 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast("httpCodec", new HttpServerCodec());
         ch.pipeline().addLast("httpAggregator", new HttpObjectAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsHttpHandler", new WebSocketHttpHandler());
-        EventExecutorGroup blockingHttp = BlockingHttpExecutionGroup.get(this.blockingHttpThreads);
+        EventExecutorGroup blockingHttp =
+                BlockingHttpExecutionGroup.get(this.blockingHttpThreads, this.blockingHttpQueueCapacity);
+        ch.pipeline()
+                .addLast(
+                        "blockingHttpAdmission",
+                        ExecutionAdmissionHandler.forBlockingHttp(
+                                "nitroSecureAssetHandler", BlockingHttpExecutionGroup.admissionGate()));
         ch.pipeline().addLast(blockingHttp, "nitroSecureAssetHandler", new NitroSecureAssetHandler());
-        ch.pipeline().addLast("nitroSecureApiHandler", new NitroSecureApiHandler());
-        ch.pipeline().addLast("authHttpHandler", new AuthHttpHandler());
+        ch.pipeline().addLast(blockingHttp, "nitroSecureApiHandler", new NitroSecureApiHandler());
+        ch.pipeline().addLast(blockingHttp, "authHttpHandler", new AuthHttpHandler());
         ch.pipeline().addLast(blockingHttp, "cmsApiHandler", new CmsApiHandler());
         ch.pipeline().addLast(blockingHttp, "badgeHttpHandler", new BadgeHttpHandler());
         ch.pipeline().addLast(blockingHttp, "badgeLeaderboardHttpHandler", new BadgeLeaderboardHttpHandler());
@@ -119,6 +131,11 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
         ch.pipeline().addLast(new GameMessageRateLimit());
         ch.pipeline().addLast("packetDispatchMarker", new PacketDispatchMarker());
+        ch.pipeline()
+                .addLast(
+                        "packetExecutionAdmission",
+                        ExecutionAdmissionHandler.forGamePackets(
+                                "packetDispatchLatency", GamePacketExecutionGroup.admissionGate()));
         ch.pipeline()
                 .addLast(GamePacketExecutionGroup.get(), "packetDispatchLatency", new PacketDispatchLatencyHandler());
         ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/WebSocketHttpCleanupHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/WebSocketHttpCleanupHandler.java
@@ -14,9 +14,11 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
  */
 public class WebSocketHttpCleanupHandler extends ChannelInboundHandlerAdapter {
     private static final String[] HTTP_ONLY_HANDLERS = {
+        "blockingHttpAdmission",
         "nitroSecureAssetHandler",
         "nitroSecureApiHandler",
         "authHttpHandler",
+        "cmsApiHandler",
         "badgeHttpHandler",
         "badgeLeaderboardHttpHandler",
         "emuStatsHttpHandler",

--- a/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
@@ -57,6 +57,8 @@ class ConfigRegistryTest {
         String reference = ConfigRegistry.standard().renderMarkdown();
 
         assertTrue(reference.contains("| `http.blocking.pool.size` | integer | `8` |"));
+        assertTrue(reference.contains("| `http.blocking.queue.capacity` | integer | `128` |"));
+        assertTrue(reference.contains("| `io.packet.handler.queue.capacity` | integer | `256` |"));
         assertTrue(reference.contains("| `io.netty.write_buffer.low_water_mark` | integer | `32768` |"));
         assertTrue(reference.contains("| `io.netty.write_buffer.high_water_mark` | integer | `65536` |"));
         assertTrue(reference.contains("| `io.netty.unwritable.timeout.seconds` | integer | `10` |"));

--- a/Emulator/src/test/java/com/eu/habbo/monitoring/NetworkDispatchMetricsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/monitoring/NetworkDispatchMetricsContractTest.java
@@ -9,11 +9,13 @@ class NetworkDispatchMetricsContractTest {
     @Test
     void networkSnapshotExposesDispatchLatencyWindow() {
         EmulatorStatsService.NetworkMetrics metrics =
-                new EmulatorStatsService.NetworkMetrics(1D, 2D, 3D, 4D, 5L, 6L, 7L, 8D, 9D, 10D);
+                new EmulatorStatsService.NetworkMetrics(1D, 2D, 3D, 4D, 5L, 6L, 7L, 8D, 9D, 10D, 11L, 12L);
 
         assertEquals(7L, metrics.dispatchSamples);
         assertEquals(8D, metrics.dispatchAverageMs);
         assertEquals(9D, metrics.dispatchP95Ms);
         assertEquals(10D, metrics.dispatchMaxMs);
+        assertEquals(11L, metrics.rejectedPacketTasks);
+        assertEquals(12L, metrics.rejectedBlockingHttpTasks);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BoundedExecutionBackpressureTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/BoundedExecutionBackpressureTest.java
@@ -1,0 +1,156 @@
+package com.eu.habbo.networking.gameserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.EventExecutorGroup;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class BoundedExecutionBackpressureTest {
+    private static final int MINIMUM_QUEUE_CAPACITY = 16;
+
+    @Test
+    void saturatedExecutorRejectsWithoutRunningWorkOnTheCaller() throws Exception {
+        long rejectedBefore = ExecutionBackpressureMetrics.snapshot().packetRejectedTasks();
+        AtomicBoolean ranOnCaller = new AtomicBoolean();
+        EventExecutorGroup group = BoundedEventExecutorGroups.create(
+                1, MINIMUM_QUEUE_CAPACITY, "PacketBackpressureTest", ExecutionBackpressureMetrics.Lane.GAME_PACKET);
+        CountDownLatch releaseWorker = saturate(group);
+
+        try {
+            assertThrows(RejectedExecutionException.class, () -> group.execute(() -> ranOnCaller.set(true)));
+            assertFalse(ranOnCaller.get(), "rejected work must never run on the Netty caller thread");
+            assertEquals(
+                    rejectedBefore + 1, ExecutionBackpressureMetrics.snapshot().packetRejectedTasks());
+        } finally {
+            releaseWorker.countDown();
+            group.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void saturatedHttpLaneReturnsRetryableServiceUnavailable() throws Exception {
+        EventExecutorGroup group = BoundedEventExecutorGroups.create(
+                1, MINIMUM_QUEUE_CAPACITY, "HttpBackpressureTest", ExecutionBackpressureMetrics.Lane.BLOCKING_HTTP);
+        ExecutionCapacityGate capacityGate =
+                new ExecutionCapacityGate(1, ExecutionBackpressureMetrics.Lane.BLOCKING_HTTP);
+        assertTrue(capacityGate.tryAcquire());
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline()
+                .addLast("httpAdmission", ExecutionAdmissionHandler.forBlockingHttp("httpTarget", capacityGate))
+                .addLast(group, "httpTarget", new ChannelInboundHandlerAdapter());
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/api/test");
+
+        try {
+            channel.writeInbound(request);
+            FullHttpResponse response = channel.readOutbound();
+
+            assertEquals(HttpResponseStatus.SERVICE_UNAVAILABLE, response.status());
+            assertEquals("1", response.headers().get(HttpHeaderNames.RETRY_AFTER));
+            assertEquals(0, request.refCnt(), "the rejected HTTP request must be released");
+            response.release();
+        } finally {
+            capacityGate.release();
+            channel.finishAndReleaseAll();
+            group.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void saturatedPacketLaneReleasesPayloadAndClosesChannel() throws Exception {
+        EventExecutorGroup group = BoundedEventExecutorGroups.create(
+                1, MINIMUM_QUEUE_CAPACITY, "PacketAdmissionTest", ExecutionBackpressureMetrics.Lane.GAME_PACKET);
+        ExecutionCapacityGate capacityGate =
+                new ExecutionCapacityGate(1, ExecutionBackpressureMetrics.Lane.GAME_PACKET);
+        assertTrue(capacityGate.tryAcquire());
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline()
+                .addLast("packetAdmission", ExecutionAdmissionHandler.forGamePackets("packetTarget", capacityGate))
+                .addLast(group, "packetTarget", new ChannelInboundHandlerAdapter());
+        ByteBuf payload = Unpooled.buffer(1).writeByte(1);
+        ClientMessage message = new ClientMessage(1, payload);
+
+        try {
+            channel.writeInbound(message);
+
+            assertEquals(0, payload.refCnt(), "the rejected packet payload must be released");
+            assertFalse(channel.isOpen(), "an overloaded game channel must be closed predictably");
+        } finally {
+            capacityGate.release();
+            channel.finishAndReleaseAll();
+            group.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void completedWorkReturnsAdmissionCapacity() {
+        EventExecutorGroup group = BoundedEventExecutorGroups.create(
+                1, MINIMUM_QUEUE_CAPACITY, "AdmissionReleaseTest", ExecutionBackpressureMetrics.Lane.BLOCKING_HTTP);
+        ExecutionCapacityGate capacityGate =
+                new ExecutionCapacityGate(1, ExecutionBackpressureMetrics.Lane.BLOCKING_HTTP);
+        AtomicInteger processed = new AtomicInteger();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline()
+                .addLast("httpAdmission", ExecutionAdmissionHandler.forBlockingHttp("httpTarget", capacityGate))
+                .addLast(group, "httpTarget", new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(io.netty.channel.ChannelHandlerContext ctx, Object msg) {
+                        ReferenceCountUtil.release(msg);
+                        processed.incrementAndGet();
+                    }
+                });
+
+        try {
+            channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/first"));
+            group.submit(() -> {}).syncUninterruptibly();
+            channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/second"));
+            group.submit(() -> {}).syncUninterruptibly();
+
+            assertEquals(2, processed.get());
+            assertTrue(channel.isOpen());
+        } finally {
+            channel.finishAndReleaseAll();
+            group.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+        }
+    }
+
+    private static CountDownLatch saturate(EventExecutorGroup group) throws InterruptedException {
+        CountDownLatch workerStarted = new CountDownLatch(1);
+        CountDownLatch releaseWorker = new CountDownLatch(1);
+        group.execute(() -> {
+            workerStarted.countDown();
+            try {
+                releaseWorker.await();
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        if (!workerStarted.await(2, TimeUnit.SECONDS)) {
+            throw new AssertionError("worker did not start");
+        }
+        for (int index = 0; index < MINIMUM_QUEUE_CAPACITY; index++) {
+            group.execute(() -> {});
+        }
+        return releaseWorker;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/GamePacketExecutionContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/GamePacketExecutionContractTest.java
@@ -38,11 +38,13 @@ class GamePacketExecutionContractTest {
 
     private static void assertLatencyProbeOrder(String pipelineSource) {
         int marker = pipelineSource.indexOf("new PacketDispatchMarker()");
+        int admission = pipelineSource.indexOf("\"packetExecutionAdmission\"");
         int latency = pipelineSource.indexOf("\"packetDispatchLatency\"");
         int handler = pipelineSource.indexOf("\"gameMessageHandler\"");
 
         assertTrue(marker >= 0);
-        assertTrue(latency > marker, "dispatch latency must start after the I/O marker");
+        assertTrue(admission > marker, "bounded admission must run after the I/O marker");
+        assertTrue(latency > admission, "bounded admission must protect the packet worker queue");
         assertTrue(handler > latency, "dispatch latency must be observed before packet handling");
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
@@ -62,7 +62,12 @@ class WebSocketHttpOffloadTest {
                     blockingExecutor,
                     awaitPresent(channel, "emuStatsHttpHandler").executor());
             assertSame(socketExecutor, awaitPresent(channel, "wsHttpHandler").executor());
-            assertSame(socketExecutor, awaitPresent(channel, "authHttpHandler").executor());
+            assertSame(
+                    blockingExecutor,
+                    awaitPresent(channel, "nitroSecureApiHandler").executor());
+            assertSame(
+                    blockingExecutor, awaitPresent(channel, "authHttpHandler").executor());
+            assertSame(blockingExecutor, awaitPresent(channel, "cmsApiHandler").executor());
         } finally {
             channel.close().syncUninterruptibly();
             eventLoops.shutdownGracefully().syncUninterruptibly();
@@ -100,9 +105,11 @@ class WebSocketHttpOffloadTest {
 
             // Handlers bound to the blocking HTTP executor are unlinked on that
             // executor, so wait for the removals to settle.
+            awaitRemoved(channel, "blockingHttpAdmission");
             awaitRemoved(channel, "nitroSecureAssetHandler");
             awaitRemoved(channel, "nitroSecureApiHandler");
             awaitRemoved(channel, "authHttpHandler");
+            awaitRemoved(channel, "cmsApiHandler");
             awaitRemoved(channel, "badgeHttpHandler");
             awaitRemoved(channel, "badgeLeaderboardHttpHandler");
             awaitRemoved(channel, "emuStatsHttpHandler");

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -43,9 +43,12 @@ Unknown keys remain allowed for plugins. Database-backed hotel settings are docu
 | `game.port` | integer | `0` | `EMU_PORT` | yes | no | Game listener setting. |
 | `habbo.console.style` | string | `` | — | yes | no | Polaris startup setting. |
 | `http.blocking.pool.size` | integer | `8` | — | yes | no | Blocking HTTP worker setting. |
+| `http.blocking.queue.capacity` | integer | `128` | — | yes | no | Blocking HTTP worker setting. |
 | `io.netty.unwritable.timeout.seconds` | integer | `10` | — | yes | no | Netty channel flow-control setting. |
 | `io.netty.write_buffer.high_water_mark` | integer | `65536` | — | yes | no | Netty channel flow-control setting. |
 | `io.netty.write_buffer.low_water_mark` | integer | `32768` | — | yes | no | Netty channel flow-control setting. |
+| `io.packet.handler.queue.capacity` | integer | `256` | — | yes | no | Game packet worker setting. |
+| `io.packet.handler.threads` | integer | `0` | — | yes | no | Game packet worker setting. |
 | `login.news.limit` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
 | `login.remember.duration.days` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
 | `login.remember.enabled` | boolean | `false` | — | yes | no | Built-in login endpoint setting. |


### PR DESCRIPTION
## Summary
- bound game-packet and blocking-HTTP work with configurable admission capacities
- reject overload predictably without running work on the Netty I/O thread
- return HTTP 503 with `Retry-After`, release rejected packet buffers, and keep control-task capacity available for channel cleanup
- expose cumulative packet/HTTP rejection counters through emulator network stats
- keep all HTTP route handlers on the same ordered worker lane and remove the complete HTTP-only chain after WebSocket upgrade

## Configuration
- `io.packet.handler.threads` (default `0`, automatic sizing)
- `io.packet.handler.queue.capacity` (default `256`)
- `http.blocking.pool.size` (existing, default `8`)
- `http.blocking.queue.capacity` (default `128`)

## Why
The default Netty executor limit was effectively unbounded. Sustained packet or blocking HTTP load could therefore retain work and payloads until memory pressure became the failure mode. The new admission gates reject excess application work before the internal executor queue loses the capacity required for lifecycle and cleanup callbacks.

## Verification
- TDD saturation tests covering no caller-runs behavior, HTTP 503/retry response, packet-buffer release, channel closure, and permit recovery
- `./mvnw.cmd -Dtest=FrozenArchitectureBaselineTest,BoundedExecutionBackpressureTest,GamePacketExecutionContractTest,WebSocketHttpOffloadTest,NetworkDispatchMetricsContractTest,ConfigRegistryTest test`
- `./mvnw.cmd test` — 1472 tests, 0 failures, 0 errors, 7 skipped
- `./mvnw.cmd spotless:check`
- `git diff --check`

This PR is independent from #578 and can be reviewed or merged separately.