### PR TITLE
feat(core): add staged and fair execution backpressure

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
+++ b/Emulator/src/main/java/com/eu/habbo/core/config/ConfigRegistry.java
@@ -131,6 +131,14 @@ public final class ConfigRegistry {
                 "session.reconnect.grace.seconds");
         keys.add(definition("runtime.threads", ConfigKey.ValueType.INTEGER, "8", true));
         keys.add(definition("http.blocking.pool.size", ConfigKey.ValueType.INTEGER, "8", true));
+        keys.add(definition("http.blocking.queue.capacity", ConfigKey.ValueType.INTEGER, "128", true));
+        keys.add(definition("execution.backpressure.pause.timeout_ms", ConfigKey.ValueType.INTEGER, "2000", true));
+        keys.add(definition("io.packet.handler.threads", ConfigKey.ValueType.INTEGER, "0", true));
+        keys.add(definition("io.packet.handler.queue.capacity", ConfigKey.ValueType.INTEGER, "256", true));
+        keys.add(definition("io.packet.handler.queue.low_watermark", ConfigKey.ValueType.INTEGER, "192", true));
+        keys.add(definition("io.packet.handler.per_connection.capacity", ConfigKey.ValueType.INTEGER, "32", true));
+        keys.add(definition("io.packet.handler.per_connection.low_watermark", ConfigKey.ValueType.INTEGER, "16", true));
+        keys.add(definition("io.packet.handler.per_connection.pending", ConfigKey.ValueType.INTEGER, "16", true));
         keys.add(definition("stress.max_bots", ConfigKey.ValueType.INTEGER, "5000", true));
         keys.add(definition("stress.max_items", ConfigKey.ValueType.INTEGER, "100000", true));
         keys.add(definition("stress.max_rollers", ConfigKey.ValueType.INTEGER, "50000", true));
@@ -181,6 +189,7 @@ public final class ConfigRegistry {
                 "Enables priority-ordered, cancellation-aware plugin event dispatch."));
         keys.add(definition("db.integrity.audit.mode", ConfigKey.ValueType.STRING, "warn", true));
         keys.add(definition("cms.api.allowed", ConfigKey.ValueType.STRING, "127.0.0.1;::1", true));
+        keys.add(definition("execution.backpressure.mode", ConfigKey.ValueType.STRING, "observe", true));
         return List.copyOf(keys);
     }
 
