### PR TITLE
fix(core): isolate persistence overload from gameplay threads

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
+++ b/Emulator/src/main/java/com/eu/habbo/PolarisBootstrap.java
@@ -38,6 +38,8 @@ import org.slf4j.LoggerFactory;
 final class PolarisBootstrap {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PolarisBootstrap.class);
+    private static final int DEFAULT_PERSISTENCE_QUEUE_CAPACITY = 2_048;
+    private static final int MAX_PERSISTENCE_QUEUE_CAPACITY = 65_536;
 
     private final PolarisRuntime runtime;
     private final Runnable registerConfigurationDefaults;
@@ -113,9 +115,12 @@ final class PolarisBootstrap {
         configuration.loaded = true;
         configuration.loadFromDatabase();
         configuration.register("runtime.threads", "8");
+        configuration.register("db.persistence.queue.capacity", "2048");
 
         int runtimeThreads = resolveRuntimeThreads(configuration);
-        PersistenceExecutor persistenceExecutor = PersistenceExecutor.forRuntimeThreads(runtimeThreads);
+        int persistenceQueueCapacity = resolvePersistenceQueueCapacity(configuration);
+        PersistenceExecutor persistenceExecutor =
+                PersistenceExecutor.forRuntimeThreads(runtimeThreads, persistenceQueueCapacity);
         runtime.installPersistenceExecutor(persistenceExecutor);
         runtime.installThreading(new ThreadPooling(runtimeThreads, persistenceExecutor));
         Emulator.synchronizeLegacyFacade(runtime);
@@ -126,6 +131,19 @@ final class PolarisBootstrap {
     static int resolveRuntimeThreads(ConfigurationManager configuration) {
         int configured = configuration.getInt("runtime.threads", 8);
         return configured > 0 ? configured : 8;
+    }
+
+    static int resolvePersistenceQueueCapacity(ConfigurationManager configuration) {
+        int configured = configuration.getInt("db.persistence.queue.capacity", DEFAULT_PERSISTENCE_QUEUE_CAPACITY);
+        if (configured < 1 || configured > MAX_PERSISTENCE_QUEUE_CAPACITY) {
+            LOGGER.warn(
+                    "Ignoring invalid db.persistence.queue.capacity {}; using {}",
+                    configured,
+                    DEFAULT_PERSISTENCE_QUEUE_CAPACITY);
+            return DEFAULT_PERSISTENCE_QUEUE_CAPACITY;
+        }
+
+        return configured;
     }
 
     private boolean initializePlugins() {

--- a/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
@@ -130,6 +130,7 @@ public final class ConfigRegistry {
                 "ws.port",
                 "session.reconnect.grace.seconds");
         keys.add(definition("runtime.threads", ConfigKey.ValueType.INTEGER, "8", true));
+        keys.add(definition("db.persistence.queue.capacity", ConfigKey.ValueType.INTEGER, "2048", true));
         keys.add(definition("http.blocking.pool.size", ConfigKey.ValueType.INTEGER, "8", true));
         keys.add(definition("stress.max_bots", ConfigKey.ValueType.INTEGER, "5000", true));
         keys.add(definition("stress.max_items", ConfigKey.ValueType.INTEGER, "100000", true));

--- a/Emulator/src/main/java/com/eu/habbo/database/PersistenceExecutor.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/PersistenceExecutor.java
@@ -3,10 +3,13 @@ package com.eu.habbo.database;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +21,11 @@ public final class PersistenceExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceExecutor.class);
     private static final int DEFAULT_QUEUE_CAPACITY = 2_048;
 
+    private final int queueCapacity;
+    private final AtomicInteger highWaterMark = new AtomicInteger();
+    private final AtomicLong saturationCount = new AtomicLong();
+    private final AtomicLong totalSubmissionWaitNanos = new AtomicLong();
+    private final ThreadLocal<Boolean> persistenceWorker = ThreadLocal.withInitial(() -> false);
     private final ThreadPoolExecutor executor;
     private final AtomicBoolean accepting = new AtomicBoolean(true);
 
@@ -29,8 +37,17 @@ public final class PersistenceExecutor {
             throw new IllegalArgumentException("queueCapacity must be positive");
         }
 
-        ThreadFactory threadFactory =
+        this.queueCapacity = queueCapacity;
+        ThreadFactory platformThreadFactory =
                 Thread.ofPlatform().name("Polaris-JDBC-", 0).factory();
+        ThreadFactory threadFactory = task -> platformThreadFactory.newThread(() -> {
+            this.persistenceWorker.set(true);
+            try {
+                task.run();
+            } finally {
+                this.persistenceWorker.remove();
+            }
+        });
         this.executor = new ThreadPoolExecutor(
                 threads,
                 threads,
@@ -38,23 +55,27 @@ public final class PersistenceExecutor {
                 TimeUnit.MILLISECONDS,
                 new ArrayBlockingQueue<>(queueCapacity),
                 threadFactory,
-                (task, ignored) -> task.run());
+                this::enqueueOnSaturation);
         this.executor.prestartAllCoreThreads();
     }
 
     public static PersistenceExecutor forRuntimeThreads(int runtimeThreads) {
+        return forRuntimeThreads(runtimeThreads, DEFAULT_QUEUE_CAPACITY);
+    }
+
+    public static PersistenceExecutor forRuntimeThreads(int runtimeThreads, int queueCapacity) {
         int threads = Math.max(2, Math.min(8, runtimeThreads));
-        return new PersistenceExecutor(threads, DEFAULT_QUEUE_CAPACITY);
+        return new PersistenceExecutor(threads, queueCapacity);
     }
 
     public void execute(Runnable task) {
         Runnable guarded = guard(Objects.requireNonNull(task, "task"));
         if (!this.accepting.get()) {
-            guarded.run();
-            return;
+            throw new RejectedExecutionException("Persistence executor is not accepting work");
         }
 
         this.executor.execute(guarded);
+        this.recordQueueDepth();
     }
 
     public int getQueueDepth() {
@@ -63,6 +84,17 @@ public final class PersistenceExecutor {
 
     public int getActiveCount() {
         return this.executor.getActiveCount();
+    }
+
+    public Metrics metrics() {
+        return new Metrics(
+                this.getActiveCount(),
+                this.getQueueDepth(),
+                this.queueCapacity,
+                this.highWaterMark.get(),
+                this.saturationCount.get(),
+                this.totalSubmissionWaitNanos.get(),
+                this.accepting.get());
     }
 
     public void shutDown() {
@@ -105,6 +137,39 @@ public final class PersistenceExecutor {
         }
     }
 
+    private void enqueueOnSaturation(Runnable task, ThreadPoolExecutor executor) {
+        if (executor.isShutdown()) {
+            throw new RejectedExecutionException("Persistence executor is shutting down");
+        }
+
+        this.saturationCount.incrementAndGet();
+        this.highWaterMark.accumulateAndGet(this.queueCapacity, Math::max);
+        if (this.persistenceWorker.get()) {
+            task.run();
+            return;
+        }
+
+        long startedAt = System.nanoTime();
+        try {
+            executor.getQueue().put(task);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RejectedExecutionException("Interrupted while waiting for persistence capacity", exception);
+        } finally {
+            this.totalSubmissionWaitNanos.addAndGet(Math.max(0L, System.nanoTime() - startedAt));
+        }
+
+        if (executor.isShutdown() && executor.remove(task)) {
+            throw new RejectedExecutionException("Persistence executor shut down while accepting work");
+        }
+
+        this.recordQueueDepth();
+    }
+
+    private void recordQueueDepth() {
+        this.highWaterMark.accumulateAndGet(this.executor.getQueue().size(), Math::max);
+    }
+
     private static Runnable guard(Runnable task) {
         return () -> {
             try {
@@ -114,4 +179,13 @@ public final class PersistenceExecutor {
             }
         };
     }
+
+    public record Metrics(
+            int activeCount,
+            int queueDepth,
+            int queueCapacity,
+            int highWaterMark,
+            long saturationCount,
+            long totalSubmissionWaitNanos,
+            boolean accepting) {}
 }

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.monitoring;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.database.PersistenceExecutor;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
@@ -8,6 +9,7 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics;
 import com.eu.habbo.habbohotel.wired.tick.WiredTickService;
 import com.eu.habbo.networking.gameserver.GameServer;
+import com.eu.habbo.threading.ThreadPooling;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
 import java.lang.management.GarbageCollectorMXBean;
@@ -242,7 +244,9 @@ public final class EmulatorStatsService {
         }
 
         HikariPoolMetrics hikariPoolMetrics = collectHikariPoolMetrics();
-        SchedulerMetrics schedulerMetrics = collectSchedulerMetrics();
+        ThreadPooling threading = Emulator.getThreading();
+        PersistenceMetrics persistenceMetrics = collectPersistenceMetrics(threading);
+        SchedulerMetrics schedulerMetrics = collectSchedulerMetrics(threading);
         NetworkMetrics networkMetrics = collectNetworkMetrics(now);
         GarbageCollectorMetrics garbageCollectorMetrics = collectGarbageCollectorMetrics(now);
         HealthSnapshot health =
@@ -281,6 +285,7 @@ public final class EmulatorStatsService {
                 wiredRooms,
                 wiredTopRooms,
                 hikariPoolMetrics,
+                persistenceMetrics,
                 schedulerMetrics,
                 networkMetrics,
                 garbageCollectorMetrics,
@@ -304,12 +309,31 @@ public final class EmulatorStatsService {
                 dataSource.getMaximumPoolSize());
     }
 
-    private static SchedulerMetrics collectSchedulerMetrics() {
-        if (Emulator.getThreading() == null) {
+    private static PersistenceMetrics collectPersistenceMetrics(ThreadPooling threading) {
+        return persistenceMetrics(threading == null ? null : threading.getPersistenceMetrics());
+    }
+
+    static PersistenceMetrics persistenceMetrics(PersistenceExecutor.Metrics metrics) {
+        if (metrics == null) {
+            return new PersistenceMetrics(0, 0, 0, 0, 0L, 0D, false);
+        }
+
+        return new PersistenceMetrics(
+                metrics.activeCount(),
+                metrics.queueDepth(),
+                metrics.queueCapacity(),
+                metrics.highWaterMark(),
+                metrics.saturationCount(),
+                metrics.totalSubmissionWaitNanos() / 1_000_000D,
+                metrics.accepting());
+    }
+
+    private static SchedulerMetrics collectSchedulerMetrics(ThreadPooling threading) {
+        if (threading == null) {
             return new SchedulerMetrics(0, 0, 0, 0, false);
         }
 
-        if (!(Emulator.getThreading().getService() instanceof ScheduledThreadPoolExecutor executor)) {
+        if (!(threading.getService() instanceof ScheduledThreadPoolExecutor executor)) {
             return new SchedulerMetrics(0, 0, 0, 0, false);
         }
 
@@ -578,6 +602,7 @@ public final class EmulatorStatsService {
         public final List<WiredRoomRow> wired;
         public final List<WiredTopRoomRow> wiredTopRooms;
         public final HikariPoolMetrics databasePool;
+        public final PersistenceMetrics persistence;
         public final SchedulerMetrics scheduler;
         public final NetworkMetrics network;
         public final GarbageCollectorMetrics garbageCollector;
@@ -624,6 +649,34 @@ public final class EmulatorStatsService {
                 NetworkMetrics network,
                 GarbageCollectorMetrics garbageCollector,
                 HealthSnapshot health) {
+            this(
+                    overview,
+                    memoryHistory,
+                    users,
+                    rooms,
+                    wired,
+                    wiredTopRooms,
+                    databasePool,
+                    persistenceMetrics(null),
+                    scheduler,
+                    network,
+                    garbageCollector,
+                    health);
+        }
+
+        public Snapshot(
+                Overview overview,
+                List<MemoryPoint> memoryHistory,
+                List<OnlineUserRow> users,
+                List<ActiveRoomRow> rooms,
+                List<WiredRoomRow> wired,
+                List<WiredTopRoomRow> wiredTopRooms,
+                HikariPoolMetrics databasePool,
+                PersistenceMetrics persistence,
+                SchedulerMetrics scheduler,
+                NetworkMetrics network,
+                GarbageCollectorMetrics garbageCollector,
+                HealthSnapshot health) {
             this.overview = overview;
             this.memoryHistory = memoryHistory;
             this.users = users;
@@ -631,6 +684,7 @@ public final class EmulatorStatsService {
             this.wired = wired;
             this.wiredTopRooms = wiredTopRooms;
             this.databasePool = databasePool;
+            this.persistence = persistence;
             this.scheduler = scheduler;
             this.network = network;
             this.garbageCollector = garbageCollector;
@@ -827,6 +881,33 @@ public final class EmulatorStatsService {
             this.delayedEventsPending = delayedEventsPending;
             this.activityPerSecond = activityPerSecond;
             this.heavy = heavy;
+        }
+    }
+
+    public static final class PersistenceMetrics {
+        public final int activeTasks;
+        public final int queueDepth;
+        public final int queueCapacity;
+        public final int highWaterMark;
+        public final long saturationCount;
+        public final double totalSubmissionWaitMs;
+        public final boolean accepting;
+
+        public PersistenceMetrics(
+                int activeTasks,
+                int queueDepth,
+                int queueCapacity,
+                int highWaterMark,
+                long saturationCount,
+                double totalSubmissionWaitMs,
+                boolean accepting) {
+            this.activeTasks = activeTasks;
+            this.queueDepth = queueDepth;
+            this.queueCapacity = queueCapacity;
+            this.highWaterMark = highWaterMark;
+            this.saturationCount = saturationCount;
+            this.totalSubmissionWaitMs = totalSubmissionWaitMs;
+            this.accepting = accepting;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
@@ -79,6 +79,10 @@ public class ThreadPooling {
         this.persistenceExecutor.execute(task);
     }
 
+    public PersistenceExecutor.Metrics getPersistenceMetrics() {
+        return this.persistenceExecutor == null ? null : this.persistenceExecutor.metrics();
+    }
+
     public void shutDown() {
         this.shutDown(5, TimeUnit.SECONDS);
     }

--- a/Emulator/src/test/java/com/eu/habbo/PolarisBootstrapRuntimeThreadsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/PolarisBootstrapRuntimeThreadsTest.java
@@ -24,4 +24,24 @@ class PolarisBootstrapRuntimeThreadsTest {
 
         assertEquals(12, PolarisBootstrap.resolveRuntimeThreads(configuration));
     }
+
+    @Test
+    void invalidPersistenceQueueCapacityUsesDefensiveDefault() {
+        ConfigurationManager configuration = mock(ConfigurationManager.class);
+        when(configuration.getInt("db.persistence.queue.capacity", 2_048)).thenReturn(0);
+
+        assertEquals(2_048, PolarisBootstrap.resolvePersistenceQueueCapacity(configuration));
+
+        when(configuration.getInt("db.persistence.queue.capacity", 2_048)).thenReturn(65_537);
+
+        assertEquals(2_048, PolarisBootstrap.resolvePersistenceQueueCapacity(configuration));
+    }
+
+    @Test
+    void validPersistenceQueueCapacityRemainsAuthoritative() {
+        ConfigurationManager configuration = mock(ConfigurationManager.class);
+        when(configuration.getInt("db.persistence.queue.capacity", 2_048)).thenReturn(4_096);
+
+        assertEquals(4_096, PolarisBootstrap.resolvePersistenceQueueCapacity(configuration));
+    }
 }

--- a/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
@@ -53,9 +53,10 @@ class ConfigRegistryTest {
     }
 
     @Test
-    void networkWorkerAndBackpressureDefaultsAreTyped() {
+    void boundedWorkerDefaultsAreTyped() {
         String reference = ConfigRegistry.standard().renderMarkdown();
 
+        assertTrue(reference.contains("| `db.persistence.queue.capacity` | integer | `2048` |"));
         assertTrue(reference.contains("| `http.blocking.pool.size` | integer | `8` |"));
         assertTrue(reference.contains("| `io.netty.write_buffer.low_water_mark` | integer | `32768` |"));
         assertTrue(reference.contains("| `io.netty.write_buffer.high_water_mark` | integer | `65536` |"));

--- a/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
@@ -1,9 +1,12 @@
 package com.eu.habbo.database;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
@@ -29,11 +32,12 @@ class PersistenceExecutorTest {
     }
 
     @Test
-    void saturationAppliesCallerBackpressureWithoutDroppingWork() throws Exception {
+    void saturationQueuesWorkWithoutExecutingJdbcOnCaller() throws Exception {
         PersistenceExecutor executor = new PersistenceExecutor(1, 1);
         CountDownLatch workerStarted = new CountDownLatch(1);
         CountDownLatch releaseWorker = new CountDownLatch(1);
-        AtomicReference<Thread> saturatedTaskThread = new AtomicReference<>();
+        CountDownLatch saturatedTaskCompleted = new CountDownLatch(1);
+        AtomicReference<String> saturatedTaskThread = new AtomicReference<>();
         try {
             executor.execute(() -> {
                 workerStarted.countDown();
@@ -42,12 +46,111 @@ class PersistenceExecutorTest {
             assertTrue(workerStarted.await(2, TimeUnit.SECONDS));
             executor.execute(() -> {});
 
-            Thread caller = Thread.currentThread();
-            executor.execute(() -> saturatedTaskThread.set(Thread.currentThread()));
+            Thread submitter = Thread.ofPlatform()
+                    .name("persistence-submitter")
+                    .start(() -> executor.execute(() -> {
+                        saturatedTaskThread.set(Thread.currentThread().getName());
+                        saturatedTaskCompleted.countDown();
+                    }));
 
-            assertEquals(caller, saturatedTaskThread.get());
+            assertFalse(saturatedTaskCompleted.await(100, TimeUnit.MILLISECONDS));
+            releaseWorker.countDown();
+            submitter.join(2_000);
+
+            assertFalse(submitter.isAlive());
+            assertTrue(saturatedTaskCompleted.await(2, TimeUnit.SECONDS));
+            assertTrue(saturatedTaskThread.get().startsWith("Polaris-JDBC-"));
+            PersistenceExecutor.Metrics metrics = executor.metrics();
+            assertEquals(1, metrics.queueCapacity());
+            assertEquals(1, metrics.highWaterMark());
+            assertEquals(1L, metrics.saturationCount());
+            assertTrue(metrics.totalSubmissionWaitNanos() > 0L);
+
         } finally {
             releaseWorker.countDown();
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void workSubmittedAfterShutdownIsRejectedWithoutRunningOnCaller() {
+        PersistenceExecutor executor = new PersistenceExecutor(1, 1);
+        executor.shutDown(2, TimeUnit.SECONDS);
+        AtomicReference<Boolean> ran = new AtomicReference<>(false);
+
+        assertThrows(RejectedExecutionException.class, () -> executor.execute(() -> ran.set(true)));
+
+        assertFalse(ran.get());
+        assertFalse(executor.metrics().accepting());
+    }
+
+    @Test
+    void nestedPersistenceSubmissionDoesNotDeadlockWhenQueueIsFull() throws Exception {
+        PersistenceExecutor executor = new PersistenceExecutor(1, 1);
+        CountDownLatch outerCompleted = new CountDownLatch(1);
+        CountDownLatch nestedCompleted = new CountDownLatch(1);
+        try {
+            executor.execute(() -> {
+                executor.execute(() -> {});
+                executor.execute(nestedCompleted::countDown);
+                outerCompleted.countDown();
+            });
+
+            assertTrue(outerCompleted.await(1, TimeUnit.SECONDS));
+            assertTrue(nestedCompleted.await(1, TimeUnit.SECONDS));
+        } finally {
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void interruptedSubmissionIsRejectedAndPreservesInterruptStatus() throws Exception {
+        PersistenceExecutor executor = new PersistenceExecutor(1, 1);
+        CountDownLatch workerStarted = new CountDownLatch(1);
+        CountDownLatch releaseWorker = new CountDownLatch(1);
+        AtomicReference<Throwable> rejection = new AtomicReference<>();
+        AtomicReference<Boolean> interrupted = new AtomicReference<>(false);
+        try {
+            executor.execute(() -> {
+                workerStarted.countDown();
+                await(releaseWorker);
+            });
+            assertTrue(workerStarted.await(2, TimeUnit.SECONDS));
+            executor.execute(() -> {});
+
+            Thread submitter = Thread.ofPlatform().start(() -> {
+                try {
+                    executor.execute(() -> {});
+                } catch (RejectedExecutionException exception) {
+                    rejection.set(exception);
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                }
+            });
+
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+            while (executor.metrics().saturationCount() == 0L && System.nanoTime() < deadline) {
+                Thread.onSpinWait();
+            }
+            assertEquals(1L, executor.metrics().saturationCount());
+
+            submitter.interrupt();
+            submitter.join(2_000);
+
+            assertFalse(submitter.isAlive());
+            assertTrue(rejection.get() instanceof RejectedExecutionException);
+            assertTrue(interrupted.get());
+        } finally {
+            releaseWorker.countDown();
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void runtimeFactoryHonorsConfiguredQueueCapacity() {
+        PersistenceExecutor executor = PersistenceExecutor.forRuntimeThreads(8, 4_096);
+        try {
+            assertEquals(4_096, executor.metrics().queueCapacity());
+        } finally {
             executor.shutDown(2, TimeUnit.SECONDS);
         }
     }

--- a/Emulator/src/test/java/com/eu/habbo/monitoring/PersistenceMetricsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/monitoring/PersistenceMetricsContractTest.java
@@ -1,0 +1,24 @@
+package com.eu.habbo.monitoring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.eu.habbo.database.PersistenceExecutor;
+import org.junit.jupiter.api.Test;
+
+class PersistenceMetricsContractTest {
+
+    @Test
+    void snapshotMapsExecutorPressureWithoutDroppingCounters() {
+        PersistenceExecutor.Metrics source = new PersistenceExecutor.Metrics(2, 7, 64, 31, 5L, 9_000_000L, false);
+        EmulatorStatsService.PersistenceMetrics mapped = EmulatorStatsService.persistenceMetrics(source);
+
+        assertEquals(2, mapped.activeTasks);
+        assertEquals(7, mapped.queueDepth);
+        assertEquals(64, mapped.queueCapacity);
+        assertEquals(31, mapped.highWaterMark);
+        assertEquals(5L, mapped.saturationCount);
+        assertEquals(9D, mapped.totalSubmissionWaitMs);
+        assertFalse(mapped.accepting);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingPersistenceRoutingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingPersistenceRoutingTest.java
@@ -1,8 +1,10 @@
 package com.eu.habbo.threading;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.eu.habbo.database.PersistenceExecutor;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,19 @@ class ThreadPoolingPersistenceRoutingTest {
             threading.runPersistence(task);
 
             verify(persistence).execute(same(task));
+        } finally {
+            threading.shutDown();
+        }
+    }
+
+    @Test
+    void persistenceMetricsComeFromTheInjectedDatabaseExecutor() {
+        PersistenceExecutor persistence = mock(PersistenceExecutor.class);
+        PersistenceExecutor.Metrics metrics = new PersistenceExecutor.Metrics(1, 2, 3, 2, 4L, 5L, true);
+        when(persistence.metrics()).thenReturn(metrics);
+        ThreadPooling threading = new ThreadPooling(1, persistence);
+        try {
+            assertSame(metrics, threading.getPersistenceMetrics());
         } finally {
             threading.shutDown();
         }

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -95,6 +95,7 @@ login.news.limit=5
 #Performance / concurrency (optional — sensible defaults apply if unset; adjust in the Database).
 ## io.packet.handler.threads=24 #Game packet-handler pool size; runs game handlers OFF the Netty I/O loop. Default max(16, 2 x CPU cores).
 ## auth.http.pool.size=16 #Dedicated worker pool for the /api/auth/* HTTP endpoints (BCrypt/JDBC/Turnstile/SMTP run off the event loop). Default 16.
+## db.persistence.queue.capacity=2048 #Maximum queued JDBC writes. Saturation waits for capacity instead of running SQL on gameplay threads.
 ## http.blocking.pool.size=8 #Dedicated workers for blocking badge, asset, leaderboard, and emulator-stats endpoints. Default 8.
 ## io.netty.allocator.pooled=false #Set true to opt into Netty's pooled ByteBuf allocator. Default false (unpooled-heap).
 ## io.netty.write_buffer.low_water_mark=32768 #Mark a channel writable again after queued outbound bytes drain below this value.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -22,6 +22,7 @@ Unknown keys remain allowed for plugins. Database-backed hotel settings are docu
 | `db.migrations.backup.timeout_seconds` | integer | `0` | — | yes | no | Migration backup setting. |
 | `db.params` | string | `` | `DB_PARAMS` | yes | no | Database startup setting. |
 | `db.password` | string | `` | `DB_PASSWORD` | yes | no | Database startup setting. |
+| `db.persistence.queue.capacity` | integer | `2048` | — | yes | no | Database startup setting. |
 | `db.pool.connection_timeout_ms` | long | `0` | — | yes | no | Database connection-pool setting. |
 | `db.pool.idle_timeout_ms` | long | `0` | — | yes | no | Database connection-pool setting. |
 | `db.pool.leak_detection_ms` | long | `0` | — | yes | no | Database connection-pool setting. |


### PR DESCRIPTION
## Summary
- replace caller-runs persistence rejection with bounded, lossless backpressure so saturated JDBC work never executes on gameplay callers
- add shutdown-race and interruption handling, plus a dedicated-worker escape path for nested submissions that prevents self-deadlock
- make persistence queue capacity configurable with a defensive default and upper bound
- expose additive persistence pressure metrics through the existing emulator statistics snapshot

## Root cause
The persistence executor used a caller-runs rejection handler. When its bounded queue filled during database slowdown, packet or room threads could execute blocking JDBC work directly, spreading database pressure into gameplay latency.

## Configuration
- `db.persistence.queue.capacity` defaults to `2048`
- accepted range: `1` to `65536`
- invalid values fall back to the default with a warning

## Compatibility
- no database schema changes
- no client packet or protocol changes
- accepted work still drains during graceful shutdown; late work is rejected explicitly instead of running on the shutdown caller

## Validation
- `mvn -Dtest=PersistenceExecutorTest,PolarisBootstrapRuntimeThreadsTest,ConfigRegistryTest,PersistenceMetricsContractTest,ThreadPoolingPersistenceRoutingTest,FrozenArchitectureBaselineTest test` (19 tests, 0 failures)
- `mvn test` (1476 tests, 0 failures, 7 skipped)
- `mvn -Dspotless.ratchetFrom=HEAD spotless:check`
- `git diff --check`

Related hardening work: #578 and #579.