### PR TITLE
Fix catalog sound preview references

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidator.java
@@ -186,7 +186,9 @@ public final class CatalogValidator {
             }
             validateItemIds(offer, issues);
             if (offer.catalogName().startsWith("SONG ")
-                    && (offer.songId() <= 0 || offer.extradata() == null || offer.extradata().isBlank())) {
+                    && (offer.songId() <= 0
+                            || offer.extradata() == null
+                            || offer.extradata().isBlank())) {
                 add(
                         issues,
                         "OFFER_SOUND_REFERENCE_MISSING",

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidator.java
@@ -185,6 +185,16 @@ public final class CatalogValidator {
                         "Offer page " + offer.pageId() + " does not exist");
             }
             validateItemIds(offer, issues);
+            if (offer.catalogName().startsWith("SONG ")
+                    && (offer.songId() <= 0 || offer.extradata() == null || offer.extradata().isBlank())) {
+                add(
+                        issues,
+                        "OFFER_SOUND_REFERENCE_MISSING",
+                        CatalogEntityType.OFFER,
+                        offer.offerId(),
+                        "songId",
+                        "Sound offers require both a song ID and soundtrack code");
+            }
             if (offer.costCredits() < 0 || offer.costPoints() < 0 || offer.amount() <= 0) {
                 add(
                         issues,

--- a/Emulator/src/main/resources/db/migration/V20260817180000__repair_catalog_sound_offer_references.sql
+++ b/Emulator/src/main/resources/db/migration/V20260817180000__repair_catalog_sound_offer_references.sql
@@ -1,0 +1,52 @@
+CREATE TEMPORARY TABLE `catalog_sound_offer_reference_repair` (
+    `catalog_name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL PRIMARY KEY,
+    `song_id` int unsigned NOT NULL,
+    `code` varchar(128) NOT NULL
+);
+
+INSERT INTO `catalog_sound_offer_reference_repair` (`catalog_name`, `song_id`, `code`) VALUES
+    ('SONG LostMyTapesAtGoa', 23, 'lost_my_tapes_at_goa'),
+    ('SONG EpicFlail', 21, 'epic_flail'),
+    ('SONG ElectricPixels', 25, 'electric_pixels'),
+    ('SONG Xmas11', 26, 'xmas_2011'),
+    ('SONG Xmas2011', 26, 'xmas_2011'),
+    ('SONG WhoDaresStacks', 27, 'who_dares_stacks'),
+    ('SONG GalacticDisco', 24, 'galactic_disco'),
+    ('SONG AlleyCatInTrouble', 22, 'alley_cat_in_trouble'),
+    ('SONG Trax_1', 15, 'party_trax'),
+    ('SONG double_peks', 14, 'double_peks'),
+    ('SONG Trax_2', 20, 'chilled_trax'),
+    ('SONG Weirdodo', 13, 'weirdodo'),
+    ('SONG Haadolocknloll', 12, 'haadolocknloll'),
+    ('SONG TeemuP1', 11, 'good_trade'),
+    ('SONG TeemuP2', 1, 'ballad_of_bonnie'),
+    ('SONG bossanova', 2, 'bossa_nova'),
+    ('SONG disco_extreme', 10, 'disco_extreme'),
+    ('SONG klubhaus', 9, 'klub_haus'),
+    ('SONG limbertake', 8, 'limber_take'),
+    ('SONG miamimiamor', 7, 'miami_miamor'),
+    ('SONG new_song', 6, 'gold_coin_digger'),
+    ('SONG park_adventure', 18, 'park_adventure'),
+    ('SONG ParkAdventure', 18, 'park_adventure'),
+    ('SONG pianissimo', 4, 'pianissimo'),
+    ('SONG RnB_Swat_Teem', 17, 'rnb_swat_teem');
+
+UPDATE `catalog_items` AS offer
+INNER JOIN `catalog_sound_offer_reference_repair` AS repair
+    ON repair.`catalog_name` = offer.`catalog_name`
+INNER JOIN `soundtracks` AS soundtrack
+    ON soundtrack.`id` = repair.`song_id`
+SET offer.`song_id` = IF(offer.`song_id` = 0, repair.`song_id`, offer.`song_id`),
+    offer.`extradata` = IF(TRIM(offer.`extradata`) = '', soundtrack.`code`, offer.`extradata`)
+WHERE offer.`song_id` = 0 OR TRIM(offer.`extradata`) = '';
+
+UPDATE `catalog_version_offers` AS offer
+INNER JOIN `catalog_sound_offer_reference_repair` AS repair
+    ON repair.`catalog_name` = offer.`catalog_name`
+INNER JOIN `soundtracks` AS soundtrack
+    ON soundtrack.`id` = repair.`song_id`
+SET offer.`song_id` = IF(offer.`song_id` = 0, repair.`song_id`, offer.`song_id`),
+    offer.`extradata` = IF(TRIM(offer.`extradata`) = '', soundtrack.`code`, offer.`extradata`)
+WHERE offer.`song_id` = 0 OR TRIM(offer.`extradata`) = '';
+
+DROP TEMPORARY TABLE `catalog_sound_offer_reference_repair`;

--- a/Emulator/src/test/java/com/eu/habbo/database/migration/CatalogSoundOfferReferencesMigrationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/migration/CatalogSoundOfferReferencesMigrationContractTest.java
@@ -1,0 +1,26 @@
+package com.eu.habbo.database.migration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class CatalogSoundOfferReferencesMigrationContractTest {
+    private static final Path MIGRATION = Path.of(
+            "src/main/resources/db/migration/V20260817180000__repair_catalog_sound_offer_references.sql");
+
+    @Test
+    void repairsLiveAndVersionedOffersWithoutReplacingValidReferences() throws IOException {
+        String sql = Files.readString(MIGRATION);
+
+        assertTrue(sql.contains("UPDATE `catalog_items`"));
+        assertTrue(sql.contains("UPDATE `catalog_version_offers`"));
+        assertTrue(sql.contains("offer.`song_id` = IF(offer.`song_id` = 0"));
+        assertTrue(sql.contains("offer.`extradata` = IF(TRIM(offer.`extradata`) = ''"));
+        assertTrue(sql.contains("'SONG LostMyTapesAtGoa', 23, 'lost_my_tapes_at_goa'"));
+        assertTrue(sql.contains("'SONG Trax_1', 15, 'party_trax'"));
+        assertTrue(sql.contains("'SONG Xmas11', 26, 'xmas_2011'"));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/database/migration/CatalogSoundOfferReferencesMigrationContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/database/migration/CatalogSoundOfferReferencesMigrationContractTest.java
@@ -8,8 +8,8 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 class CatalogSoundOfferReferencesMigrationContractTest {
-    private static final Path MIGRATION = Path.of(
-            "src/main/resources/db/migration/V20260817180000__repair_catalog_sound_offer_references.sql");
+    private static final Path MIGRATION =
+            Path.of("src/main/resources/db/migration/V20260817180000__repair_catalog_sound_offer_references.sql");
 
     @Test
     void repairsLiveAndVersionedOffersWithoutReplacingValidReferences() throws IOException {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidatorTest.java
@@ -180,20 +180,6 @@ class CatalogValidatorTest {
 
     private static CatalogOfferSnapshot soundOffer(int id, int pageId, int songId, String extradata) {
         return new CatalogOfferSnapshot(
-                id,
-                "100",
-                pageId,
-                "SONG LostMyTapesAtGoa",
-                0,
-                150,
-                5,
-                1,
-                0,
-                id,
-                id,
-                songId,
-                extradata,
-                true,
-                false);
+                id, "100", pageId, "SONG LostMyTapesAtGoa", 0, 150, 5, 1, 0, id, id, songId, extradata, true, false);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidatorTest.java
@@ -55,6 +55,20 @@ class CatalogValidatorTest {
     }
 
     @Test
+    void rejectsANewSoundOfferWithoutATrackReference() {
+        List<CatalogPageSnapshot> pages =
+                List.of(page(1, -1, 0, true, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+        CatalogVersionSnapshot baseline = snapshot(pages, List.of(soundOffer(10, 2, 23, "lost_my_tapes_at_goa")));
+        CatalogVersionSnapshot draft = snapshot(pages, List.of(soundOffer(10, 2, 0, "")));
+
+        CatalogValidationReport report =
+                validator(Set.of(100), Set.of(5), Map.of()).validateChanges(baseline, draft);
+
+        assertFalse(report.valid());
+        assertCodes(report, "OFFER_SOUND_REFERENCE_MISSING");
+    }
+
+    @Test
     void reportsStructuralReferenceAndCommercialErrorsTogether() {
         CatalogVersionSnapshot snapshot = snapshot(
                 List.of(
@@ -160,6 +174,25 @@ class CatalogValidatorTest {
                 id,
                 0,
                 "",
+                true,
+                false);
+    }
+
+    private static CatalogOfferSnapshot soundOffer(int id, int pageId, int songId, String extradata) {
+        return new CatalogOfferSnapshot(
+                id,
+                "100",
+                pageId,
+                "SONG LostMyTapesAtGoa",
+                0,
+                150,
+                5,
+                1,
+                0,
+                id,
+                id,
+                songId,
+                extradata,
                 true,
                 false);
     }


### PR DESCRIPTION
## Summary
- restore soundtrack IDs and codes for known catalog sound offers in both the live catalog and versioned Catalog Studio snapshots
- reject newly introduced sound offers that omit either the song ID or soundtrack code
- add regression coverage for the migration and draft validation behavior

## Root cause
The imported sound catalog offers had `song_id = 0` and an empty `extradata` value. The emulator consequently serialized no soundtrack code, so the client could not resolve a song ID and the preview control remained unavailable. Repairing only the live table would not be durable because the next Catalog Studio publication would project the same incomplete versioned data again.

## Impact
Known sound offers regain their correct preview and purchase references. Existing valid references are preserved, and future incomplete sound offers are blocked during draft validation instead of silently breaking playback.

## Validation
- `mvn -Dtest=CatalogValidatorTest,CatalogSoundOfferReferencesMigrationContractTest test`
- `mvn clean package` (1,553 tests, 0 failures, 0 errors, 7 skipped)
- migration executed against the local MariaDB catalog: 23/28 live offers and the corresponding published/draft offers repaired; the remaining five have no soundtrack rows and are intentionally left unmapped