@@ -263,6 +272,9 @@ public final class ConfigRegistry {
         }
         if (name.startsWith("http.blocking.")) {
             return "Blocking HTTP worker setting.";
+        }
+        if (name.startsWith("execution.backpressure.") || name.startsWith("io.packet.handler.")) {
+            return "Inbound execution backpressure setting.";
         }
         if (name.startsWith("io.netty.")) {
             return "Netty channel flow-control setting.";

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/EmulatorStatsService.java
@@ -7,6 +7,7 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics;
 import com.eu.habbo.habbohotel.wired.tick.WiredTickService;
+import com.eu.habbo.networking.gameserver.ExecutionBackpressureStatus;
 import com.eu.habbo.networking.gameserver.GameServer;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
@@ -452,6 +453,8 @@ public final class EmulatorStatsService {
         previousOutgoingBytes = outgoingBytes;
         previousTelemetryAt = now;
         PacketDispatchLatencyMetrics.Snapshot dispatch = PacketDispatchLatencyMetrics.snapshot();
+        ExecutionBackpressureStatus.Snapshot packetBackpressure = ExecutionBackpressureStatus.packet();
+        ExecutionBackpressureStatus.Snapshot httpBackpressure = ExecutionBackpressureStatus.http();
 
         return new NetworkMetrics(
                 Math.max(0D, incomingPacketsPerSecond),
@@ -463,7 +466,9 @@ public final class EmulatorStatsService {
                 dispatch.samples(),
                 dispatch.averageMs(),
                 dispatch.p95Ms(),
-                dispatch.maxMs());
+                dispatch.maxMs(),
+                packetBackpressure,
+                httpBackpressure);
     }
 
     private static GarbageCollectorMetrics collectGarbageCollectorMetrics(long now) {
@@ -879,6 +884,8 @@ public final class EmulatorStatsService {
         public final double dispatchAverageMs;
         public final double dispatchP95Ms;
         public final double dispatchMaxMs;
+        public final ExecutionBackpressureStatus.Snapshot packetBackpressure;
+        public final ExecutionBackpressureStatus.Snapshot httpBackpressure;
 
         public NetworkMetrics(
                 double incomingPacketsPerSecond,
@@ -897,7 +904,9 @@ public final class EmulatorStatsService {
                     0L,
                     0D,
                     0D,
-                    0D);
+                    0D,
+                    ExecutionBackpressureStatus.Snapshot.inactive(),
+                    ExecutionBackpressureStatus.Snapshot.inactive());
         }
 
         public NetworkMetrics(
@@ -911,6 +920,34 @@ public final class EmulatorStatsService {
                 double dispatchAverageMs,
                 double dispatchP95Ms,
                 double dispatchMaxMs) {
+            this(
+                    incomingPacketsPerSecond,
+                    outgoingPacketsPerSecond,
+                    incomingKilobytesPerSecond,
+                    outgoingKilobytesPerSecond,
+                    totalIncomingPackets,
+                    totalOutgoingPackets,
+                    dispatchSamples,
+                    dispatchAverageMs,
+                    dispatchP95Ms,
+                    dispatchMaxMs,
+                    ExecutionBackpressureStatus.Snapshot.inactive(),
+                    ExecutionBackpressureStatus.Snapshot.inactive());
+        }
+
+        public NetworkMetrics(
+                double incomingPacketsPerSecond,
+                double outgoingPacketsPerSecond,
+                double incomingKilobytesPerSecond,
+                double outgoingKilobytesPerSecond,
+                long totalIncomingPackets,
+                long totalOutgoingPackets,
+                long dispatchSamples,
+                double dispatchAverageMs,
+                double dispatchP95Ms,
+                double dispatchMaxMs,
+                ExecutionBackpressureStatus.Snapshot packetBackpressure,
+                ExecutionBackpressureStatus.Snapshot httpBackpressure) {
             this.incomingPacketsPerSecond = incomingPacketsPerSecond;
             this.outgoingPacketsPerSecond = outgoingPacketsPerSecond;
             this.incomingKilobytesPerSecond = incomingKilobytesPerSecond;
@@ -921,6 +958,8 @@ public final class EmulatorStatsService {
             this.dispatchAverageMs = dispatchAverageMs;
             this.dispatchP95Ms = dispatchP95Ms;
             this.dispatchMaxMs = dispatchMaxMs;
+            this.packetBackpressure = packetBackpressure;
+            this.httpBackpressure = httpBackpressure;
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/monitoring/ExecutionBackpressureMetrics.java
+++ b/Emulator/src/main/java/com/eu/habbo/monitoring/ExecutionBackpressureMetrics.java
@@ -1,0 +1,87 @@
+package com.eu.habbo.monitoring;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+public final class ExecutionBackpressureMetrics {
+    public record Snapshot(
+            String lane,
+            long affectedConnections,
+            int activePauses,
+            long pauseEvents,
+            long resumes,
+            long timeoutDisconnects,
+            long overflowDisconnects,
+            long httpRejections,
+            long dispatchFailures,
+            long totalPauseMillis,
+            long longestPauseMillis) {}
+
+    private final String lane;
+    private final LongAdder affectedConnections = new LongAdder();
+    private final AtomicInteger activePauses = new AtomicInteger();
+    private final LongAdder pauseEvents = new LongAdder();
+    private final LongAdder resumes = new LongAdder();
+    private final LongAdder timeoutDisconnects = new LongAdder();
+    private final LongAdder overflowDisconnects = new LongAdder();
+    private final LongAdder httpRejections = new LongAdder();
+    private final LongAdder dispatchFailures = new LongAdder();
+    private final LongAdder totalPauseNanos = new LongAdder();
+    private final AtomicLong longestPauseNanos = new AtomicLong();
+
+    public ExecutionBackpressureMetrics(String lane) {
+        this.lane = Objects.requireNonNull(lane, "lane");
+    }
+
+    public void recordAffectedConnection() {
+        this.affectedConnections.increment();
+    }
+
+    public void recordPauseStarted() {
+        this.pauseEvents.increment();
+        this.activePauses.incrementAndGet();
+    }
+
+    public void recordPauseEnded(long durationNanos, boolean resumed) {
+        long boundedDuration = Math.max(0L, durationNanos);
+        this.activePauses.updateAndGet(current -> Math.max(0, current - 1));
+        this.totalPauseNanos.add(boundedDuration);
+        this.longestPauseNanos.accumulateAndGet(boundedDuration, Math::max);
+        if (resumed) {
+            this.resumes.increment();
+        }
+    }
+
+    public void recordTimeoutDisconnect() {
+        this.timeoutDisconnects.increment();
+    }
+
+    public void recordOverflowDisconnect() {
+        this.overflowDisconnects.increment();
+    }
+
+    public void recordHttpRejection() {
+        this.httpRejections.increment();
+    }
+
+    public void recordDispatchFailure() {
+        this.dispatchFailures.increment();
+    }
+
+    public Snapshot snapshot() {
+        return new Snapshot(
+                this.lane,
+                this.affectedConnections.sum(),
+                this.activePauses.get(),
+                this.pauseEvents.sum(),
+                this.resumes.sum(),
+                this.timeoutDisconnects.sum(),
+                this.overflowDisconnects.sum(),
+                this.httpRejections.sum(),
+                this.dispatchFailures.sum(),
+                this.totalPauseNanos.sum() / 1_000_000L,
+                this.longestPauseNanos.get() / 1_000_000L);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BlockingHttpExecutionGroup.java
@@ -1,7 +1,6 @@
 package com.eu.habbo.networking.gameserver;
 
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
 import io.netty.util.concurrent.EventExecutorGroup;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -14,7 +13,27 @@ final class BlockingHttpExecutionGroup {
     private BlockingHttpExecutionGroup() {}
 
     static EventExecutorGroup get(int configuredThreads) {
-        return GROUP.get(configuredThreads);
+        return GROUP.get(configuredThreads, ExecutionBackpressureSettings.defaults());
+    }
+
+    static EventExecutorGroup get(int configuredThreads, ExecutionBackpressureSettings settings) {
+        return GROUP.get(configuredThreads, settings);
+    }
+
+    static ExecutionAdmissionHandler admissionHandler(String targetHandlerName) {
+        return GROUP.admissionHandler(targetHandlerName);
+    }
+
+    static ExecutionCapacityController.Snapshot capacitySnapshot() {
+        return GROUP.state().controller.snapshot();
+    }
+
+    static ExecutionBackpressureMetrics.Snapshot metricsSnapshot() {
+        return GROUP.state().metrics.snapshot();
+    }
+
+    static ExecutionBackpressureStatus.Snapshot statusSnapshot() {
+        return GROUP.statusSnapshot();
     }
 
     static void shutdown() {
@@ -22,27 +41,62 @@ final class BlockingHttpExecutionGroup {
     }
 
     private static final class GroupHolder {
-        private EventExecutorGroup group;
+        private State current;
 
-        private synchronized EventExecutorGroup get(int configuredThreads) {
-            if (this.group == null || this.group.isShuttingDown() || this.group.isShutdown()) {
+        private synchronized EventExecutorGroup get(int configuredThreads, ExecutionBackpressureSettings settings) {
+            if (this.current == null || this.current.executor.isShuttingDown() || this.current.executor.isShutdown()) {
                 int threads = configuredThreads > 0 ? configuredThreads : 8;
-                this.group = new DefaultEventExecutorGroup(threads, new DefaultThreadFactory("BlockingHttp", true));
+                ExecutionCapacityController controller = new ExecutionCapacityController(
+                        settings.httpCapacity(),
+                        Math.max(0, (int) (((long) settings.httpCapacity() * 3L) / 4L)),
+                        settings.mode());
+                ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("http");
+                EventExecutorGroup executor = BoundedEventExecutorGroups.create(
+                        threads, settings.httpCapacity(), "BlockingHttp", settings.mode());
+                this.current = new State(executor, controller, metrics);
             }
-            return this.group;
+            return this.current.executor;
+        }
+
+        private synchronized State state() {
+            if (this.current == null) {
+                get(8, ExecutionBackpressureSettings.defaults());
+            }
+            return this.current;
+        }
+
+        private synchronized ExecutionAdmissionHandler admissionHandler(String targetHandlerName) {
+            State state = state();
+            return ExecutionAdmissionHandler.forBlockingHttp(targetHandlerName, state.controller, state.metrics);
         }
 
         private synchronized void shutdown() {
-            if (this.group == null) {
+            if (this.current == null) {
                 return;
             }
             try {
-                this.group.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).syncUninterruptibly();
+                this.current
+                        .executor
+                        .shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS)
+                        .syncUninterruptibly();
             } catch (Exception e) {
                 LOGGER.warn("Blocking HTTP group shutdown interrupted", e);
             } finally {
-                this.group = null;
+                this.current = null;
             }
         }
+
+        private synchronized ExecutionBackpressureStatus.Snapshot statusSnapshot() {
+            if (this.current == null) {
+                return ExecutionBackpressureStatus.Snapshot.inactive();
+            }
+            return ExecutionBackpressureStatus.combine(
+                    this.current.controller.snapshot(), this.current.metrics.snapshot());
+        }
     }
+
+    private record State(
+            EventExecutorGroup executor,
+            ExecutionCapacityController controller,
+            ExecutionBackpressureMetrics metrics) {}
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BoundedEventExecutorGroups.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/BoundedEventExecutorGroups.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.networking.gameserver;
+
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.EventExecutorGroup;
+import java.util.concurrent.RejectedExecutionException;
+
+final class BoundedEventExecutorGroups {
+    private static final int MINIMUM_PENDING_TASKS = 16;
+    private static final int CONTROL_TASK_RESERVE = 64;
+
+    private BoundedEventExecutorGroups() {}
+
+    static EventExecutorGroup create(
+            int threads, int applicationCapacity, String threadPrefix, ExecutionCapacityController.Mode mode) {
+        if (threads <= 0) {
+            throw new IllegalArgumentException("Executor thread count must be positive");
+        }
+        if (applicationCapacity <= 0) {
+            throw new IllegalArgumentException("Application capacity must be positive");
+        }
+
+        DefaultThreadFactory threadFactory = new DefaultThreadFactory(threadPrefix, true);
+        if (mode == ExecutionCapacityController.Mode.OBSERVE) {
+            return new DefaultEventExecutorGroup(threads, threadFactory);
+        }
+
+        int pendingTasks = Math.max(MINIMUM_PENDING_TASKS, withControlTaskReserve(applicationCapacity));
+        return new DefaultEventExecutorGroup(threads, threadFactory, pendingTasks, (task, executor) -> {
+            throw new RejectedExecutionException(threadPrefix + " execution queue is full");
+        });
+    }
+
+    private static int withControlTaskReserve(int applicationCapacity) {
+        if (applicationCapacity > Integer.MAX_VALUE - CONTROL_TASK_RESERVE) {
+            return Integer.MAX_VALUE;
+        }
+        return applicationCapacity + CONTROL_TASK_RESERVE;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionAdmissionHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionAdmissionHandler.java
@@ -1,0 +1,355 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.ScheduledFuture;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+final class ExecutionAdmissionHandler extends ChannelInboundHandlerAdapter {
+    private static final byte[] BUSY_RESPONSE =
+            "{\"error\":\"Server busy, try again shortly.\"}".getBytes(StandardCharsets.UTF_8);
+
+    private final String targetHandlerName;
+    private final Lane lane;
+    private final ExecutionCapacityController capacityController;
+    private final ExecutionBackpressureMetrics metrics;
+    private final int perConnectionCapacity;
+    private final int perConnectionLowWatermark;
+    private final int pendingCapacity;
+    private final long pauseTimeoutMillis;
+    private final Deque<ClientMessage> pendingMessages = new ArrayDeque<>();
+
+    private int inFlight;
+    private boolean paused;
+    private boolean affectedRecorded;
+    private boolean autoReadWasEnabled;
+    private long pauseStartedAtNanos;
+    private ScheduledFuture<?> pauseDeadline;
+
+    private ExecutionAdmissionHandler(
+            String targetHandlerName,
+            Lane lane,
+            ExecutionCapacityController capacityController,
+            ExecutionBackpressureMetrics metrics,
+            int perConnectionCapacity,
+            int perConnectionLowWatermark,
+            int pendingCapacity,
+            long pauseTimeoutMillis) {
+        this.targetHandlerName = Objects.requireNonNull(targetHandlerName, "targetHandlerName");
+        this.lane = Objects.requireNonNull(lane, "lane");
+        this.capacityController = Objects.requireNonNull(capacityController, "capacityController");
+        this.metrics = Objects.requireNonNull(metrics, "metrics");
+        if (perConnectionCapacity <= 0) {
+            throw new IllegalArgumentException("Per-connection capacity must be positive");
+        }
+        if (perConnectionLowWatermark < 0 || perConnectionLowWatermark >= perConnectionCapacity) {
+            throw new IllegalArgumentException("Per-connection low watermark is out of range");
+        }
+        if (pendingCapacity <= 0) {
+            throw new IllegalArgumentException("Pending capacity must be positive");
+        }
+        if (pauseTimeoutMillis <= 0) {
+            throw new IllegalArgumentException("Pause timeout must be positive");
+        }
+        this.perConnectionCapacity = perConnectionCapacity;
+        this.perConnectionLowWatermark = perConnectionLowWatermark;
+        this.pendingCapacity = pendingCapacity;
+        this.pauseTimeoutMillis = pauseTimeoutMillis;
+    }
+
+    static ExecutionAdmissionHandler forGamePackets(
+            String targetHandlerName,
+            ExecutionCapacityController capacityController,
+            ExecutionBackpressureMetrics metrics,
+            int perConnectionCapacity,
+            int perConnectionLowWatermark,
+            int pendingCapacity,
+            long pauseTimeoutMillis) {
+        return new ExecutionAdmissionHandler(
+                targetHandlerName,
+                Lane.GAME_PACKET,
+                capacityController,
+                metrics,
+                perConnectionCapacity,
+                perConnectionLowWatermark,
+                pendingCapacity,
+                pauseTimeoutMillis);
+    }
+
+    static ExecutionAdmissionHandler forBlockingHttp(
+            String targetHandlerName,
+            ExecutionCapacityController capacityController,
+            ExecutionBackpressureMetrics metrics) {
+        return new ExecutionAdmissionHandler(
+                targetHandlerName, Lane.BLOCKING_HTTP, capacityController, metrics, 1, 0, 1, 1_000L);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (!this.lane.accepts(msg)) {
+            ctx.fireChannelRead(msg);
+            return;
+        }
+
+        if (this.lane == Lane.BLOCKING_HTTP) {
+            admitHttp(ctx, msg);
+            return;
+        }
+
+        ClientMessage message = (ClientMessage) msg;
+        if (this.capacityController.isEnforcing() && this.inFlight >= this.perConnectionCapacity) {
+            queuePacket(ctx, message);
+            return;
+        }
+
+        if (this.capacityController.tryAcquire(this) == ExecutionCapacityController.Admission.SATURATED) {
+            queuePacket(ctx, message);
+            this.capacityController.registerWaiter(this, () -> scheduleDrain(ctx));
+            return;
+        }
+
+        this.inFlight++;
+        dispatch(ctx, message, true);
+    }
+
+    private void admitHttp(ChannelHandlerContext ctx, Object msg) {
+        if (this.capacityController.tryAcquire() == ExecutionCapacityController.Admission.SATURATED) {
+            rejectHttp(ctx, msg);
+            return;
+        }
+        dispatch(ctx, msg, false);
+    }
+
+    private void queuePacket(ChannelHandlerContext ctx, ClientMessage message) {
+        if (this.pendingMessages.size() >= this.pendingCapacity) {
+            message.release();
+            this.metrics.recordOverflowDisconnect();
+            endPause(false);
+            ctx.close();
+            return;
+        }
+
+        this.pendingMessages.addLast(message);
+        if (this.paused) {
+            return;
+        }
+
+        this.paused = true;
+        this.pauseStartedAtNanos = System.nanoTime();
+        this.autoReadWasEnabled = ctx.channel().config().isAutoRead();
+        if (this.autoReadWasEnabled) {
+            ctx.channel().config().setAutoRead(false);
+        }
+        if (!this.affectedRecorded) {
+            this.affectedRecorded = true;
+            this.metrics.recordAffectedConnection();
+        }
+        this.metrics.recordPauseStarted();
+        this.pauseDeadline =
+                ctx.executor().schedule(() -> onPauseTimeout(ctx), this.pauseTimeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    private void onPauseTimeout(ChannelHandlerContext ctx) {
+        if (!this.paused) {
+            return;
+        }
+        this.metrics.recordTimeoutDisconnect();
+        endPause(false);
+        ctx.close();
+    }
+
+    private void dispatch(ChannelHandlerContext ctx, Object msg, boolean packet) {
+        ChannelHandlerContext target = ctx.pipeline().context(this.targetHandlerName);
+        if (target == null) {
+            releaseAdmission(ctx, packet);
+            releaseMessage(msg);
+            this.metrics.recordDispatchFailure();
+            ctx.close();
+            return;
+        }
+
+        Runnable task = () -> {
+            try {
+                ctx.fireChannelRead(msg);
+            } finally {
+                complete(ctx, packet);
+            }
+        };
+
+        EventExecutor executor = target.executor();
+        if (executor.inEventLoop()) {
+            task.run();
+            return;
+        }
+
+        try {
+            executor.execute(task);
+        } catch (RejectedExecutionException rejected) {
+            releaseAdmission(ctx, packet);
+            releaseMessage(msg);
+            this.metrics.recordDispatchFailure();
+            if (packet) {
+                ctx.close();
+            } else {
+                writeBusyResponse(ctx);
+            }
+        }
+    }
+
+    private void complete(ChannelHandlerContext ctx, boolean packet) {
+        if (!packet) {
+            this.capacityController.release();
+            return;
+        }
+
+        try {
+            ctx.executor().execute(() -> {
+                this.inFlight--;
+                this.capacityController.release();
+                drainOrResume(ctx);
+            });
+        } catch (RejectedExecutionException rejected) {
+            this.capacityController.release();
+        }
+    }
+
+    private void releaseAdmission(ChannelHandlerContext ctx, boolean packet) {
+        if (packet && ctx.executor().inEventLoop()) {
+            this.inFlight--;
+        }
+        this.capacityController.release();
+    }
+
+    private void scheduleDrain(ChannelHandlerContext ctx) {
+        try {
+            ctx.executor().execute(() -> drainOrResume(ctx));
+        } catch (RejectedExecutionException ignored) {
+            this.capacityController.cancelWaiter(this);
+        }
+    }
+
+    private void drainOrResume(ChannelHandlerContext ctx) {
+        if (!ctx.channel().isActive()) {
+            endPause(false);
+            cleanupQueuedMessages();
+            return;
+        }
+
+        if (!this.pendingMessages.isEmpty() && this.inFlight < this.perConnectionCapacity) {
+            if (this.capacityController.tryAcquire(this) == ExecutionCapacityController.Admission.SATURATED) {
+                this.capacityController.registerWaiter(this, () -> scheduleDrain(ctx));
+                return;
+            }
+            ClientMessage next = this.pendingMessages.removeFirst();
+            this.inFlight++;
+            dispatch(ctx, next, true);
+            if (!this.pendingMessages.isEmpty() && this.inFlight < this.perConnectionCapacity) {
+                scheduleDrain(ctx);
+            }
+            return;
+        }
+
+        ExecutionCapacityController.Snapshot capacity = this.capacityController.snapshot();
+        if (this.pendingMessages.isEmpty()
+                && this.inFlight <= this.perConnectionLowWatermark
+                && capacity.inFlight() <= capacity.lowWatermark()) {
+            endPause(true);
+            if (this.autoReadWasEnabled && ctx.channel().isActive()) {
+                ctx.channel().config().setAutoRead(true);
+            }
+        } else if (this.paused && capacity.inFlight() > capacity.lowWatermark()) {
+            this.capacityController.registerWaiter(this, () -> scheduleDrain(ctx));
+        }
+    }
+
+    private void rejectHttp(ChannelHandlerContext ctx, Object msg) {
+        releaseMessage(msg);
+        this.metrics.recordHttpRejection();
+        writeBusyResponse(ctx);
+    }
+
+    private static void writeBusyResponse(ChannelHandlerContext ctx) {
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.SERVICE_UNAVAILABLE, Unpooled.wrappedBuffer(BUSY_RESPONSE));
+        response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json; charset=UTF-8");
+        response.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, BUSY_RESPONSE.length);
+        response.headers().set(HttpHeaderNames.RETRY_AFTER, "1");
+        response.headers().set(HttpHeaderNames.CONNECTION, "close");
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private void endPause(boolean resumed) {
+        if (!this.paused) {
+            return;
+        }
+        this.paused = false;
+        this.capacityController.cancelWaiter(this);
+        if (this.pauseDeadline != null) {
+            this.pauseDeadline.cancel(false);
+            this.pauseDeadline = null;
+        }
+        this.metrics.recordPauseEnded(System.nanoTime() - this.pauseStartedAtNanos, resumed);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        endPause(false);
+        cleanupQueuedMessages();
+        ctx.fireChannelInactive();
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) {
+        endPause(false);
+        cleanupQueuedMessages();
+    }
+
+    private void cleanupQueuedMessages() {
+        ClientMessage message;
+        while ((message = this.pendingMessages.pollFirst()) != null) {
+            message.release();
+        }
+    }
+
+    private static void releaseMessage(Object message) {
+        if (message instanceof ClientMessage clientMessage) {
+            clientMessage.release();
+        } else {
+            ReferenceCountUtil.release(message);
+        }
+    }
+
+    private enum Lane {
+        GAME_PACKET {
+            @Override
+            boolean accepts(Object message) {
+                return message instanceof ClientMessage;
+            }
+        },
+        BLOCKING_HTTP {
+            @Override
+            boolean accepts(Object message) {
+                return message instanceof FullHttpRequest;
+            }
+        };
+
+        abstract boolean accepts(Object message);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionBackpressureSettings.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionBackpressureSettings.java
@@ -1,0 +1,74 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.core.ConfigurationManager;
+import java.util.Objects;
+
+record ExecutionBackpressureSettings(
+        ExecutionCapacityController.Mode mode,
+        int packetCapacity,
+        int packetLowWatermark,
+        int perConnectionCapacity,
+        int perConnectionLowWatermark,
+        int perConnectionPendingCapacity,
+        long pauseTimeoutMillis,
+        int httpCapacity) {
+    private static final int DEFAULT_PACKET_CAPACITY = 256;
+    private static final int DEFAULT_PER_CONNECTION_CAPACITY = 32;
+
+    static ExecutionBackpressureSettings defaults() {
+        return new ExecutionBackpressureSettings(
+                ExecutionCapacityController.Mode.OBSERVE, 256, 192, 32, 16, 16, 2_000L, 128);
+    }
+
+    static ExecutionBackpressureSettings from(ConfigurationManager configuration) {
+        Objects.requireNonNull(configuration, "configuration");
+
+        ExecutionCapacityController.Mode mode = ExecutionCapacityController.Mode.parse(
+                configuration.getValue("execution.backpressure.mode", "observe"));
+        int packetCapacity = positive(
+                configuration.getInt("io.packet.handler.queue.capacity", DEFAULT_PACKET_CAPACITY),
+                DEFAULT_PACKET_CAPACITY);
+        int packetLowWatermark = lowWatermark(
+                configuration.getInt("io.packet.handler.queue.low_watermark", percentage(packetCapacity, 75)),
+                packetCapacity,
+                percentage(packetCapacity, 75));
+        int perConnectionCapacity = positive(
+                configuration.getInt("io.packet.handler.per_connection.capacity", DEFAULT_PER_CONNECTION_CAPACITY),
+                DEFAULT_PER_CONNECTION_CAPACITY);
+        perConnectionCapacity = Math.min(perConnectionCapacity, packetCapacity);
+        int perConnectionLowWatermark = lowWatermark(
+                configuration.getInt("io.packet.handler.per_connection.low_watermark", perConnectionCapacity / 2),
+                perConnectionCapacity,
+                perConnectionCapacity / 2);
+        int perConnectionPendingCapacity =
+                positive(configuration.getInt("io.packet.handler.per_connection.pending", 16), 16);
+        long pauseTimeoutMillis =
+                positive(configuration.getInt("execution.backpressure.pause.timeout_ms", 2_000), 2_000);
+        int httpCapacity = positive(configuration.getInt("http.blocking.queue.capacity", 128), 128);
+
+        return new ExecutionBackpressureSettings(
+                mode,
+                packetCapacity,
+                packetLowWatermark,
+                perConnectionCapacity,
+                perConnectionLowWatermark,
+                perConnectionPendingCapacity,
+                pauseTimeoutMillis,
+                httpCapacity);
+    }
+
+    private static int positive(int configured, int fallback) {
+        return configured > 0 ? configured : fallback;
+    }
+
+    private static int lowWatermark(int configured, int capacity, int fallback) {
+        if (configured < 0 || configured >= capacity) {
+            return Math.min(Math.max(0, fallback), capacity - 1);
+        }
+        return configured;
+    }
+
+    private static int percentage(int value, int percentage) {
+        return Math.max(0, (value * percentage) / 100);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionBackpressureStatus.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionBackpressureStatus.java
@@ -1,0 +1,65 @@
+package com.eu.habbo.networking.gameserver;
+
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
+
+public final class ExecutionBackpressureStatus {
+    public record Snapshot(
+            String mode,
+            int capacity,
+            int lowWatermark,
+            int inFlight,
+            int highWatermark,
+            long wouldThrottle,
+            long rejections,
+            int waitingConnections,
+            long affectedConnections,
+            int activePauses,
+            long pauseEvents,
+            long resumes,
+            long timeoutDisconnects,
+            long overflowDisconnects,
+            long httpRejections,
+            long dispatchFailures,
+            long totalPauseMillis,
+            long longestPauseMillis) {
+        public static Snapshot inactive() {
+            return new Snapshot("inactive", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        }
+    }
+
+    private ExecutionBackpressureStatus() {}
+
+    public static Snapshot packet() {
+        return GamePacketExecutionGroup.statusSnapshot();
+    }
+
+    public static Snapshot http() {
+        return BlockingHttpExecutionGroup.statusSnapshot();
+    }
+
+    static Snapshot combine(
+            ExecutionCapacityController.Snapshot capacity, ExecutionBackpressureMetrics.Snapshot metrics) {
+        if (capacity == null || metrics == null) {
+            return Snapshot.inactive();
+        }
+        return new Snapshot(
+                capacity.mode().name().toLowerCase(java.util.Locale.ROOT),
+                capacity.capacity(),
+                capacity.lowWatermark(),
+                capacity.inFlight(),
+                capacity.highWatermark(),
+                capacity.wouldThrottle(),
+                capacity.rejections(),
+                capacity.waitingConnections(),
+                metrics.affectedConnections(),
+                metrics.activePauses(),
+                metrics.pauseEvents(),
+                metrics.resumes(),
+                metrics.timeoutDisconnects(),
+                metrics.overflowDisconnects(),
+                metrics.httpRejections(),
+                metrics.dispatchFailures(),
+                metrics.totalPauseMillis(),
+                metrics.longestPauseMillis());
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionCapacityController.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/ExecutionCapacityController.java
@@ -1,0 +1,161 @@
+package com.eu.habbo.networking.gameserver;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+final class ExecutionCapacityController {
+    enum Admission {
+        ADMITTED,
+        SATURATED
+    }
+
+    enum Mode {
+        OBSERVE,
+        ENFORCE;
+
+        static Mode parse(String value) {
+            return "enforce".equalsIgnoreCase(value) ? ENFORCE : OBSERVE;
+        }
+    }
+
+    record Snapshot(
+            Mode mode,
+            int capacity,
+            int lowWatermark,
+            int inFlight,
+            int highWatermark,
+            long wouldThrottle,
+            long rejections,
+            int waitingConnections) {}
+
+    private final int capacity;
+    private final int lowWatermark;
+    private final Mode mode;
+    private final Map<Object, Runnable> waiters = new LinkedHashMap<>();
+    private final Set<Object> reservations = new HashSet<>();
+
+    private int inFlight;
+    private int highWatermark;
+    private long wouldThrottle;
+    private long rejections;
+
+    ExecutionCapacityController(int capacity, int lowWatermark, Mode mode) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Execution capacity must be positive");
+        }
+        if (lowWatermark < 0 || lowWatermark >= capacity) {
+            throw new IllegalArgumentException("Low watermark must be between zero and capacity - 1");
+        }
+        this.capacity = capacity;
+        this.lowWatermark = lowWatermark;
+        this.mode = Objects.requireNonNull(mode, "mode");
+    }
+
+    synchronized Admission tryAcquire() {
+        return tryAcquire(null);
+    }
+
+    boolean isEnforcing() {
+        return this.mode == Mode.ENFORCE;
+    }
+
+    synchronized Admission tryAcquire(Object key) {
+        if (key != null && this.reservations.remove(key)) {
+            this.inFlight++;
+            this.highWatermark = Math.max(this.highWatermark, this.inFlight);
+            return Admission.ADMITTED;
+        }
+
+        if (this.mode == Mode.ENFORCE && occupiedCapacity() >= this.capacity) {
+            this.rejections++;
+            return Admission.SATURATED;
+        }
+
+        this.inFlight++;
+        this.highWatermark = Math.max(this.highWatermark, this.inFlight);
+        if (this.mode == Mode.OBSERVE && this.inFlight > this.capacity) {
+            this.wouldThrottle++;
+        }
+        return Admission.ADMITTED;
+    }
+
+    void release() {
+        Runnable waiter;
+        synchronized (this) {
+            if (this.inFlight == 0) {
+                throw new IllegalStateException("Execution capacity released without an admission");
+            }
+            this.inFlight--;
+            waiter = reserveNextWaiter();
+        }
+        if (waiter != null) {
+            waiter.run();
+        }
+    }
+
+    void registerWaiter(Object key, Runnable callback) {
+        Objects.requireNonNull(key, "key");
+        Objects.requireNonNull(callback, "callback");
+        Runnable immediate = null;
+        synchronized (this) {
+            if (this.reservations.contains(key) || this.waiters.containsKey(key)) {
+                return;
+            }
+            if (this.mode == Mode.OBSERVE) {
+                immediate = callback;
+            } else if (this.inFlight <= this.lowWatermark && occupiedCapacity() < this.capacity) {
+                this.reservations.add(key);
+                immediate = callback;
+            } else {
+                this.waiters.put(key, callback);
+            }
+        }
+        if (immediate != null) {
+            immediate.run();
+        }
+    }
+
+    void cancelWaiter(Object key) {
+        Runnable waiter;
+        synchronized (this) {
+            this.waiters.remove(key);
+            this.reservations.remove(key);
+            waiter = reserveNextWaiter();
+        }
+        if (waiter != null) {
+            waiter.run();
+        }
+    }
+
+    synchronized Snapshot snapshot() {
+        return new Snapshot(
+                this.mode,
+                this.capacity,
+                this.lowWatermark,
+                this.inFlight,
+                this.highWatermark,
+                this.wouldThrottle,
+                this.rejections,
+                this.waiters.size() + this.reservations.size());
+    }
+
+    private int occupiedCapacity() {
+        return this.inFlight + this.reservations.size();
+    }
+
+    private Runnable reserveNextWaiter() {
+        if (this.mode != Mode.ENFORCE
+                || this.inFlight > this.lowWatermark
+                || occupiedCapacity() >= this.capacity
+                || this.waiters.isEmpty()) {
+            return null;
+        }
+        Map.Entry<Object, Runnable> entry = this.waiters.entrySet().iterator().next();
+        this.waiters.remove(entry.getKey());
+        this.reservations.add(entry.getKey());
+        return entry.getValue();
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GamePacketExecutionGroup.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GamePacketExecutionGroup.java
@@ -1,8 +1,8 @@
 package com.eu.habbo.networking.gameserver;
 
 import com.eu.habbo.Emulator;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
-import io.netty.util.concurrent.DefaultThreadFactory;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
 import io.netty.util.concurrent.EventExecutorGroup;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -10,30 +10,104 @@ import org.slf4j.LoggerFactory;
 
 final class GamePacketExecutionGroup {
     private static final Logger LOGGER = LoggerFactory.getLogger(GamePacketExecutionGroup.class);
-    private static final EventExecutorGroup GROUP =
-            new DefaultEventExecutorGroup(configuredThreads(), new DefaultThreadFactory("GamePacketHandler", true));
+    private static final GroupHolder GROUP = new GroupHolder();
 
     private GamePacketExecutionGroup() {}
 
     static EventExecutorGroup get() {
-        return GROUP;
+        return GROUP.state().executor;
+    }
+
+    static ExecutionAdmissionHandler admissionHandler(String targetHandlerName) {
+        State state = GROUP.state();
+        ExecutionBackpressureSettings settings = state.settings;
+        return ExecutionAdmissionHandler.forGamePackets(
+                targetHandlerName,
+                state.controller,
+                state.metrics,
+                settings.perConnectionCapacity(),
+                settings.perConnectionLowWatermark(),
+                settings.perConnectionPendingCapacity(),
+                settings.pauseTimeoutMillis());
+    }
+
+    static ExecutionCapacityController.Snapshot capacitySnapshot() {
+        return GROUP.state().controller.snapshot();
+    }
+
+    static ExecutionBackpressureMetrics.Snapshot metricsSnapshot() {
+        return GROUP.state().metrics.snapshot();
+    }
+
+    static ExecutionBackpressureStatus.Snapshot statusSnapshot() {
+        return GROUP.statusSnapshot();
     }
 
     static void shutdown() {
-        try {
-            GROUP.shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS).syncUninterruptibly();
-        } catch (Exception e) {
-            LOGGER.warn("Packet handler group shutdown interrupted", e);
-        }
+        GROUP.shutdown();
     }
 
     static int configuredThreads() {
         int fallback = Math.max(16, Runtime.getRuntime().availableProcessors() * 2);
-        if (Emulator.getConfig() == null) {
+        ConfigurationManager configuration = Emulator.getConfig();
+        if (configuration == null) {
             return fallback;
         }
 
-        int configured = Emulator.getConfig().getInt("io.packet.handler.threads", fallback);
+        int configured = configuration.getInt("io.packet.handler.threads", fallback);
         return configured > 0 ? configured : fallback;
+    }
+
+    private static ExecutionBackpressureSettings settings() {
+        ConfigurationManager configuration = Emulator.getConfig();
+        return configuration == null
+                ? ExecutionBackpressureSettings.defaults()
+                : ExecutionBackpressureSettings.from(configuration);
+    }
+
+    private record State(
+            EventExecutorGroup executor,
+            ExecutionCapacityController controller,
+            ExecutionBackpressureMetrics metrics,
+            ExecutionBackpressureSettings settings) {}
+
+    private static final class GroupHolder {
+        private State state;
+
+        private synchronized State state() {
+            if (this.state == null || this.state.executor.isShuttingDown() || this.state.executor.isShutdown()) {
+                ExecutionBackpressureSettings settings = settings();
+                ExecutionCapacityController controller = new ExecutionCapacityController(
+                        settings.packetCapacity(), settings.packetLowWatermark(), settings.mode());
+                ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("packet");
+                EventExecutorGroup executor = BoundedEventExecutorGroups.create(
+                        configuredThreads(), settings.packetCapacity(), "GamePacketHandler", settings.mode());
+                this.state = new State(executor, controller, metrics, settings);
+            }
+            return this.state;
+        }
+
+        private synchronized void shutdown() {
+            if (this.state == null) {
+                return;
+            }
+            try {
+                this.state
+                        .executor
+                        .shutdownGracefully(100, 3000, TimeUnit.MILLISECONDS)
+                        .syncUninterruptibly();
+            } catch (Exception e) {
+                LOGGER.warn("Packet handler group shutdown interrupted", e);
+            } finally {
+                this.state = null;
+            }
+        }
+
+        private synchronized ExecutionBackpressureStatus.Snapshot statusSnapshot() {
+            if (this.state == null) {
+                return ExecutionBackpressureStatus.Snapshot.inactive();
+            }
+            return ExecutionBackpressureStatus.combine(this.state.controller.snapshot(), this.state.metrics.snapshot());
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/GameServer.java
@@ -77,6 +77,10 @@ public class GameServer extends Server {
                 ch.pipeline().addLast("packetDispatchMarker", new PacketDispatchMarker());
                 ch.pipeline()
                         .addLast(
+                                "packetExecutionAdmission",
+                                GamePacketExecutionGroup.admissionHandler("packetDispatchLatency"));
+                ch.pipeline()
+                        .addLast(
                                 GamePacketExecutionGroup.get(),
                                 "packetDispatchLatency",
                                 new PacketDispatchLatencyHandler());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/WebSocketChannelInitializer.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.networking.gameserver;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.messages.PacketManager;
 import com.eu.habbo.networking.gameserver.auth.AuthHttpHandler;
 import com.eu.habbo.networking.gameserver.auth.NitroSecureApiHandler;
@@ -91,20 +92,40 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast("httpCodec", new HttpServerCodec());
         ch.pipeline().addLast("httpAggregator", new HttpObjectAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsHttpHandler", new WebSocketHttpHandler());
-        EventExecutorGroup blockingHttp = BlockingHttpExecutionGroup.get(this.blockingHttpThreads);
+        ConfigurationManager configuration = Emulator.getConfig();
+        ExecutionBackpressureSettings backpressureSettings = configuration == null
+                ? ExecutionBackpressureSettings.defaults()
+                : ExecutionBackpressureSettings.from(configuration);
+        EventExecutorGroup blockingHttp =
+                BlockingHttpExecutionGroup.get(this.blockingHttpThreads, backpressureSettings);
+        ch.pipeline()
+                .addLast(
+                        "blockingHttpAdmissionAssets",
+                        BlockingHttpExecutionGroup.admissionHandler("nitroSecureAssetHandler"));
         ch.pipeline().addLast(blockingHttp, "nitroSecureAssetHandler", new NitroSecureAssetHandler());
         ch.pipeline().addLast("nitroSecureApiHandler", new NitroSecureApiHandler());
         ch.pipeline().addLast("authHttpHandler", new AuthHttpHandler());
+        ch.pipeline().addLast("blockingHttpAdmissionCms", BlockingHttpExecutionGroup.admissionHandler("cmsApiHandler"));
         ch.pipeline().addLast(blockingHttp, "cmsApiHandler", new CmsApiHandler());
+        ch.pipeline()
+                .addLast("blockingHttpAdmissionBadge", BlockingHttpExecutionGroup.admissionHandler("badgeHttpHandler"));
         ch.pipeline().addLast(blockingHttp, "badgeHttpHandler", new BadgeHttpHandler());
+        ch.pipeline()
+                .addLast(
+                        "blockingHttpAdmissionBadgeLeaderboard",
+                        BlockingHttpExecutionGroup.admissionHandler("badgeLeaderboardHttpHandler"));
         ch.pipeline().addLast(blockingHttp, "badgeLeaderboardHttpHandler", new BadgeLeaderboardHttpHandler());
+        ch.pipeline()
+                .addLast(
+                        "blockingHttpAdmissionStats",
+                        BlockingHttpExecutionGroup.admissionHandler("emuStatsHttpHandler"));
         ch.pipeline().addLast(blockingHttp, "emuStatsHttpHandler", new EmuStatsHttpHandler());
         ch.pipeline().addLast("wsProtocolHandler", new WebSocketServerProtocolHandler(this.wsConfig));
         ch.pipeline().addLast("wsHttpCleanup", new WebSocketHttpCleanupHandler());
         ch.pipeline().addLast("wsFrameAggregator", new WebSocketFrameAggregator(MAX_FRAME_SIZE));
         ch.pipeline().addLast("wsCodec", new WebSocketCodec());
 
-        if (Emulator.getConfig().getBoolean("crypto.ws.enabled", false)) {
+        if (configuration != null && configuration.getBoolean("crypto.ws.enabled", false)) {
             ch.pipeline().addLast(WsHandshakeHandler.HANDLER_NAME, new WsHandshakeHandler());
         }
 
@@ -119,6 +140,9 @@ public class WebSocketChannelInitializer extends ChannelInitializer<SocketChanne
         ch.pipeline().addLast("idleEventHandler", new IdleTimeoutHandler(30, 60));
         ch.pipeline().addLast(new GameMessageRateLimit());
         ch.pipeline().addLast("packetDispatchMarker", new PacketDispatchMarker());
+        ch.pipeline()
+                .addLast(
+                        "packetExecutionAdmission", GamePacketExecutionGroup.admissionHandler("packetDispatchLatency"));
         ch.pipeline()
                 .addLast(GamePacketExecutionGroup.get(), "packetDispatchLatency", new PacketDispatchLatencyHandler());
         ch.pipeline().addLast(GamePacketExecutionGroup.get(), "gameMessageHandler", new GameMessageHandler());

--- a/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/WebSocketHttpCleanupHandler.java
+++ b/Emulator/src/main/java/com/eu/habbo/networking/gameserver/handlers/WebSocketHttpCleanupHandler.java
@@ -14,11 +14,17 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
  */
 public class WebSocketHttpCleanupHandler extends ChannelInboundHandlerAdapter {
     private static final String[] HTTP_ONLY_HANDLERS = {
+        "blockingHttpAdmissionAssets",
         "nitroSecureAssetHandler",
         "nitroSecureApiHandler",
         "authHttpHandler",
+        "blockingHttpAdmissionCms",
+        "cmsApiHandler",
+        "blockingHttpAdmissionBadge",
         "badgeHttpHandler",
+        "blockingHttpAdmissionBadgeLeaderboard",
         "badgeLeaderboardHttpHandler",
+        "blockingHttpAdmissionStats",
         "emuStatsHttpHandler",
     };
 

--- a/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/core/config/ConfigRegistryTest.java
@@ -57,6 +57,11 @@ class ConfigRegistryTest {
         String reference = ConfigRegistry.standard().renderMarkdown();
 
         assertTrue(reference.contains("| `http.blocking.pool.size` | integer | `8` |"));
+        assertTrue(reference.contains("| `http.blocking.queue.capacity` | integer | `128` |"));
+        assertTrue(reference.contains("| `execution.backpressure.mode` | string | `observe` |"));
+        assertTrue(reference.contains("| `execution.backpressure.pause.timeout_ms` | integer | `2000` |"));
+        assertTrue(reference.contains("| `io.packet.handler.queue.capacity` | integer | `256` |"));
+        assertTrue(reference.contains("| `io.packet.handler.per_connection.capacity` | integer | `32` |"));
         assertTrue(reference.contains("| `io.netty.write_buffer.low_water_mark` | integer | `32768` |"));
         assertTrue(reference.contains("| `io.netty.write_buffer.high_water_mark` | integer | `65536` |"));
         assertTrue(reference.contains("| `io.netty.unwritable.timeout.seconds` | integer | `10` |"));

--- a/Emulator/src/test/java/com/eu/habbo/monitoring/NetworkDispatchMetricsContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/monitoring/NetworkDispatchMetricsContractTest.java
@@ -2,18 +2,26 @@ package com.eu.habbo.monitoring;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.eu.habbo.networking.gameserver.ExecutionBackpressureStatus;
 import org.junit.jupiter.api.Test;
 
 class NetworkDispatchMetricsContractTest {
 
     @Test
     void networkSnapshotExposesDispatchLatencyWindow() {
+        ExecutionBackpressureStatus.Snapshot packet = new ExecutionBackpressureStatus.Snapshot(
+                "enforce", 100, 75, 20, 80, 3, 2, 1, 4, 1, 4, 3, 1, 0, 0, 0, 25, 10);
+        ExecutionBackpressureStatus.Snapshot http = new ExecutionBackpressureStatus.Snapshot(
+                "observe", 50, 37, 2, 7, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0);
         EmulatorStatsService.NetworkMetrics metrics =
-                new EmulatorStatsService.NetworkMetrics(1D, 2D, 3D, 4D, 5L, 6L, 7L, 8D, 9D, 10D);
+                new EmulatorStatsService.NetworkMetrics(1D, 2D, 3D, 4D, 5L, 6L, 7L, 8D, 9D, 10D, packet, http);
 
         assertEquals(7L, metrics.dispatchSamples);
         assertEquals(8D, metrics.dispatchAverageMs);
         assertEquals(9D, metrics.dispatchP95Ms);
         assertEquals(10D, metrics.dispatchMaxMs);
+        assertEquals(80, metrics.packetBackpressure.highWatermark());
+        assertEquals(3, metrics.packetBackpressure.wouldThrottle());
+        assertEquals(2, metrics.httpBackpressure.httpRejections());
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/ExecutionAdmissionHandlerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/ExecutionAdmissionHandlerTest.java
@@ -1,0 +1,363 @@
+package com.eu.habbo.networking.gameserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class ExecutionAdmissionHandlerTest {
+
+    @Test
+    void packetLanePausesAndResumesWithoutDroppingQueuedMessages() throws Exception {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("packet");
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        List<Integer> handled = new CopyOnWriteArrayList<>();
+        DefaultEventExecutorGroup workers = new DefaultEventExecutorGroup(1);
+        EmbeddedChannel channel =
+                packetChannel(controller, metrics, 2_000, 2, workers, firstStarted, releaseFirst, handled);
+        try {
+            channel.writeInbound(message(1));
+            assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+            channel.writeInbound(message(2));
+
+            assertTrue(channel.isActive());
+            assertFalse(channel.config().isAutoRead());
+            assertEquals(1, metrics.snapshot().activePauses());
+
+            releaseFirst.countDown();
+            await(channel, () -> handled.size() == 2 && channel.config().isAutoRead());
+
+            assertEquals(List.of(1, 2), handled);
+            assertTrue(channel.isActive());
+            assertTrue(channel.config().isAutoRead());
+            assertEquals(0, metrics.snapshot().activePauses());
+            assertEquals(1, metrics.snapshot().resumes());
+        } finally {
+            releaseFirst.countDown();
+            channel.finishAndReleaseAll();
+            workers.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void sustainedPacketCongestionDisconnectsAfterTheConfiguredDeadline() throws Exception {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("packet");
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        DefaultEventExecutorGroup workers = new DefaultEventExecutorGroup(1);
+        EmbeddedChannel channel = packetChannel(
+                controller, metrics, 40, 2, workers, firstStarted, releaseFirst, new CopyOnWriteArrayList<>());
+        try {
+            channel.writeInbound(message(1));
+            assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+            channel.writeInbound(message(2));
+
+            Thread.sleep(60);
+            channel.runScheduledPendingTasks();
+            channel.runPendingTasks();
+
+            assertFalse(channel.isActive());
+            assertEquals(1, metrics.snapshot().timeoutDisconnects());
+        } finally {
+            releaseFirst.countDown();
+            channel.finishAndReleaseAll();
+            workers.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void exceedingThePerConnectionPendingLimitClosesAndReleasesMessages() throws Exception {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("packet");
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        DefaultEventExecutorGroup workers = new DefaultEventExecutorGroup(1);
+        EmbeddedChannel channel = packetChannel(
+                controller, metrics, 2_000, 1, workers, firstStarted, releaseFirst, new CopyOnWriteArrayList<>());
+        ClientMessage queued = message(2);
+        ClientMessage overflow = message(3);
+        try {
+            channel.writeInbound(message(1));
+            assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+            channel.writeInbound(queued);
+            channel.writeInbound(overflow);
+            channel.runPendingTasks();
+
+            assertFalse(channel.isActive());
+            assertEquals(0, queued.getBuffer().refCnt());
+            assertEquals(0, overflow.getBuffer().refCnt());
+            assertEquals(1, metrics.snapshot().overflowDisconnects());
+        } finally {
+            releaseFirst.countDown();
+            channel.finishAndReleaseAll();
+            workers.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void closingAPausedConnectionReleasesItsPendingMessagesAndWaiter() throws Exception {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("packet");
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        DefaultEventExecutorGroup workers = new DefaultEventExecutorGroup(1);
+        EmbeddedChannel channel = packetChannel(
+                controller, metrics, 2_000, 2, workers, firstStarted, releaseFirst, new CopyOnWriteArrayList<>());
+        ClientMessage queued = message(2);
+        try {
+            channel.writeInbound(message(1));
+            assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+            channel.writeInbound(queued);
+
+            channel.close().syncUninterruptibly();
+            channel.runPendingTasks();
+
+            assertEquals(0, queued.getBuffer().refCnt());
+            assertEquals(0, metrics.snapshot().activePauses());
+            assertEquals(0, controller.snapshot().waitingConnections());
+        } finally {
+            releaseFirst.countDown();
+            channel.finishAndReleaseAll();
+            workers.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void missingDispatchTargetClosesAndReleasesTheAdmission() {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("packet");
+        EmbeddedChannel channel = new EmbeddedChannel(
+                ExecutionAdmissionHandler.forGamePackets("missing", controller, metrics, 1, 0, 1, 2_000));
+        ClientMessage message = message(1);
+        try {
+            channel.writeInbound(message);
+            channel.runPendingTasks();
+
+            assertFalse(channel.isActive());
+            assertEquals(0, message.getBuffer().refCnt());
+            assertEquals(0, controller.snapshot().inFlight());
+            assertEquals(1, metrics.snapshot().dispatchFailures());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void observeModeRecordsPressureWithoutPausingTheConnection() throws Exception {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.OBSERVE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("packet");
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        List<Integer> handled = new CopyOnWriteArrayList<>();
+        DefaultEventExecutorGroup workers = new DefaultEventExecutorGroup(1);
+        EmbeddedChannel channel =
+                packetChannel(controller, metrics, 2_000, 1, workers, firstStarted, releaseFirst, handled);
+        try {
+            channel.writeInbound(message(1));
+            assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+            channel.writeInbound(message(2));
+
+            assertTrue(channel.isActive());
+            assertTrue(channel.config().isAutoRead());
+            assertEquals(1, controller.snapshot().wouldThrottle());
+
+            releaseFirst.countDown();
+            await(channel, () -> handled.size() == 2);
+            assertEquals(List.of(1, 2), handled);
+        } finally {
+            releaseFirst.countDown();
+            channel.finishAndReleaseAll();
+            workers.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void sharedCapacityServesAnOlderWaitingConnectionBeforeTheReleasingConnection() throws Exception {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("packet");
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        List<Integer> handled = new CopyOnWriteArrayList<>();
+        DefaultEventExecutorGroup workers = new DefaultEventExecutorGroup(2);
+        EmbeddedChannel first =
+                packetChannel(controller, metrics, 2_000, 2, workers, firstStarted, releaseFirst, handled);
+        EmbeddedChannel second = packetChannel(
+                controller, metrics, 2_000, 2, workers, new CountDownLatch(1), new CountDownLatch(0), handled);
+        try {
+            first.writeInbound(message(1));
+            assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+            second.writeInbound(message(100));
+            first.writeInbound(message(2));
+
+            releaseFirst.countDown();
+            awaitBoth(first, second, () -> handled.size() == 3);
+
+            assertEquals(List.of(1, 100, 2), handled);
+        } finally {
+            releaseFirst.countDown();
+            first.finishAndReleaseAll();
+            second.finishAndReleaseAll();
+            workers.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void saturatedHttpLaneReturnsRetryableServiceUnavailable() throws Exception {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics("http");
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        DefaultEventExecutorGroup workers = new DefaultEventExecutorGroup(1);
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline()
+                .addLast("admission", ExecutionAdmissionHandler.forBlockingHttp("target", controller, metrics));
+        channel.pipeline().addLast(workers, "target", new BlockingHandler(firstStarted, releaseFirst));
+        try {
+            channel.writeInbound(request("/first"));
+            assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+            DefaultFullHttpRequest rejected = request("/second");
+            channel.writeInbound(rejected);
+            channel.runPendingTasks();
+
+            FullHttpResponse response = channel.readOutbound();
+            assertEquals(HttpResponseStatus.SERVICE_UNAVAILABLE, response.status());
+            assertEquals("1", response.headers().get(HttpHeaderNames.RETRY_AFTER));
+            assertEquals(0, rejected.refCnt());
+            assertEquals(1, metrics.snapshot().httpRejections());
+            ReferenceCountUtil.release(response);
+        } finally {
+            releaseFirst.countDown();
+            channel.finishAndReleaseAll();
+            workers.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    private static EmbeddedChannel packetChannel(
+            ExecutionCapacityController controller,
+            ExecutionBackpressureMetrics metrics,
+            long timeoutMillis,
+            int pendingCapacity,
+            DefaultEventExecutorGroup workers,
+            CountDownLatch firstStarted,
+            CountDownLatch releaseFirst,
+            List<Integer> handled) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline()
+                .addLast(
+                        "admission",
+                        ExecutionAdmissionHandler.forGamePackets(
+                                "target", controller, metrics, 1, 0, pendingCapacity, timeoutMillis));
+        channel.pipeline().addLast(workers, "target", new PacketHandler(firstStarted, releaseFirst, handled));
+        return channel;
+    }
+
+    private static ClientMessage message(int id) {
+        return new ClientMessage(id, Unpooled.buffer(1).writeByte(id));
+    }
+
+    private static DefaultFullHttpRequest request(String path) {
+        return new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path);
+    }
+
+    private static void await(EmbeddedChannel channel, Condition condition) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (!condition.satisfied() && System.nanoTime() < deadline) {
+            channel.runPendingTasks();
+            channel.runScheduledPendingTasks();
+            Thread.sleep(5);
+        }
+        assertTrue(condition.satisfied(), "condition was not satisfied before the deadline");
+    }
+
+    private static void awaitBoth(EmbeddedChannel first, EmbeddedChannel second, Condition condition) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (!condition.satisfied() && System.nanoTime() < deadline) {
+            first.runPendingTasks();
+            first.runScheduledPendingTasks();
+            second.runPendingTasks();
+            second.runScheduledPendingTasks();
+            Thread.sleep(5);
+        }
+        assertTrue(condition.satisfied(), "condition was not satisfied before the deadline");
+    }
+
+    private interface Condition {
+        boolean satisfied();
+    }
+
+    private static final class PacketHandler extends ChannelInboundHandlerAdapter {
+        private final CountDownLatch firstStarted;
+        private final CountDownLatch releaseFirst;
+        private final List<Integer> handled;
+
+        private PacketHandler(CountDownLatch firstStarted, CountDownLatch releaseFirst, List<Integer> handled) {
+            this.firstStarted = firstStarted;
+            this.releaseFirst = releaseFirst;
+            this.handled = handled;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            ClientMessage message = (ClientMessage) msg;
+            try {
+                if (this.handled.isEmpty()) {
+                    this.firstStarted.countDown();
+                    this.releaseFirst.await(2, TimeUnit.SECONDS);
+                }
+                this.handled.add(message.getMessageId());
+            } finally {
+                message.release();
+            }
+        }
+    }
+
+    private static final class BlockingHandler extends ChannelInboundHandlerAdapter {
+        private final CountDownLatch started;
+        private final CountDownLatch release;
+
+        private BlockingHandler(CountDownLatch started, CountDownLatch release) {
+            this.started = started;
+            this.release = release;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            try {
+                this.started.countDown();
+                this.release.await(2, TimeUnit.SECONDS);
+            } finally {
+                ReferenceCountUtil.release(msg);
+            }
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/ExecutionAdmissionNetworkIT.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/ExecutionAdmissionNetworkIT.java
@@ -1,0 +1,211 @@
+package com.eu.habbo.networking.gameserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.messages.ClientMessage;
+import com.eu.habbo.monitoring.ExecutionBackpressureMetrics;
+import com.eu.habbo.networking.gameserver.codec.WebSocketCodec;
+import com.eu.habbo.networking.gameserver.decoders.GameByteDecoder;
+import com.eu.habbo.networking.gameserver.decoders.GameByteFrameDecoder;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolConfig;
+import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class ExecutionAdmissionNetworkIT {
+
+    @Test
+    void tcpConnectionPausesAndRecoversWithoutLosingPackets() throws Exception {
+        runTransportScenario(false);
+    }
+
+    @Test
+    void webSocketConnectionPausesAndRecoversWithoutLosingPackets() throws Exception {
+        runTransportScenario(true);
+    }
+
+    private static void runTransportScenario(boolean webSocket) throws Exception {
+        EventLoopGroup boss = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        EventLoopGroup workers = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        EventLoopGroup clients = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        DefaultEventExecutorGroup packetWorkers = new DefaultEventExecutorGroup(1);
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        ExecutionBackpressureMetrics metrics = new ExecutionBackpressureMetrics(webSocket ? "websocket" : "tcp");
+        CountDownLatch accepted = new CountDownLatch(1);
+        CountDownLatch handshake = new CountDownLatch(webSocket ? 1 : 0);
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        AtomicReference<Channel> serverConnection = new AtomicReference<>();
+        List<Integer> handled = new CopyOnWriteArrayList<>();
+        Channel listener = null;
+        Channel client = null;
+        try {
+            ServerBootstrap server = new ServerBootstrap()
+                    .group(boss, workers)
+                    .channel(NioServerSocketChannel.class)
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel channel) {
+                            serverConnection.set(channel);
+                            accepted.countDown();
+                            if (webSocket) {
+                                channel.pipeline().addLast(new HttpServerCodec());
+                                channel.pipeline().addLast(new HttpObjectAggregator(16_384));
+                                channel.pipeline().addLast(new WebSocketServerProtocolHandler("/"));
+                                channel.pipeline().addLast(new WebSocketCodec());
+                            }
+                            channel.pipeline().addLast(new GameByteFrameDecoder());
+                            channel.pipeline().addLast(new GameByteDecoder());
+                            channel.pipeline()
+                                    .addLast(
+                                            "admission",
+                                            ExecutionAdmissionHandler.forGamePackets(
+                                                    "target", controller, metrics, 1, 0, 2, 2_000));
+                            channel.pipeline()
+                                    .addLast(
+                                            packetWorkers,
+                                            "target",
+                                            new BlockingPacketHandler(firstStarted, releaseFirst, handled));
+                        }
+                    });
+            listener = server.bind("127.0.0.1", 0).sync().channel();
+            int port = ((InetSocketAddress) listener.localAddress()).getPort();
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(clients)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel channel) {
+                            if (!webSocket) {
+                                return;
+                            }
+                            channel.pipeline().addLast(new HttpClientCodec());
+                            channel.pipeline().addLast(new HttpObjectAggregator(16_384));
+                            WebSocketClientProtocolConfig config = WebSocketClientProtocolConfig.newBuilder()
+                                    .webSocketUri(URI.create("ws://127.0.0.1:" + port + "/"))
+                                    .build();
+                            channel.pipeline().addLast(new WebSocketClientProtocolHandler(config));
+                            channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                                @Override
+                                public void userEventTriggered(ChannelHandlerContext ctx, Object event)
+                                        throws Exception {
+                                    if (event
+                                            == WebSocketClientProtocolHandler.ClientHandshakeStateEvent
+                                                    .HANDSHAKE_COMPLETE) {
+                                        handshake.countDown();
+                                    }
+                                    ctx.fireUserEventTriggered(event);
+                                }
+                            });
+                        }
+                    });
+            client = clientBootstrap.connect("127.0.0.1", port).sync().channel();
+            assertTrue(accepted.await(2, TimeUnit.SECONDS));
+            assertTrue(handshake.await(2, TimeUnit.SECONDS));
+
+            writePacket(client, webSocket, 1);
+            assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
+            writePacket(client, webSocket, 2);
+
+            Channel acceptedChannel = serverConnection.get();
+            await(() -> !acceptedChannel.config().isAutoRead());
+            assertTrue(acceptedChannel.isActive());
+            assertFalse(acceptedChannel.config().isAutoRead());
+
+            releaseFirst.countDown();
+            await(() -> handled.size() == 2 && acceptedChannel.config().isAutoRead());
+
+            assertEquals(List.of(1, 2), handled);
+            assertTrue(acceptedChannel.isActive());
+            assertEquals(1, metrics.snapshot().resumes());
+        } finally {
+            releaseFirst.countDown();
+            if (client != null) {
+                client.close().syncUninterruptibly();
+            }
+            if (listener != null) {
+                listener.close().syncUninterruptibly();
+            }
+            packetWorkers.shutdownGracefully().syncUninterruptibly();
+            clients.shutdownGracefully().syncUninterruptibly();
+            workers.shutdownGracefully().syncUninterruptibly();
+            boss.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    private static void writePacket(Channel channel, boolean webSocket, int messageId) {
+        ByteBuf payload = channel.alloc().buffer(6).writeInt(2).writeShort(messageId);
+        if (webSocket) {
+            channel.writeAndFlush(new BinaryWebSocketFrame(payload)).syncUninterruptibly();
+        } else {
+            channel.writeAndFlush(payload).syncUninterruptibly();
+        }
+    }
+
+    private static void await(Condition condition) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+        while (!condition.satisfied() && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        assertTrue(condition.satisfied(), "condition was not satisfied before the deadline");
+    }
+
+    private interface Condition {
+        boolean satisfied();
+    }
+
+    private static final class BlockingPacketHandler extends ChannelInboundHandlerAdapter {
+        private final CountDownLatch firstStarted;
+        private final CountDownLatch releaseFirst;
+        private final List<Integer> handled;
+
+        private BlockingPacketHandler(CountDownLatch firstStarted, CountDownLatch releaseFirst, List<Integer> handled) {
+            this.firstStarted = firstStarted;
+            this.releaseFirst = releaseFirst;
+            this.handled = handled;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            ClientMessage message = (ClientMessage) msg;
+            try {
+                if (this.handled.isEmpty()) {
+                    this.firstStarted.countDown();
+                    this.releaseFirst.await(2, TimeUnit.SECONDS);
+                }
+                this.handled.add(message.getMessageId());
+            } finally {
+                message.release();
+            }
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/ExecutionBackpressureSettingsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/ExecutionBackpressureSettingsTest.java
@@ -1,0 +1,60 @@
+package com.eu.habbo.networking.gameserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.eu.habbo.core.ConfigurationManager;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ExecutionBackpressureSettingsTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void defaultsToObservationWithTheApprovedTwoSecondDeadline() throws Exception {
+        ConfigurationManager configuration = configuration("");
+
+        ExecutionBackpressureSettings settings = ExecutionBackpressureSettings.from(configuration);
+
+        assertEquals(ExecutionCapacityController.Mode.OBSERVE, settings.mode());
+        assertEquals(256, settings.packetCapacity());
+        assertEquals(192, settings.packetLowWatermark());
+        assertEquals(32, settings.perConnectionCapacity());
+        assertEquals(16, settings.perConnectionLowWatermark());
+        assertEquals(16, settings.perConnectionPendingCapacity());
+        assertEquals(2_000L, settings.pauseTimeoutMillis());
+        assertEquals(128, settings.httpCapacity());
+    }
+
+    @Test
+    void readsEnforcementGeometryAndClampsInvalidLowWatermarks() throws Exception {
+        ConfigurationManager configuration = configuration("execution.backpressure.mode=enforce\n"
+                + "io.packet.handler.queue.capacity=40\n"
+                + "io.packet.handler.queue.low_watermark=80\n"
+                + "io.packet.handler.per_connection.capacity=8\n"
+                + "io.packet.handler.per_connection.low_watermark=9\n"
+                + "io.packet.handler.per_connection.pending=6\n"
+                + "execution.backpressure.pause.timeout_ms=1500\n"
+                + "http.blocking.queue.capacity=20\n");
+
+        ExecutionBackpressureSettings settings = ExecutionBackpressureSettings.from(configuration);
+
+        assertEquals(ExecutionCapacityController.Mode.ENFORCE, settings.mode());
+        assertEquals(40, settings.packetCapacity());
+        assertEquals(30, settings.packetLowWatermark());
+        assertEquals(8, settings.perConnectionCapacity());
+        assertEquals(4, settings.perConnectionLowWatermark());
+        assertEquals(6, settings.perConnectionPendingCapacity());
+        assertEquals(1_500L, settings.pauseTimeoutMillis());
+        assertEquals(20, settings.httpCapacity());
+    }
+
+    private ConfigurationManager configuration(String contents) throws Exception {
+        Path file = this.temporaryDirectory.resolve("config.ini");
+        Files.writeString(file, contents);
+        return new ConfigurationManager(file.toString());
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/ExecutionCapacityControllerTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/ExecutionCapacityControllerTest.java
@@ -1,0 +1,86 @@
+package com.eu.habbo.networking.gameserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ExecutionCapacityControllerTest {
+
+    @Test
+    void observeModeMeasuresPressureWithoutRejectingWork() {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(2, 1, ExecutionCapacityController.Mode.OBSERVE);
+
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire());
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire());
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire());
+
+        ExecutionCapacityController.Snapshot snapshot = controller.snapshot();
+        assertEquals(3, snapshot.inFlight());
+        assertEquals(3, snapshot.highWatermark());
+        assertEquals(1, snapshot.wouldThrottle());
+        assertEquals(0, snapshot.rejections());
+    }
+
+    @Test
+    void enforceModeBoundsOccupancyAndWakesWaitersInFifoOrderAtLowWatermark() {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(3, 1, ExecutionCapacityController.Mode.ENFORCE);
+        List<String> awakened = new ArrayList<>();
+
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire());
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire());
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire());
+        assertEquals(ExecutionCapacityController.Admission.SATURATED, controller.tryAcquire());
+        controller.registerWaiter("first", () -> awakened.add("first"));
+        controller.registerWaiter("second", () -> awakened.add("second"));
+
+        controller.release();
+        assertEquals(List.of(), awakened);
+        controller.release();
+        assertEquals(List.of("first"), awakened);
+        controller.release();
+        assertEquals(List.of("first", "second"), awakened);
+
+        ExecutionCapacityController.Snapshot snapshot = controller.snapshot();
+        assertEquals(0, snapshot.inFlight());
+        assertEquals(3, snapshot.highWatermark());
+        assertEquals(1, snapshot.rejections());
+    }
+
+    @Test
+    void waiterRegistrationIsIdempotentAndReleaseCannotUnderflow() {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        List<String> awakened = new ArrayList<>();
+
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire());
+        controller.registerWaiter("same-channel", () -> awakened.add("first"));
+        controller.registerWaiter("same-channel", () -> awakened.add("duplicate"));
+
+        controller.release();
+
+        assertEquals(List.of("first"), awakened);
+        assertThrows(IllegalStateException.class, controller::release);
+    }
+
+    @Test
+    void releasedCapacityIsReservedForTheOldestWaitingConnection() {
+        ExecutionCapacityController controller =
+                new ExecutionCapacityController(1, 0, ExecutionCapacityController.Mode.ENFORCE);
+        List<String> awakened = new ArrayList<>();
+
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire("active"));
+        controller.registerWaiter("oldest", () -> awakened.add("oldest"));
+        controller.registerWaiter("newest", () -> awakened.add("newest"));
+
+        controller.release();
+
+        assertEquals(List.of("oldest"), awakened);
+        assertEquals(ExecutionCapacityController.Admission.SATURATED, controller.tryAcquire("active"));
+        assertEquals(ExecutionCapacityController.Admission.ADMITTED, controller.tryAcquire("oldest"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/networking/gameserver/WebSocketHttpOffloadTest.java
@@ -52,6 +52,15 @@ class WebSocketHttpOffloadTest {
             EventExecutor blockingExecutor =
                     awaitPresent(channel, "nitroSecureAssetHandler").executor();
 
+            assertSame(
+                    socketExecutor,
+                    awaitPresent(channel, "blockingHttpAdmissionAssets").executor());
+            assertSame(
+                    socketExecutor,
+                    awaitPresent(channel, "blockingHttpAdmissionCms").executor());
+            assertSame(
+                    socketExecutor,
+                    awaitPresent(channel, "packetExecutionAdmission").executor());
             assertNotSame(socketExecutor, blockingExecutor);
             assertSame(
                     blockingExecutor, awaitPresent(channel, "badgeHttpHandler").executor());
@@ -101,8 +110,14 @@ class WebSocketHttpOffloadTest {
             // Handlers bound to the blocking HTTP executor are unlinked on that
             // executor, so wait for the removals to settle.
             awaitRemoved(channel, "nitroSecureAssetHandler");
+            awaitRemoved(channel, "blockingHttpAdmissionAssets");
+            awaitRemoved(channel, "blockingHttpAdmissionCms");
+            awaitRemoved(channel, "blockingHttpAdmissionBadge");
+            awaitRemoved(channel, "blockingHttpAdmissionBadgeLeaderboard");
+            awaitRemoved(channel, "blockingHttpAdmissionStats");
             awaitRemoved(channel, "nitroSecureApiHandler");
             awaitRemoved(channel, "authHttpHandler");
+            awaitRemoved(channel, "cmsApiHandler");
             awaitRemoved(channel, "badgeHttpHandler");
             awaitRemoved(channel, "badgeLeaderboardHttpHandler");
             awaitRemoved(channel, "emuStatsHttpHandler");

--- a/config example/config.ini.example
+++ b/config example/config.ini.example
@@ -94,8 +94,16 @@ login.news.limit=5
 
 #Performance / concurrency (optional — sensible defaults apply if unset; adjust in the Database).
 ## io.packet.handler.threads=24 #Game packet-handler pool size; runs game handlers OFF the Netty I/O loop. Default max(16, 2 x CPU cores).
+## execution.backpressure.mode=observe #Use observe to measure pressure without limiting traffic; switch to enforce after validation.
+## execution.backpressure.pause.timeout_ms=2000 #Maximum packet-lane pause before disconnecting a persistently congested connection.
+## io.packet.handler.queue.capacity=256 #Global packet executions allowed in flight while enforcement is active.
+## io.packet.handler.queue.low_watermark=192 #Resume waiting connections after global occupancy drains to this value.
+## io.packet.handler.per_connection.capacity=32 #Maximum concurrent packet executions owned by one connection.
+## io.packet.handler.per_connection.low_watermark=16 #Per-connection occupancy required before reads resume.
+## io.packet.handler.per_connection.pending=16 #Already-decoded packets retained per paused connection.
 ## auth.http.pool.size=16 #Dedicated worker pool for the /api/auth/* HTTP endpoints (BCrypt/JDBC/Turnstile/SMTP run off the event loop). Default 16.
 ## http.blocking.pool.size=8 #Dedicated workers for blocking badge, asset, leaderboard, and emulator-stats endpoints. Default 8.
+## http.blocking.queue.capacity=128 #Global blocking HTTP executions allowed in flight while enforcement is active.
 ## io.netty.allocator.pooled=false #Set true to opt into Netty's pooled ByteBuf allocator. Default false (unpooled-heap).
 ## io.netty.write_buffer.low_water_mark=32768 #Mark a channel writable again after queued outbound bytes drain below this value.
 ## io.netty.write_buffer.high_water_mark=65536 #Mark a channel unwritable after queued outbound bytes exceed this value.

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -39,13 +39,22 @@ Unknown keys remain allowed for plugins. Database-backed hotel settings are docu
 | `enc.e` | string | `` | — | yes | no | Legacy transport encryption setting. |
 | `enc.enabled` | boolean | `false` | — | yes | no | Legacy transport encryption setting. |
 | `enc.n` | string | `` | — | yes | no | Legacy transport encryption setting. |
+| `execution.backpressure.mode` | string | `observe` | — | yes | no | Inbound execution backpressure setting. |
+| `execution.backpressure.pause.timeout_ms` | integer | `2000` | — | yes | no | Inbound execution backpressure setting. |
 | `game.host` | string | `` | `EMU_HOST` | yes | no | Game listener setting. |
 | `game.port` | integer | `0` | `EMU_PORT` | yes | no | Game listener setting. |
 | `habbo.console.style` | string | `` | — | yes | no | Polaris startup setting. |
 | `http.blocking.pool.size` | integer | `8` | — | yes | no | Blocking HTTP worker setting. |
+| `http.blocking.queue.capacity` | integer | `128` | — | yes | no | Blocking HTTP worker setting. |
 | `io.netty.unwritable.timeout.seconds` | integer | `10` | — | yes | no | Netty channel flow-control setting. |
 | `io.netty.write_buffer.high_water_mark` | integer | `65536` | — | yes | no | Netty channel flow-control setting. |
 | `io.netty.write_buffer.low_water_mark` | integer | `32768` | — | yes | no | Netty channel flow-control setting. |
+| `io.packet.handler.per_connection.capacity` | integer | `32` | — | yes | no | Inbound execution backpressure setting. |
+| `io.packet.handler.per_connection.low_watermark` | integer | `16` | — | yes | no | Inbound execution backpressure setting. |
+| `io.packet.handler.per_connection.pending` | integer | `16` | — | yes | no | Inbound execution backpressure setting. |
+| `io.packet.handler.queue.capacity` | integer | `256` | — | yes | no | Inbound execution backpressure setting. |
+| `io.packet.handler.queue.low_watermark` | integer | `192` | — | yes | no | Inbound execution backpressure setting. |
+| `io.packet.handler.threads` | integer | `0` | — | yes | no | Inbound execution backpressure setting. |
 | `login.news.limit` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
 | `login.remember.duration.days` | integer | `0` | — | yes | no | Built-in login endpoint setting. |
 | `login.remember.enabled` | boolean | `false` | — | yes | no | Built-in login endpoint setting. |


### PR DESCRIPTION
## Summary

- add observe-by-default execution pressure telemetry without changing current connection behavior
- add opt-in enforce mode with bounded global capacity, per-connection fairness, FIFO reservations, pause/resume watermarks, and bounded pending queues
- return HTTP 503 with Retry-After when the blocking HTTP lane is saturated
- expose pressure, pause, resume, timeout, overflow, and rejection metrics and document every setting

## Safety

Enforcement is disabled by default. When enabled, saturated connections pause reads and resume below configured low watermarks. No packets are silently dropped; a connection is closed only after the configured pause timeout or pending-queue overflow.

## Validation

- mvn -f Emulator/pom.xml verify
- 1,482 unit/contract tests: 0 failures, 0 errors, 7 skipped
- 18 integration tests: 0 failures, 0 errors, 13 Docker-dependent tests skipped locally
- real TCP and WebSocket pause/recovery/order integration tests passed
- Spotless and SpotBugs passed

## Related work

Related: #580, #581.

This is the safer staged replacement for the behavior reverted by #582 after #579: observation first, explicit enforcement, fair admission, and automatic recovery.