### PR TITLE
feat(core): add persistence failure observability

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/database/PersistenceExecutor.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/PersistenceExecutor.java
@@ -3,6 +3,7 @@ package com.eu.habbo.database;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +18,10 @@ import org.slf4j.LoggerFactory;
 public final class PersistenceExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceExecutor.class);
     private static final int DEFAULT_QUEUE_CAPACITY = 2_048;
+    private static final int RECENT_FAILURE_CAPACITY = 64;
 
+    private final PersistenceOperationMonitor operationMonitor =
+            new PersistenceOperationMonitor(RECENT_FAILURE_CAPACITY);
     private final ThreadPoolExecutor executor;
     private final AtomicBoolean accepting = new AtomicBoolean(true);
 
@@ -48,13 +52,25 @@ public final class PersistenceExecutor {
     }
 
     public void execute(Runnable task) {
-        Runnable guarded = guard(Objects.requireNonNull(task, "task"));
-        if (!this.accepting.get()) {
-            guarded.run();
-            return;
-        }
+        Runnable requiredTask = Objects.requireNonNull(task, "task");
+        this.execute(operationType(requiredTask), requiredTask);
+    }
 
-        this.executor.execute(guarded);
+    public void execute(String operationType, Runnable task) {
+        Runnable requiredTask = Objects.requireNonNull(task, "task");
+        PersistenceOperationMonitor.Operation operation = this.operationMonitor.started(operationType);
+        Runnable guarded = this.guard(operation, requiredTask);
+        try {
+            if (!this.accepting.get()) {
+                guarded.run();
+                return;
+            }
+
+            this.executor.execute(guarded);
+        } catch (RejectedExecutionException exception) {
+            this.operationMonitor.rejected(operation, exception);
+            throw exception;
+        }
     }
 
     public int getQueueDepth() {
@@ -63,6 +79,10 @@ public final class PersistenceExecutor {
 
     public int getActiveCount() {
         return this.executor.getActiveCount();
+    }
+
+    public PersistenceOperationMonitor.Snapshot operationSnapshot() {
+        return this.operationMonitor.snapshot();
     }
 
     public void shutDown() {
@@ -105,13 +125,32 @@ public final class PersistenceExecutor {
         }
     }
 
-    private static Runnable guard(Runnable task) {
+    private Runnable guard(PersistenceOperationMonitor.Operation operation, Runnable task) {
         return () -> {
             try {
                 task.run();
+                this.operationMonitor.succeeded(operation);
             } catch (Exception exception) {
-                LOGGER.error("Persistence task failed", exception);
+                this.operationMonitor.failed(operation, exception);
+                LOGGER.error(
+                        "Persistence task failed: operationId={}, operationType={}",
+                        operation.operationId(),
+                        operation.operationType(),
+                        exception);
+            } catch (Error error) {
+                this.operationMonitor.failed(operation, error);
+                LOGGER.error(
+                        "Persistence task failed: operationId={}, operationType={}",
+                        operation.operationId(),
+                        operation.operationType(),
+                        error);
+                throw error;
             }
         };
+    }
+
+    private static String operationType(Runnable task) {
+        String simpleName = task.getClass().getSimpleName();
+        return simpleName.isBlank() || simpleName.contains("$$Lambda") ? "anonymous" : simpleName;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/database/PersistenceOperationMonitor.java
+++ b/Emulator/src/main/java/com/eu/habbo/database/PersistenceOperationMonitor.java
@@ -1,0 +1,136 @@
+package com.eu.habbo.database;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+public final class PersistenceOperationMonitor {
+    private final int failureCapacity;
+    private final LongSupplier nanoTime;
+    private final LongSupplier epochMillis;
+    private final AtomicLong nextOperationId = new AtomicLong();
+    private final AtomicLong submittedCount = new AtomicLong();
+    private final AtomicLong succeededCount = new AtomicLong();
+    private final AtomicLong failedCount = new AtomicLong();
+    private final AtomicLong rejectedCount = new AtomicLong();
+    private final AtomicLong activeCount = new AtomicLong();
+    private final AtomicLong totalDurationNanos = new AtomicLong();
+    private final AtomicLong maxDurationNanos = new AtomicLong();
+    private final ArrayDeque<RecentFailure> recentFailures = new ArrayDeque<>();
+
+    public PersistenceOperationMonitor(int failureCapacity) {
+        this(failureCapacity, System::nanoTime, System::currentTimeMillis);
+    }
+
+    PersistenceOperationMonitor(int failureCapacity, LongSupplier nanoTime, LongSupplier epochMillis) {
+        if (failureCapacity < 1) {
+            throw new IllegalArgumentException("failureCapacity must be positive");
+        }
+        this.failureCapacity = failureCapacity;
+        this.nanoTime = Objects.requireNonNull(nanoTime, "nanoTime");
+        this.epochMillis = Objects.requireNonNull(epochMillis, "epochMillis");
+    }
+
+    Operation started(String operationType) {
+        long operationId = this.nextOperationId.incrementAndGet();
+        this.submittedCount.incrementAndGet();
+        this.activeCount.incrementAndGet();
+        return new Operation(
+                operationId,
+                normalizeOperationType(operationType),
+                this.epochMillis.getAsLong(),
+                this.nanoTime.getAsLong());
+    }
+
+    void succeeded(Operation operation) {
+        this.succeededCount.incrementAndGet();
+        this.complete(operation);
+    }
+
+    void failed(Operation operation, Throwable failure) {
+        this.failedCount.incrementAndGet();
+        this.recordFailure(operation, "FAILED", failure, this.complete(operation));
+    }
+
+    void rejected(Operation operation, Throwable failure) {
+        this.rejectedCount.incrementAndGet();
+        this.recordFailure(operation, "REJECTED", failure, this.complete(operation));
+    }
+
+    public Snapshot snapshot() {
+        List<RecentFailure> failures;
+        synchronized (this.recentFailures) {
+            failures = List.copyOf(this.recentFailures);
+        }
+        return new Snapshot(
+                this.submittedCount.get(),
+                this.succeededCount.get(),
+                this.failedCount.get(),
+                this.rejectedCount.get(),
+                this.activeCount.get(),
+                this.totalDurationNanos.get(),
+                this.maxDurationNanos.get(),
+                failures);
+    }
+
+    private long complete(Operation operation) {
+        long durationNanos = Math.max(0L, this.nanoTime.getAsLong() - operation.startedAtNanos());
+        this.activeCount.decrementAndGet();
+        this.totalDurationNanos.addAndGet(durationNanos);
+        this.maxDurationNanos.accumulateAndGet(durationNanos, Math::max);
+        return durationNanos;
+    }
+
+    private void recordFailure(Operation operation, String outcome, Throwable failure, long durationNanos) {
+        RecentFailure recentFailure = new RecentFailure(
+                operation.operationId(),
+                operation.operationType(),
+                outcome,
+                operation.startedAtEpochMs(),
+                durationNanos,
+                errorType(failure));
+        synchronized (this.recentFailures) {
+            this.recentFailures.addFirst(recentFailure);
+            while (this.recentFailures.size() > this.failureCapacity) {
+                this.recentFailures.removeLast();
+            }
+        }
+    }
+
+    private static String normalizeOperationType(String operationType) {
+        if (operationType == null || operationType.isBlank()) {
+            return "unknown";
+        }
+        return operationType.strip();
+    }
+
+    private static String errorType(Throwable failure) {
+        if (failure == null) {
+            return "UnknownFailure";
+        }
+        String simpleName = failure.getClass().getSimpleName();
+        return simpleName.isBlank() ? failure.getClass().getName() : simpleName;
+    }
+
+    record Operation(long operationId, String operationType, long startedAtEpochMs, long startedAtNanos) {}
+
+    public record RecentFailure(
+            long operationId,
+            String operationType,
+            String outcome,
+            long startedAtEpochMs,
+            long durationNanos,
+            String errorType) {}
+
+    public record Snapshot(
+            long submittedCount,
+            long succeededCount,
+            long failedCount,
+            long rejectedCount,
+            long activeCount,
+            long totalDurationNanos,
+            long maxDurationNanos,
+            List<RecentFailure> recentFailures) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.monitoring;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.database.PersistenceOperationMonitor;
 import com.eu.habbo.habbohotel.GameEnvironment;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.users.Habbo;
@@ -8,6 +9,7 @@ import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics;
 import com.eu.habbo.habbohotel.wired.tick.WiredTickService;
 import com.eu.habbo.networking.gameserver.GameServer;
+import com.eu.habbo.threading.ThreadPooling;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
 import java.lang.management.GarbageCollectorMXBean;
@@ -241,8 +243,11 @@ public final class EmulatorStatsService {
             wiredTopRooms = new ArrayList<>(wiredTopRooms.subList(0, 5));
         }
 
+        ThreadPooling threading = Emulator.getThreading();
         HikariPoolMetrics hikariPoolMetrics = collectHikariPoolMetrics();
-        SchedulerMetrics schedulerMetrics = collectSchedulerMetrics();
+        SchedulerMetrics schedulerMetrics = collectSchedulerMetrics(threading);
+        PersistenceOperationMetrics persistenceOperations =
+                persistenceOperationMetrics(threading == null ? null : threading.getPersistenceOperationSnapshot());
         NetworkMetrics networkMetrics = collectNetworkMetrics(now);
         GarbageCollectorMetrics garbageCollectorMetrics = collectGarbageCollectorMetrics(now);
         HealthSnapshot health =
@@ -282,6 +287,7 @@ public final class EmulatorStatsService {
                 wiredTopRooms,
                 hikariPoolMetrics,
                 schedulerMetrics,
+                persistenceOperations,
                 networkMetrics,
                 garbageCollectorMetrics,
                 health);
@@ -304,12 +310,12 @@ public final class EmulatorStatsService {
                 dataSource.getMaximumPoolSize());
     }
 
-    private static SchedulerMetrics collectSchedulerMetrics() {
-        if (Emulator.getThreading() == null) {
+    private static SchedulerMetrics collectSchedulerMetrics(ThreadPooling threading) {
+        if (threading == null) {
             return new SchedulerMetrics(0, 0, 0, 0, false);
         }
 
-        if (!(Emulator.getThreading().getService() instanceof ScheduledThreadPoolExecutor executor)) {
+        if (!(threading.getService() instanceof ScheduledThreadPoolExecutor executor)) {
             return new SchedulerMetrics(0, 0, 0, 0, false);
         }
 
@@ -319,6 +325,36 @@ public final class EmulatorStatsService {
                 executor.getPoolSize(),
                 executor.getCompletedTaskCount(),
                 !executor.isShutdown());
+    }
+
+    static PersistenceOperationMetrics persistenceOperationMetrics(PersistenceOperationMonitor.Snapshot snapshot) {
+        if (snapshot == null) {
+            return PersistenceOperationMetrics.empty();
+        }
+
+        List<PersistenceFailureRow> failures = snapshot.recentFailures().stream()
+                .map(failure -> new PersistenceFailureRow(
+                        failure.operationId(),
+                        failure.operationType(),
+                        failure.outcome(),
+                        failure.startedAtEpochMs(),
+                        nanosToMillis(failure.durationNanos()),
+                        failure.errorType()))
+                .toList();
+
+        return new PersistenceOperationMetrics(
+                snapshot.submittedCount(),
+                snapshot.succeededCount(),
+                snapshot.failedCount(),
+                snapshot.rejectedCount(),
+                snapshot.activeCount(),
+                nanosToMillis(snapshot.totalDurationNanos()),
+                nanosToMillis(snapshot.maxDurationNanos()),
+                failures);
+    }
+
+    private static double nanosToMillis(long nanos) {
+        return Math.max(0L, nanos) / 1_000_000D;
     }
 
     private static HealthSnapshot collectHealth(
@@ -579,6 +615,7 @@ public final class EmulatorStatsService {
         public final List<WiredTopRoomRow> wiredTopRooms;
         public final HikariPoolMetrics databasePool;
         public final SchedulerMetrics scheduler;
+        public final PersistenceOperationMetrics persistenceOperations;
         public final NetworkMetrics network;
         public final GarbageCollectorMetrics garbageCollector;
         public final HealthSnapshot health;
@@ -603,6 +640,7 @@ public final class EmulatorStatsService {
                     wiredTopRooms,
                     databasePool,
                     scheduler,
+                    PersistenceOperationMetrics.empty(),
                     network,
                     garbageCollector,
                     new HealthSnapshot(
@@ -624,6 +662,34 @@ public final class EmulatorStatsService {
                 NetworkMetrics network,
                 GarbageCollectorMetrics garbageCollector,
                 HealthSnapshot health) {
+            this(
+                    overview,
+                    memoryHistory,
+                    users,
+                    rooms,
+                    wired,
+                    wiredTopRooms,
+                    databasePool,
+                    scheduler,
+                    PersistenceOperationMetrics.empty(),
+                    network,
+                    garbageCollector,
+                    health);
+        }
+
+        public Snapshot(
+                Overview overview,
+                List<MemoryPoint> memoryHistory,
+                List<OnlineUserRow> users,
+                List<ActiveRoomRow> rooms,
+                List<WiredRoomRow> wired,
+                List<WiredTopRoomRow> wiredTopRooms,
+                HikariPoolMetrics databasePool,
+                SchedulerMetrics scheduler,
+                PersistenceOperationMetrics persistenceOperations,
+                NetworkMetrics network,
+                GarbageCollectorMetrics garbageCollector,
+                HealthSnapshot health) {
             this.overview = overview;
             this.memoryHistory = memoryHistory;
             this.users = users;
@@ -632,6 +698,7 @@ public final class EmulatorStatsService {
             this.wiredTopRooms = wiredTopRooms;
             this.databasePool = databasePool;
             this.scheduler = scheduler;
+            this.persistenceOperations = persistenceOperations;
             this.network = network;
             this.garbageCollector = garbageCollector;
             this.health = health;
@@ -865,6 +932,64 @@ public final class EmulatorStatsService {
             this.poolSize = poolSize;
             this.completedTasks = completedTasks;
             this.running = running;
+        }
+    }
+
+    public static final class PersistenceOperationMetrics {
+        public final long submitted;
+        public final long succeeded;
+        public final long failed;
+        public final long rejected;
+        public final long active;
+        public final double totalDurationMs;
+        public final double maxDurationMs;
+        public final List<PersistenceFailureRow> recentFailures;
+
+        public PersistenceOperationMetrics(
+                long submitted,
+                long succeeded,
+                long failed,
+                long rejected,
+                long active,
+                double totalDurationMs,
+                double maxDurationMs,
+                List<PersistenceFailureRow> recentFailures) {
+            this.submitted = submitted;
+            this.succeeded = succeeded;
+            this.failed = failed;
+            this.rejected = rejected;
+            this.active = active;
+            this.totalDurationMs = totalDurationMs;
+            this.maxDurationMs = maxDurationMs;
+            this.recentFailures = List.copyOf(recentFailures);
+        }
+
+        private static PersistenceOperationMetrics empty() {
+            return new PersistenceOperationMetrics(0L, 0L, 0L, 0L, 0L, 0D, 0D, List.of());
+        }
+    }
+
+    public static final class PersistenceFailureRow {
+        public final long operationId;
+        public final String operationType;
+        public final String outcome;
+        public final long startedAtEpochMs;
+        public final double durationMs;
+        public final String errorType;
+
+        public PersistenceFailureRow(
+                long operationId,
+                String operationType,
+                String outcome,
+                long startedAtEpochMs,
+                double durationMs,
+                String errorType) {
+            this.operationId = operationId;
+            this.operationType = operationType;
+            this.outcome = outcome;
+            this.startedAtEpochMs = startedAtEpochMs;
+            this.durationMs = durationMs;
+            this.errorType = errorType;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/ThreadPooling.java
@@ -2,6 +2,7 @@ package com.eu.habbo.threading;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.database.PersistenceExecutor;
+import com.eu.habbo.database.PersistenceOperationMonitor;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -77,6 +78,10 @@ public class ThreadPooling {
         }
 
         this.persistenceExecutor.execute(task);
+    }
+
+    public PersistenceOperationMonitor.Snapshot getPersistenceOperationSnapshot() {
+        return this.persistenceExecutor == null ? null : this.persistenceExecutor.operationSnapshot();
     }
 
     public void shutDown() {

--- a/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.database;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
@@ -64,11 +65,56 @@ class PersistenceExecutorTest {
         assertEquals(0L, completed.getCount());
     }
 
+    @Test
+    void operationSnapshotIdentifiesFailuresAndTracksSuccessfulWork() {
+        PersistenceExecutor executor = new PersistenceExecutor(1, 8);
+        try {
+            executor.execute(new FailingPersistenceTask());
+            executor.execute("test.barrier", () -> {});
+            executor.shutDown(2, TimeUnit.SECONDS);
+
+            PersistenceOperationMonitor.Snapshot snapshot = executor.operationSnapshot();
+            assertEquals(2L, snapshot.submittedCount());
+            assertEquals(1L, snapshot.succeededCount());
+            assertEquals(1L, snapshot.failedCount());
+            assertEquals(0L, snapshot.activeCount());
+            assertEquals(1, snapshot.recentFailures().size());
+            assertEquals(
+                    "FailingPersistenceTask", snapshot.recentFailures().get(0).operationType());
+            assertEquals(
+                    "IllegalStateException", snapshot.recentFailures().get(0).errorType());
+            assertTrue(snapshot.recentFailures().get(0).operationId() > 0L);
+        } finally {
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void rejectedNullTaskDoesNotCreatePhantomActiveOperation() {
+        PersistenceExecutor executor = new PersistenceExecutor(1, 8);
+        try {
+            assertThrows(NullPointerException.class, () -> executor.execute("invalid", null));
+
+            PersistenceOperationMonitor.Snapshot snapshot = executor.operationSnapshot();
+            assertEquals(0L, snapshot.submittedCount());
+            assertEquals(0L, snapshot.activeCount());
+        } finally {
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
     private static void await(CountDownLatch latch) {
         try {
             latch.await();
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
+        }
+    }
+
+    private static final class FailingPersistenceTask implements Runnable {
+        @Override
+        public void run() {
+            throw new IllegalStateException("sensitive failure detail");
         }
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/PersistenceExecutorTest.java
@@ -103,6 +103,32 @@ class PersistenceExecutorTest {
         }
     }
 
+    @Test
+    void capacityMetricsRemainAvailableAlongsideOperationTelemetry() throws Exception {
+        PersistenceExecutor executor = new PersistenceExecutor(1, 1);
+        CountDownLatch workerStarted = new CountDownLatch(1);
+        CountDownLatch releaseWorker = new CountDownLatch(1);
+        try {
+            executor.execute("test.blocking", () -> {
+                workerStarted.countDown();
+                await(releaseWorker);
+            });
+            assertTrue(workerStarted.await(2, TimeUnit.SECONDS));
+            executor.execute("test.queued", () -> {});
+
+            PersistenceExecutor.Metrics metrics = executor.metrics();
+            PersistenceOperationMonitor.Snapshot operations = executor.operationSnapshot();
+
+            assertEquals(1, metrics.activeCount());
+            assertEquals(1, metrics.queueDepth());
+            assertEquals(1, metrics.queueCapacity());
+            assertEquals(2L, operations.submittedCount());
+        } finally {
+            releaseWorker.countDown();
+            executor.shutDown(2, TimeUnit.SECONDS);
+        }
+    }
+
     private static void await(CountDownLatch latch) {
         try {
             latch.await();

--- a/Emulator/src/test/java/com/eu/habbo/database/PersistenceOperationMonitorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/PersistenceOperationMonitorTest.java
@@ -1,0 +1,78 @@
+package com.eu.habbo.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class PersistenceOperationMonitorTest {
+
+    @Test
+    void successfulOperationUpdatesCountersAndDuration() {
+        AtomicLong nanoTime = new AtomicLong(100L);
+        AtomicLong epochMillis = new AtomicLong(1_000L);
+        PersistenceOperationMonitor monitor = new PersistenceOperationMonitor(4, nanoTime::get, epochMillis::get);
+
+        PersistenceOperationMonitor.Operation operation = monitor.started("inventory.delete");
+        nanoTime.set(350L);
+        monitor.succeeded(operation);
+
+        PersistenceOperationMonitor.Snapshot snapshot = monitor.snapshot();
+        assertEquals(1L, snapshot.submittedCount());
+        assertEquals(1L, snapshot.succeededCount());
+        assertEquals(0L, snapshot.failedCount());
+        assertEquals(0L, snapshot.rejectedCount());
+        assertEquals(0L, snapshot.activeCount());
+        assertEquals(250L, snapshot.totalDurationNanos());
+        assertEquals(250L, snapshot.maxDurationNanos());
+        assertEquals(0, snapshot.recentFailures().size());
+    }
+
+    @Test
+    void recentFailuresAreBoundedNewestFirstAndExcludeExceptionMessages() {
+        AtomicLong nanoTime = new AtomicLong(100L);
+        AtomicLong epochMillis = new AtomicLong(1_000L);
+        PersistenceOperationMonitor monitor = new PersistenceOperationMonitor(2, nanoTime::get, epochMillis::get);
+
+        fail(monitor, nanoTime, "first", new IllegalStateException("secret-one"));
+        fail(monitor, nanoTime, "second", new IllegalArgumentException("secret-two"));
+        fail(monitor, nanoTime, "third", new UnsupportedOperationException("secret-three"));
+
+        PersistenceOperationMonitor.Snapshot snapshot = monitor.snapshot();
+        assertEquals(3L, snapshot.submittedCount());
+        assertEquals(3L, snapshot.failedCount());
+        assertEquals(2, snapshot.recentFailures().size());
+        assertEquals("third", snapshot.recentFailures().get(0).operationType());
+        assertEquals(
+                "UnsupportedOperationException",
+                snapshot.recentFailures().get(0).errorType());
+        assertEquals("second", snapshot.recentFailures().get(1).operationType());
+    }
+
+    @Test
+    void rejectedOperationHasAUniqueIdAndLeavesNoActiveWork() {
+        AtomicLong nanoTime = new AtomicLong(100L);
+        AtomicLong epochMillis = new AtomicLong(1_000L);
+        PersistenceOperationMonitor monitor = new PersistenceOperationMonitor(2, nanoTime::get, epochMillis::get);
+
+        PersistenceOperationMonitor.Operation first = monitor.started("first");
+        monitor.succeeded(first);
+        PersistenceOperationMonitor.Operation rejected = monitor.started("second");
+        nanoTime.set(150L);
+        monitor.rejected(rejected, new IllegalStateException("not accepted"));
+
+        PersistenceOperationMonitor.Snapshot snapshot = monitor.snapshot();
+        assertEquals(1L, first.operationId());
+        assertEquals(2L, rejected.operationId());
+        assertEquals(1L, snapshot.rejectedCount());
+        assertEquals(0L, snapshot.activeCount());
+        assertEquals("REJECTED", snapshot.recentFailures().get(0).outcome());
+    }
+
+    private static void fail(
+            PersistenceOperationMonitor monitor, AtomicLong nanoTime, String type, RuntimeException failure) {
+        PersistenceOperationMonitor.Operation operation = monitor.started(type);
+        nanoTime.addAndGet(10L);
+        monitor.failed(operation, failure);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/monitoring/PersistenceOperationMetricsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/monitoring/PersistenceOperationMetricsContractTest.java
@@ -1,0 +1,55 @@
+package com.eu.habbo.monitoring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.database.PersistenceOperationMonitor;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PersistenceOperationMetricsContractTest {
+
+    @Test
+    void mapsPersistenceCountersDurationsAndSafeFailureMetadata() {
+        PersistenceOperationMonitor.Snapshot source = new PersistenceOperationMonitor.Snapshot(
+                11L,
+                7L,
+                2L,
+                1L,
+                1L,
+                12_500_000L,
+                8_250_000L,
+                List.of(new PersistenceOperationMonitor.RecentFailure(
+                        42L, "SaveUser", "FAILED", 1_234L, 2_750_000L, "SQLException")));
+
+        EmulatorStatsService.PersistenceOperationMetrics metrics =
+                EmulatorStatsService.persistenceOperationMetrics(source);
+
+        assertEquals(11L, metrics.submitted);
+        assertEquals(7L, metrics.succeeded);
+        assertEquals(2L, metrics.failed);
+        assertEquals(1L, metrics.rejected);
+        assertEquals(1L, metrics.active);
+        assertEquals(12.5D, metrics.totalDurationMs);
+        assertEquals(8.25D, metrics.maxDurationMs);
+        assertEquals(1, metrics.recentFailures.size());
+
+        EmulatorStatsService.PersistenceFailureRow failure = metrics.recentFailures.getFirst();
+        assertEquals(42L, failure.operationId);
+        assertEquals("SaveUser", failure.operationType);
+        assertEquals("FAILED", failure.outcome);
+        assertEquals(1_234L, failure.startedAtEpochMs);
+        assertEquals(2.75D, failure.durationMs);
+        assertEquals("SQLException", failure.errorType);
+    }
+
+    @Test
+    void mapsUnavailablePersistenceExecutorToAnEmptySnapshot() {
+        EmulatorStatsService.PersistenceOperationMetrics metrics =
+                EmulatorStatsService.persistenceOperationMetrics(null);
+
+        assertEquals(0L, metrics.submitted);
+        assertEquals(0L, metrics.active);
+        assertTrue(metrics.recentFailures.isEmpty());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingPersistenceRoutingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/threading/ThreadPoolingPersistenceRoutingTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.verify;
 
 import com.eu.habbo.database.PersistenceExecutor;
+import com.eu.habbo.database.PersistenceOperationMonitor;
 import org.junit.jupiter.api.Test;
 
 class ThreadPoolingPersistenceRoutingTest {
@@ -20,6 +21,24 @@ class ThreadPoolingPersistenceRoutingTest {
             verify(persistence).execute(same(task));
         } finally {
             threading.shutDown();
+        }
+    }
+
+    @Test
+    void exposesPersistenceOperationMetrics() {
+        PersistenceExecutor persistence = new PersistenceExecutor(1, 4);
+        ThreadPooling threading = new ThreadPooling(1, persistence);
+        try {
+            threading.runPersistence(() -> {});
+            persistence.shutDown();
+
+            PersistenceOperationMonitor.Snapshot snapshot = threading.getPersistenceOperationSnapshot();
+            org.junit.jupiter.api.Assertions.assertEquals(1L, snapshot.submittedCount());
+            org.junit.jupiter.api.Assertions.assertEquals(1L, snapshot.succeededCount());
+            org.junit.jupiter.api.Assertions.assertEquals(0L, snapshot.activeCount());
+        } finally {
+            threading.shutDown();
+            persistence.shutDown();
         }
     }
 }


### PR DESCRIPTION
## Summary

- assign a monotonic operation ID and stable operation type to every accepted persistence task
- expose submitted, successful, failed, rejected, active, total-duration, and max-duration counters through the emulator diagnostics snapshot
- retain the newest 64 persistence failures with outcome, timing, and exception class only
- keep full stack traces in the existing server log while excluding SQL, payloads, and exception messages from the in-memory diagnostic history

## Why

Asynchronous persistence failures were logged but could not be correlated or inspected from the emulator diagnostics. Operators now get bounded, read-only failure metadata and aggregate counters without adding retries or changing execution semantics.

## Compatibility

- [x] Existing public API, fields, live collections, packet layouts, and plugin behavior remain compatible; the diagnostics field is additive.
- [x] No plugin-facing or packaging changes.
- [x] No database or protocol changes.

## Interaction with #580

This PR is independently based on `dev` and is designed to compose with #580. Once #580 is merged, its explicit overload rejection path will feed the `rejected` counter and recent-failure history. Because both PRs touch `PersistenceExecutor`, the later PR may need a small rebase.

## Validation

- `mvn test` — 1,476 tests, 0 failures, 0 errors, 7 skipped
- `mvn "-Dspotless.ratchetFrom=HEAD" spotless:check`

## Manual testing

- None.
