### PR TITLE
Catalog Studio: reconcile live changes during publish

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogChangeSource.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogChangeSource.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.catalog.versioning;
 public enum CatalogChangeSource {
     UI,
     SQL,
+    LIVE_SYNC,
     RESTORE,
     UNDO
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveReconciler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveReconciler.java
@@ -1,0 +1,11 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface CatalogLiveReconciler {
+    CatalogLiveReconciliationResult reconcile(
+            Connection connection, CatalogVersionSnapshot active, CatalogVersionSnapshot draft, int actorId)
+            throws SQLException;
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveReconciliationResult.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveReconciliationResult.java
@@ -1,0 +1,13 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import java.util.List;
+import java.util.Objects;
+
+public record CatalogLiveReconciliationResult(
+        CatalogVersionSnapshot snapshot, int importedChanges, List<CatalogMergeConflict> conflicts) {
+    public CatalogLiveReconciliationResult {
+        snapshot = Objects.requireNonNull(snapshot, "snapshot");
+        if (importedChanges < 0) throw new IllegalArgumentException("importedChanges cannot be negative");
+        conflicts = List.copyOf(conflicts);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveReconciliationService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveReconciliationService.java
@@ -1,0 +1,69 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Objects;
+
+public final class CatalogLiveReconciliationService implements CatalogLiveReconciler {
+    private final CatalogLiveSnapshotRepository liveSnapshots;
+    private final CatalogSnapshotThreeWayMerge merger;
+    private final CatalogVersionRepository versions;
+    private final CatalogSnapshotWriter writer;
+    private final CatalogChangeJournal journal;
+
+    public CatalogLiveReconciliationService(
+            CatalogLiveSnapshotRepository liveSnapshots,
+            CatalogSnapshotThreeWayMerge merger,
+            CatalogVersionRepository versions,
+            CatalogSnapshotWriter writer,
+            CatalogChangeJournal journal) {
+        this.liveSnapshots = Objects.requireNonNull(liveSnapshots, "liveSnapshots");
+        this.merger = Objects.requireNonNull(merger, "merger");
+        this.versions = Objects.requireNonNull(versions, "versions");
+        this.writer = Objects.requireNonNull(writer, "writer");
+        this.journal = Objects.requireNonNull(journal, "journal");
+    }
+
+    @Override
+    public CatalogLiveReconciliationResult reconcile(
+            Connection connection, CatalogVersionSnapshot active, CatalogVersionSnapshot draft, int actorId)
+            throws SQLException {
+        CatalogVersionSnapshot live = liveSnapshots.load(connection, active.version());
+        CatalogSnapshotMergeResult merge = merger.merge(active, live, draft);
+        if (!merge.conflicts().isEmpty()) {
+            return new CatalogLiveReconciliationResult(draft, 0, merge.conflicts());
+        }
+        List<CatalogChangeEntry> imported = merge.importedChanges();
+        if (imported.isEmpty()) return new CatalogLiveReconciliationResult(draft, 0, List.of());
+
+        writer.replace(connection, draft.version().id(), merge.snapshot());
+        long revision = versions.incrementRevision(
+                connection, draft.version().id(), draft.version().revision());
+        CatalogVersionSnapshot reconciled = withRevision(merge.snapshot(), revision);
+        journal.append(
+                connection,
+                draft.version().id(),
+                revision,
+                actorId,
+                "Automatically imported live catalog changes",
+                CatalogChangeSource.LIVE_SYNC,
+                imported);
+        return new CatalogLiveReconciliationResult(reconciled, imported.size(), List.of());
+    }
+
+    private static CatalogVersionSnapshot withRevision(CatalogVersionSnapshot snapshot, long revision) {
+        CatalogVersion current = snapshot.version();
+        CatalogVersion updated = new CatalogVersion(
+                current.id(),
+                current.status(),
+                current.basedOnVersionId(),
+                revision,
+                current.label(),
+                current.createdBy(),
+                current.createdAt(),
+                current.publishedBy(),
+                current.publishedAt());
+        return new CatalogVersionSnapshot(updated, snapshot.pages(), snapshot.offers());
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSnapshotRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSnapshotRepository.java
@@ -1,0 +1,9 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@FunctionalInterface
+public interface CatalogLiveSnapshotRepository {
+    CatalogVersionSnapshot load(Connection connection, CatalogVersion version) throws SQLException;
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogMergeConflict.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogMergeConflict.java
@@ -1,0 +1,13 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import java.util.Objects;
+
+public record CatalogMergeConflict(
+        CatalogEntityType entityType, CatalogPageType catalogType, int entityId, String field) {
+    public CatalogMergeConflict {
+        entityType = Objects.requireNonNull(entityType, "entityType");
+        catalogType = Objects.requireNonNull(catalogType, "catalogType");
+        field = Objects.requireNonNull(field, "field");
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogPublicationResult.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogPublicationResult.java
@@ -1,11 +1,21 @@
 package com.eu.habbo.habbohotel.catalog.versioning;
 
+import java.util.List;
 import java.util.Objects;
 
 public record CatalogPublicationResult(
-        boolean published, CatalogValidationReport validation, long activeVersionId, long draftVersionId) {
+        boolean published,
+        boolean noChanges,
+        CatalogValidationReport validation,
+        long activeVersionId,
+        long draftVersionId,
+        long revision,
+        int importedChanges,
+        List<CatalogMergeConflict> conflicts) {
 
     public CatalogPublicationResult {
         validation = Objects.requireNonNull(validation, "validation");
+        if (importedChanges < 0) throw new IllegalArgumentException("importedChanges cannot be negative");
+        conflicts = List.copyOf(conflicts);
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogPublicationService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogPublicationService.java
@@ -9,6 +9,7 @@ public final class CatalogPublicationService {
     private final DataSource dataSource;
     private final CatalogVersionRepository versions;
     private final CatalogValidationDataRepository validationData;
+    private final CatalogLiveReconciler reconciler;
     private final CatalogLiveProjection projection;
     private final CatalogLockRepository locks;
     private final CatalogPublicationHooks hooks;
@@ -20,9 +21,29 @@ public final class CatalogPublicationService {
             CatalogLiveProjection projection,
             CatalogLockRepository locks,
             CatalogPublicationHooks hooks) {
+        this(
+                dataSource,
+                versions,
+                validationData,
+                (connection, active, draft, actorId) ->
+                        new CatalogLiveReconciliationResult(draft, 0, java.util.List.of()),
+                projection,
+                locks,
+                hooks);
+    }
+
+    public CatalogPublicationService(
+            DataSource dataSource,
+            CatalogVersionRepository versions,
+            CatalogValidationDataRepository validationData,
+            CatalogLiveReconciler reconciler,
+            CatalogLiveProjection projection,
+            CatalogLockRepository locks,
+            CatalogPublicationHooks hooks) {
         this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
         this.versions = Objects.requireNonNull(versions, "versions");
         this.validationData = Objects.requireNonNull(validationData, "validationData");
+        this.reconciler = Objects.requireNonNull(reconciler, "reconciler");
         this.projection = Objects.requireNonNull(projection, "projection");
         this.locks = Objects.requireNonNull(locks, "locks");
         this.hooks = Objects.requireNonNull(hooks, "hooks");
@@ -32,6 +53,7 @@ public final class CatalogPublicationService {
         Objects.requireNonNull(request, "request");
         CatalogVersionSnapshot publishedSnapshot;
         long nextDraftVersionId;
+        int importedChanges;
 
         try (Connection connection = dataSource.getConnection()) {
             connection.setAutoCommit(false);
@@ -50,12 +72,48 @@ public final class CatalogPublicationService {
                 }
 
                 CatalogVersionSnapshot active = versions.loadSnapshot(connection, runtime.activeVersionId());
+                CatalogLiveReconciliationResult reconciliation =
+                        reconciler.reconcile(connection, active, draft, request.actorId());
+                if (!reconciliation.conflicts().isEmpty()) {
+                    connection.rollback();
+                    return new CatalogPublicationResult(
+                            false,
+                            false,
+                            new CatalogValidationReport(java.util.List.of()),
+                            runtime.activeVersionId(),
+                            runtime.draftVersionId(),
+                            draft.version().revision(),
+                            0,
+                            reconciliation.conflicts());
+                }
+                draft = reconciliation.snapshot();
+                importedChanges = reconciliation.importedChanges();
                 CatalogValidationReport report =
                         validationData.load(connection).validator().validateChanges(active, draft);
                 if (!report.valid()) {
                     connection.rollback();
                     return new CatalogPublicationResult(
-                            false, report, runtime.activeVersionId(), runtime.draftVersionId());
+                            false,
+                            false,
+                            report,
+                            runtime.activeVersionId(),
+                            runtime.draftVersionId(),
+                            request.expectedRevision(),
+                            0,
+                            java.util.List.of());
+                }
+
+                if (sameCatalog(active, draft)) {
+                    connection.commit();
+                    return new CatalogPublicationResult(
+                            false,
+                            true,
+                            new CatalogValidationReport(java.util.List.of()),
+                            runtime.activeVersionId(),
+                            runtime.draftVersionId(),
+                            draft.version().revision(),
+                            0,
+                            java.util.List.of());
                 }
 
                 projection.replace(connection, draft);
@@ -85,9 +143,17 @@ public final class CatalogPublicationService {
         hooks.afterCommit(publishedSnapshot, nextDraftVersionId);
         return new CatalogPublicationResult(
                 true,
+                false,
                 new CatalogValidationReport(java.util.List.of()),
                 publishedSnapshot.version().id(),
-                nextDraftVersionId);
+                nextDraftVersionId,
+                publishedSnapshot.version().revision(),
+                importedChanges,
+                java.util.List.of());
+    }
+
+    private static boolean sameCatalog(CatalogVersionSnapshot left, CatalogVersionSnapshot right) {
+        return left.pages().equals(right.pages()) && left.offers().equals(right.offers());
     }
 
     private static void rollback(Connection connection, Exception original) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogSnapshotMergeResult.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogSnapshotMergeResult.java
@@ -1,0 +1,15 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import java.util.List;
+import java.util.Objects;
+
+public record CatalogSnapshotMergeResult(
+        CatalogVersionSnapshot snapshot,
+        List<CatalogMergeConflict> conflicts,
+        List<CatalogChangeEntry> importedChanges) {
+    public CatalogSnapshotMergeResult {
+        snapshot = Objects.requireNonNull(snapshot, "snapshot");
+        conflicts = List.copyOf(conflicts);
+        importedChanges = List.copyOf(importedChanges);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogSnapshotThreeWayMerge.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogSnapshotThreeWayMerge.java
@@ -1,0 +1,121 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class CatalogSnapshotThreeWayMerge {
+    private final Gson gson;
+
+    public CatalogSnapshotThreeWayMerge(Gson gson) {
+        this.gson = Objects.requireNonNull(gson, "gson");
+    }
+
+    public CatalogSnapshotMergeResult merge(
+            CatalogVersionSnapshot base, CatalogVersionSnapshot live, CatalogVersionSnapshot draft) {
+        List<CatalogMergeConflict> conflicts = new ArrayList<>();
+        List<CatalogPageSnapshot> pages = mergeEntities(
+                CatalogEntityType.PAGE,
+                indexPages(base.pages()),
+                indexPages(live.pages()),
+                indexPages(draft.pages()),
+                CatalogPageSnapshot.class,
+                conflicts);
+        List<CatalogOfferSnapshot> offers = mergeEntities(
+                CatalogEntityType.OFFER,
+                indexOffers(base.offers()),
+                indexOffers(live.offers()),
+                indexOffers(draft.offers()),
+                CatalogOfferSnapshot.class,
+                conflicts);
+        CatalogVersionSnapshot merged = new CatalogVersionSnapshot(draft.version(), pages, offers);
+        return new CatalogSnapshotMergeResult(merged, conflicts, CatalogChangeSetSupport.diff(draft, merged, gson));
+    }
+
+    private <T> List<T> mergeEntities(
+            CatalogEntityType entityType,
+            Map<EntityKey, T> base,
+            Map<EntityKey, T> live,
+            Map<EntityKey, T> draft,
+            Class<T> type,
+            List<CatalogMergeConflict> conflicts) {
+        Set<EntityKey> keys = new LinkedHashSet<>();
+        keys.addAll(base.keySet());
+        keys.addAll(live.keySet());
+        keys.addAll(draft.keySet());
+        List<T> merged = new ArrayList<>();
+        for (EntityKey key : keys) {
+            T baseValue = base.get(key);
+            T liveValue = live.get(key);
+            T draftValue = draft.get(key);
+            T value;
+            if (baseValue != null && liveValue != null && draftValue != null) {
+                value = mergeFields(entityType, key, baseValue, liveValue, draftValue, type, conflicts);
+            } else if (Objects.equals(liveValue, baseValue)) value = draftValue;
+            else if (Objects.equals(draftValue, baseValue)) value = liveValue;
+            else if (Objects.equals(liveValue, draftValue)) value = liveValue;
+            else {
+                conflicts.add(new CatalogMergeConflict(entityType, key.catalogType(), key.entityId(), "$entity"));
+                value = draftValue;
+            }
+            if (value != null) merged.add(value);
+        }
+        return List.copyOf(merged);
+    }
+
+    private <T> T mergeFields(
+            CatalogEntityType entityType,
+            EntityKey key,
+            T base,
+            T live,
+            T draft,
+            Class<T> type,
+            List<CatalogMergeConflict> conflicts) {
+        JsonObject baseJson = gson.toJsonTree(base).getAsJsonObject();
+        JsonObject liveJson = gson.toJsonTree(live).getAsJsonObject();
+        JsonObject draftJson = gson.toJsonTree(draft).getAsJsonObject();
+        JsonObject mergedJson = draftJson.deepCopy();
+        Set<String> fields = new LinkedHashSet<>();
+        fields.addAll(baseJson.keySet());
+        fields.addAll(liveJson.keySet());
+        fields.addAll(draftJson.keySet());
+        for (String field : fields) {
+            JsonElement baseValue = baseJson.get(field);
+            JsonElement liveValue = liveJson.get(field);
+            JsonElement draftValue = draftJson.get(field);
+            if (Objects.equals(liveValue, baseValue)) mergedJson.add(field, draftValue);
+            else if (Objects.equals(draftValue, baseValue) || Objects.equals(liveValue, draftValue)) {
+                mergedJson.add(field, liveValue);
+            } else {
+                conflicts.add(new CatalogMergeConflict(entityType, key.catalogType(), key.entityId(), field));
+            }
+        }
+        return gson.fromJson(mergedJson, type);
+    }
+
+    private static Map<EntityKey, CatalogPageSnapshot> indexPages(List<CatalogPageSnapshot> pages) {
+        Map<EntityKey, CatalogPageSnapshot> result = new LinkedHashMap<>();
+        for (CatalogPageSnapshot page : pages) {
+            result.put(new EntityKey(page.catalogType(), page.pageId()), page);
+        }
+        return result;
+    }
+
+    private static Map<EntityKey, CatalogOfferSnapshot> indexOffers(List<CatalogOfferSnapshot> offers) {
+        Map<EntityKey, CatalogOfferSnapshot> result = new LinkedHashMap<>();
+        for (CatalogOfferSnapshot offer : offers) {
+            result.put(new EntityKey(offer.catalogType(), offer.offerId()), offer);
+        }
+        return result;
+    }
+
+    private record EntityKey(CatalogPageType catalogType, int entityId) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveSnapshotRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveSnapshotRepository.java
@@ -1,0 +1,108 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class JdbcCatalogLiveSnapshotRepository implements CatalogLiveSnapshotRepository {
+    static final String LOAD_NORMAL_PAGES_SQL = "SELECT id AS page_id, parent_id, caption_save, caption, page_layout, "
+            + "icon_color, icon_image, min_rank, order_num, visible, enabled, club_only, catalog_mode, vip_only, "
+            + "page_headline, page_teaser, COALESCE(page_special, '') AS page_special, page_text1, page_text2, "
+            + "page_text_details, page_text_teaser, COALESCE(room_id, 0) AS room_id, includes "
+            + "FROM catalog_pages ORDER BY id FOR UPDATE";
+    static final String LOAD_NORMAL_OFFERS_SQL = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
+            + "cost_credits, cost_points, points_type, amount, limited_stack, order_number, offer_id AS offer_id_client, "
+            + "song_id, extradata, have_offer, club_only FROM catalog_items ORDER BY id FOR UPDATE";
+    static final String LOAD_BUILDER_PAGES_SQL = "SELECT id AS page_id, parent_id, '' AS caption_save, caption, "
+            + "page_layout, icon_color, icon_image, 1 AS min_rank, order_num, visible, enabled, 0 AS club_only, "
+            + "'BUILDER' AS catalog_mode, 0 AS vip_only, page_headline, page_teaser, "
+            + "COALESCE(page_special, '') AS page_special, page_text1, page_text2, page_text_details, "
+            + "page_text_teaser, 0 AS room_id, '' AS includes FROM catalog_pages_bc ORDER BY id FOR UPDATE";
+    static final String LOAD_BUILDER_OFFERS_SQL = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
+            + "0 AS cost_credits, 0 AS cost_points, 0 AS points_type, 1 AS amount, 0 AS limited_stack, order_number, "
+            + "-1 AS offer_id_client, 0 AS song_id, extradata, 1 AS have_offer, 0 AS club_only "
+            + "FROM catalog_items_bc ORDER BY id FOR UPDATE";
+
+    @Override
+    public CatalogVersionSnapshot load(Connection connection, CatalogVersion version) throws SQLException {
+        List<CatalogPageSnapshot> normalPages = loadPages(connection, LOAD_NORMAL_PAGES_SQL, CatalogPageType.NORMAL);
+        List<CatalogOfferSnapshot> normalOffers =
+                loadOffers(connection, LOAD_NORMAL_OFFERS_SQL, CatalogPageType.NORMAL);
+        List<CatalogPageSnapshot> builderPages = loadPages(connection, LOAD_BUILDER_PAGES_SQL, CatalogPageType.BUILDER);
+        List<CatalogOfferSnapshot> builderOffers =
+                loadOffers(connection, LOAD_BUILDER_OFFERS_SQL, CatalogPageType.BUILDER);
+        List<CatalogPageSnapshot> pages = new ArrayList<>(normalPages);
+        pages.addAll(builderPages);
+        List<CatalogOfferSnapshot> offers = new ArrayList<>(normalOffers);
+        offers.addAll(builderOffers);
+        return new CatalogVersionSnapshot(version, pages, offers);
+    }
+
+    private static List<CatalogPageSnapshot> loadPages(Connection connection, String sql, CatalogPageType catalogType)
+            throws SQLException {
+        List<CatalogPageSnapshot> pages = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(sql);
+                ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                pages.add(new CatalogPageSnapshot(
+                        catalogType,
+                        resultSet.getInt("page_id"),
+                        resultSet.getInt("parent_id"),
+                        resultSet.getString("caption_save"),
+                        resultSet.getString("caption"),
+                        resultSet.getString("page_layout"),
+                        resultSet.getInt("icon_color"),
+                        resultSet.getInt("icon_image"),
+                        resultSet.getInt("min_rank"),
+                        resultSet.getInt("order_num"),
+                        JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "visible"),
+                        JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "enabled"),
+                        JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "club_only"),
+                        resultSet.getString("catalog_mode"),
+                        JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "vip_only"),
+                        resultSet.getString("page_headline"),
+                        resultSet.getString("page_teaser"),
+                        resultSet.getString("page_special"),
+                        resultSet.getString("page_text1"),
+                        resultSet.getString("page_text2"),
+                        resultSet.getString("page_text_details"),
+                        resultSet.getString("page_text_teaser"),
+                        resultSet.getInt("room_id"),
+                        resultSet.getString("includes")));
+            }
+        }
+        return pages;
+    }
+
+    private static List<CatalogOfferSnapshot> loadOffers(Connection connection, String sql, CatalogPageType catalogType)
+            throws SQLException {
+        List<CatalogOfferSnapshot> offers = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(sql);
+                ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                offers.add(new CatalogOfferSnapshot(
+                        catalogType,
+                        resultSet.getInt("offer_id"),
+                        resultSet.getString("item_ids"),
+                        resultSet.getInt("page_id"),
+                        resultSet.getString("catalog_name"),
+                        resultSet.getInt("cost_credits"),
+                        resultSet.getInt("cost_points"),
+                        resultSet.getInt("points_type"),
+                        resultSet.getInt("amount"),
+                        resultSet.getInt("limited_stack"),
+                        resultSet.getInt("order_number"),
+                        resultSet.getInt("offer_id_client"),
+                        resultSet.getInt("song_id"),
+                        resultSet.getString("extradata"),
+                        JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "have_offer"),
+                        JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "club_only")));
+            }
+        }
+        return offers;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/studio/CatalogStudioPublishEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/studio/CatalogStudioPublishEvent.java
@@ -2,7 +2,9 @@ package com.eu.habbo.messages.incoming.catalog.catalogadmin.studio;
 
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogPublicationRequest;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogPublicationResult;
+import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioChangedEntity;
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioPublishComposer;
+import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioPublishConflict;
 import java.util.List;
 
 public final class CatalogStudioPublishEvent extends CatalogStudioEvent {
@@ -16,14 +18,39 @@ public final class CatalogStudioPublishEvent extends CatalogStudioEvent {
                         request.expectedRevision(),
                         actorId(),
                         "Shared draft after publication"));
+        boolean liveConflict = !result.conflicts().isEmpty();
+        List<CatalogStudioChangedEntity> changedEntities = result.conflicts().stream()
+                .map(conflict ->
+                        new CatalogStudioChangedEntity(conflict.entityType().name(), conflict.entityId()))
+                .distinct()
+                .toList();
+        List<CatalogStudioPublishConflict> conflicts = result.conflicts().stream()
+                .map(conflict -> new CatalogStudioPublishConflict(
+                        conflict.catalogType().name(),
+                        conflict.entityType().name(),
+                        conflict.entityId(),
+                        conflict.field()))
+                .toList();
+        boolean success = result.published() || result.noChanges();
+        String message = result.noChanges()
+                ? "Catalog is already up to date"
+                : result.published()
+                        ? result.importedChanges() == 0
+                                ? "Catalog published"
+                                : "Catalog published with " + result.importedChanges() + " external database change(s)"
+                        : liveConflict
+                                ? result.conflicts().size() + " external database conflict(s) block publication"
+                                : result.validation().issues().size() + " validation issues block publication";
         this.client.sendResponse(new CatalogStudioPublishComposer(
                 request.operationId(),
-                result.published(),
-                result.published() ? "PUBLISHED" : "VALIDATION_FAILED",
-                result.published()
-                        ? "Catalog published"
-                        : result.validation().issues().size() + " validation issues block publication",
-                result.published() ? 0 : request.expectedRevision(),
-                List.of()));
+                success,
+                result.noChanges()
+                        ? "NO_CHANGES"
+                        : result.published() ? "PUBLISHED" : liveConflict ? "LIVE_SYNC_CONFLICT" : "VALIDATION_FAILED",
+                message,
+                result.revision(),
+                changedEntities,
+                result.importedChanges(),
+                conflicts));
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/studio/CatalogStudioRuntime.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/studio/CatalogStudioRuntime.java
@@ -6,16 +6,19 @@ import com.eu.habbo.habbohotel.catalog.versioning.CatalogDraftChangeSetService;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogDraftLifecycleService;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogDraftPreviewService;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogDraftValidationService;
+import com.eu.habbo.habbohotel.catalog.versioning.CatalogLiveReconciliationService;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogLockService;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogOperationalOfferRepository;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogPreviewPresentation;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogPublicationHooks;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogPublicationService;
+import com.eu.habbo.habbohotel.catalog.versioning.CatalogSnapshotThreeWayMerge;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogStudioDocumentService;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogUndoService;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogVersionRepository;
 import com.eu.habbo.habbohotel.catalog.versioning.JdbcCatalogChangeJournal;
 import com.eu.habbo.habbohotel.catalog.versioning.JdbcCatalogLiveProjection;
+import com.eu.habbo.habbohotel.catalog.versioning.JdbcCatalogLiveSnapshotRepository;
 import com.eu.habbo.habbohotel.catalog.versioning.JdbcCatalogLockRepository;
 import com.eu.habbo.habbohotel.catalog.versioning.JdbcCatalogOperationRepository;
 import com.eu.habbo.habbohotel.catalog.versioning.JdbcCatalogSnapshotWriter;
@@ -69,6 +72,12 @@ public final class CatalogStudioRuntime {
         JdbcCatalogOperationRepository operationRepository = new JdbcCatalogOperationRepository();
         CatalogStudioDocumentService documents = new CatalogStudioDocumentService();
         CatalogOperationalOfferRepository operationalOffers = new CatalogOperationalOfferRepository(dataSource);
+        CatalogLiveReconciliationService liveReconciliation = new CatalogLiveReconciliationService(
+                new JdbcCatalogLiveSnapshotRepository(),
+                new CatalogSnapshotThreeWayMerge(gson),
+                versions,
+                snapshotWriter,
+                journal);
         return new Services(
                 queries,
                 new CatalogLockService(lockRepository),
@@ -83,6 +92,7 @@ public final class CatalogStudioRuntime {
                         dataSource,
                         versions,
                         validationData,
+                        liveReconciliation,
                         new JdbcCatalogLiveProjection(),
                         lockRepository,
                         publicationHooks),

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/catalogadmin/studio/CatalogStudioPublishComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/catalogadmin/studio/CatalogStudioPublishComposer.java
@@ -5,6 +5,9 @@ import com.eu.habbo.messages.outgoing.Outgoing;
 import java.util.List;
 
 public final class CatalogStudioPublishComposer extends AbstractCatalogStudioOperationComposer {
+    private final int importedChanges;
+    private final List<CatalogStudioPublishConflict> conflicts;
+
     public CatalogStudioPublishComposer(
             String operationId,
             boolean success,
@@ -12,12 +15,36 @@ public final class CatalogStudioPublishComposer extends AbstractCatalogStudioOpe
             String message,
             long revision,
             List<CatalogStudioChangedEntity> changedEntities) {
+        this(operationId, success, code, message, revision, changedEntities, 0, List.of());
+    }
+
+    public CatalogStudioPublishComposer(
+            String operationId,
+            boolean success,
+            String code,
+            String message,
+            long revision,
+            List<CatalogStudioChangedEntity> changedEntities,
+            int importedChanges,
+            List<CatalogStudioPublishConflict> conflicts) {
         super(operationId, success, code, message, revision, changedEntities);
+        if (importedChanges < 0) throw new IllegalArgumentException("importedChanges cannot be negative");
+        this.importedChanges = importedChanges;
+        this.conflicts = List.copyOf(conflicts);
     }
 
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.CatalogStudioPublishComposer);
-        return appendPayload();
+        appendPayload();
+        this.response.appendInt(importedChanges);
+        this.response.appendInt(conflicts.size());
+        for (CatalogStudioPublishConflict conflict : conflicts) {
+            this.response.appendString(conflict.catalogType());
+            this.response.appendString(conflict.entityType());
+            this.response.appendInt(conflict.entityId());
+            this.response.appendString(conflict.field());
+        }
+        return this.response;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/catalogadmin/studio/CatalogStudioPublishConflict.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/catalogadmin/studio/CatalogStudioPublishConflict.java
@@ -1,0 +1,11 @@
+package com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio;
+
+import java.util.Objects;
+
+public record CatalogStudioPublishConflict(String catalogType, String entityType, int entityId, String field) {
+    public CatalogStudioPublishConflict {
+        catalogType = Objects.requireNonNull(catalogType, "catalogType");
+        entityType = Objects.requireNonNull(entityType, "entityType");
+        field = Objects.requireNonNull(field, "field");
+    }
+}

--- a/Emulator/src/main/resources/db/migration/V20260821150000__catalog_live_sync_source.sql
+++ b/Emulator/src/main/resources/db/migration/V20260821150000__catalog_live_sync_source.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `catalog_change_groups`
+  MODIFY COLUMN `source` enum('UI','SQL','LIVE_SYNC','RESTORE','UNDO') NOT NULL;
+
+ALTER TABLE `catalog_operations`
+  MODIFY COLUMN `source` enum('UI','SQL','LIVE_SYNC','RESTORE','UNDO') NOT NULL;

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveReconciliationServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveReconciliationServiceTest.java
@@ -1,0 +1,156 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import java.sql.Connection;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CatalogLiveReconciliationServiceTest {
+    private final Connection connection = org.mockito.Mockito.mock(Connection.class);
+
+    @Test
+    void persistsLiveChangesInTheDraftAndJournalsTheNewRevision() throws Exception {
+        CatalogVersionSnapshot active = snapshot(1, CatalogVersionStatus.PUBLISHED, 10, 0);
+        CatalogVersionSnapshot draft = snapshot(2, CatalogVersionStatus.DRAFT, 10, 5);
+        CatalogVersionSnapshot live = snapshot(1, CatalogVersionStatus.PUBLISHED, 25, 0);
+        RecordingVersions versions = new RecordingVersions();
+        RecordingWriter writer = new RecordingWriter();
+        RecordingJournal journal = new RecordingJournal();
+        CatalogLiveReconciliationService service = new CatalogLiveReconciliationService(
+                (ignored, version) -> live, new CatalogSnapshotThreeWayMerge(new Gson()), versions, writer, journal);
+
+        CatalogLiveReconciliationResult result = service.reconcile(connection, active, draft, 7);
+
+        assertTrue(result.conflicts().isEmpty());
+        assertEquals(1, result.importedChanges());
+        assertEquals(6, result.snapshot().version().revision());
+        assertEquals(25, result.snapshot().offer(10).orElseThrow().costCredits());
+        assertEquals(2, writer.versionId);
+        assertEquals(25, writer.snapshot.offer(10).orElseThrow().costCredits());
+        assertEquals(5, versions.expectedRevision);
+        assertEquals(CatalogChangeSource.LIVE_SYNC, journal.source);
+        assertEquals(6, journal.revision);
+        assertEquals(1, journal.entries.size());
+    }
+
+    private static CatalogVersionSnapshot snapshot(
+            long versionId, CatalogVersionStatus status, int credits, long revision) {
+        CatalogVersion version = new CatalogVersion(
+                versionId,
+                status,
+                status == CatalogVersionStatus.DRAFT ? 1L : null,
+                revision,
+                status.name(),
+                7,
+                Instant.parse("2026-08-21T10:00:00Z"),
+                status == CatalogVersionStatus.PUBLISHED ? 7 : null,
+                status == CatalogVersionStatus.PUBLISHED ? Instant.parse("2026-08-21T10:00:00Z") : null);
+        CatalogPageSnapshot page = new CatalogPageSnapshot(
+                1, -1, "shop", "Shop", "root", 0, 0, 1, 0, true, true, false, "NORMAL", false, "", "", "", "", "", "",
+                "", 0, "");
+        CatalogOfferSnapshot offer =
+                new CatalogOfferSnapshot(10, "100", 1, "Chair", credits, 0, 0, 1, 0, 0, 10, 0, "", true, false);
+        return new CatalogVersionSnapshot(version, List.of(page), List.of(offer));
+    }
+
+    private static final class RecordingVersions implements CatalogVersionRepository {
+        private long expectedRevision = -1;
+
+        @Override
+        public CatalogRuntimeState lockRuntimeState(Connection connection) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CatalogVersionSnapshot loadSnapshot(Connection connection, long versionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long incrementRevision(Connection connection, long versionId, long expectedRevision) {
+            this.expectedRevision = expectedRevision;
+            return expectedRevision + 1;
+        }
+
+        @Override
+        public long cloneAsDraft(Connection connection, long sourceVersionId, int actorId, String label) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void archiveVersion(Connection connection, long versionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void markPublished(Connection connection, long versionId, int actorId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void updateRuntimePointers(Connection connection, long activeVersionId, long draftVersionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long nextPageId(Connection connection) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long nextOfferId(Connection connection) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class RecordingWriter implements CatalogSnapshotWriter {
+        private long versionId;
+        private CatalogVersionSnapshot snapshot;
+
+        @Override
+        public void apply(Connection connection, long versionId, CatalogChangeEntry change) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void replace(Connection connection, long versionId, CatalogVersionSnapshot source) {
+            this.versionId = versionId;
+            this.snapshot = source;
+        }
+    }
+
+    private static final class RecordingJournal implements CatalogChangeJournal {
+        private long revision;
+        private CatalogChangeSource source;
+        private List<CatalogChangeEntry> entries = List.of();
+
+        @Override
+        public CatalogChangeGroup load(Connection connection, long groupId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasLaterChangesToSameEntities(Connection connection, CatalogChangeGroup group) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long append(
+                Connection connection,
+                long versionId,
+                long revision,
+                int actorId,
+                String summary,
+                CatalogChangeSource source,
+                List<CatalogChangeEntry> entries) {
+            this.revision = revision;
+            this.source = source;
+            this.entries = List.copyOf(entries);
+            return 1;
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogPublicationServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogPublicationServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -35,6 +36,7 @@ class CatalogPublicationServiceTest {
     private final FakeVersionRepository versions = new FakeVersionRepository();
     private final FakeProjection projection = new FakeProjection();
     private final FakeLocks locks = new FakeLocks();
+    private final FakeReconciler reconciler = new FakeReconciler();
     private final CatalogPublicationHooks hooks = (published, nextDraftId) -> events.add("afterCommit:" + nextDraftId);
     private DataSource dataSource;
 
@@ -55,7 +57,8 @@ class CatalogPublicationServiceTest {
                 .when(connection)
                 .rollback();
         versions.snapshot = snapshot();
-        versions.activeSnapshot = snapshot();
+        versions.activeSnapshot = snapshotWithCredits("100", 2);
+        reconciler.result = null;
     }
 
     @Test
@@ -67,14 +70,14 @@ class CatalogPublicationServiceTest {
 
         assertFalse(result.published());
         assertFalse(result.validation().valid());
-        assertEquals(List.of("lockRuntime", "loadSnapshot:2", "loadSnapshot:1", "rollback"), events);
+        assertEquals(List.of("lockRuntime", "loadSnapshot:2", "loadSnapshot:1", "reconcile", "rollback"), events);
         assertEquals(0, projection.calls);
         verify(connection, never()).commit();
     }
 
     @Test
     void inheritedValidationIssuesDoNotBlockPublication() {
-        versions.activeSnapshot = snapshot("404");
+        versions.activeSnapshot = snapshotWithCredits("404", 2);
         versions.snapshot = snapshot("404");
         CatalogPublicationService service = service(referenceData(Set.of(100), Map.of(10, 1)));
 
@@ -92,7 +95,8 @@ class CatalogPublicationServiceTest {
 
         assertThrows(CatalogPublicationException.class, () -> service.publish(request()));
 
-        assertEquals(List.of("lockRuntime", "loadSnapshot:2", "loadSnapshot:1", "project", "rollback"), events);
+        assertEquals(
+                List.of("lockRuntime", "loadSnapshot:2", "loadSnapshot:1", "reconcile", "project", "rollback"), events);
         verify(connection, never()).commit();
         assertFalse(events.stream().anyMatch(event -> event.startsWith("afterCommit")));
     }
@@ -112,6 +116,7 @@ class CatalogPublicationServiceTest {
                         "lockRuntime",
                         "loadSnapshot:2",
                         "loadSnapshot:1",
+                        "reconcile",
                         "project",
                         "archive:1",
                         "publish:2",
@@ -123,9 +128,55 @@ class CatalogPublicationServiceTest {
                 events);
     }
 
+    @Test
+    void publicationProjectsTheAutomaticallyReconciledLiveChanges() {
+        CatalogVersionSnapshot reconciled = snapshotWithCredits(25);
+        reconciler.result = new CatalogLiveReconciliationResult(reconciled, 1, List.of());
+        CatalogPublicationService service = service(referenceData(Set.of(100), Map.of(10, 1)));
+
+        CatalogPublicationResult result = service.publish(request());
+
+        assertTrue(result.published());
+        assertEquals(1, result.importedChanges());
+        assertEquals(25, projection.snapshot.offer(10).orElseThrow().costCredits());
+    }
+
+    @Test
+    void publicationDoesNotCreateARedundantVersionWhenLiveAndDraftAreUnchanged() throws Exception {
+        versions.activeSnapshot = snapshot();
+        CatalogPublicationService service = service(referenceData(Set.of(100), Map.of(10, 1)));
+
+        CatalogPublicationResult result = service.publish(request());
+
+        assertFalse(result.published());
+        assertTrue(result.noChanges());
+        assertEquals(ACTIVE_ID, result.activeVersionId());
+        assertEquals(DRAFT_ID, result.draftVersionId());
+        assertEquals(List.of("lockRuntime", "loadSnapshot:2", "loadSnapshot:1", "reconcile", "commit"), events);
+        assertEquals(0, projection.calls);
+        assertFalse(events.stream().anyMatch(event -> event.startsWith("afterCommit")));
+    }
+
+    @Test
+    void liveConflictRollsBackWithoutProjectingOrSwitchingVersions() throws Exception {
+        CatalogMergeConflict conflict =
+                new CatalogMergeConflict(CatalogEntityType.OFFER, CatalogPageType.NORMAL, 10, "costCredits");
+        reconciler.result = new CatalogLiveReconciliationResult(versions.snapshot, 0, List.of(conflict));
+        CatalogPublicationService service = service(referenceData(Set.of(100), Map.of(10, 1)));
+
+        CatalogPublicationResult result = service.publish(request());
+
+        assertFalse(result.published());
+        assertFalse(result.noChanges());
+        assertEquals(List.of(conflict), result.conflicts());
+        assertEquals(List.of("lockRuntime", "loadSnapshot:2", "loadSnapshot:1", "reconcile", "rollback"), events);
+        assertEquals(0, projection.calls);
+        verify(connection, never()).commit();
+    }
+
     private CatalogPublicationService service(CatalogValidationReferenceData referenceData) {
         return new CatalogPublicationService(
-                dataSource, versions, connection -> referenceData, projection, locks, hooks);
+                dataSource, versions, connection -> referenceData, reconciler, projection, locks, hooks);
     }
 
     private static CatalogPublicationRequest request() {
@@ -158,6 +209,33 @@ class CatalogPublicationServiceTest {
                 null,
                 null);
         return new CatalogVersionSnapshot(version, List.of(root), List.of(offer));
+    }
+
+    private static CatalogVersionSnapshot snapshotWithCredits(int credits) {
+        return snapshotWithCredits("100", credits);
+    }
+
+    private static CatalogVersionSnapshot snapshotWithCredits(String itemIds, int credits) {
+        CatalogVersionSnapshot original = snapshot(itemIds);
+        CatalogOfferSnapshot offer = original.offer(10).orElseThrow();
+        CatalogOfferSnapshot changed = new CatalogOfferSnapshot(
+                offer.catalogType(),
+                offer.offerId(),
+                offer.itemIds(),
+                offer.pageId(),
+                offer.catalogName(),
+                credits,
+                offer.costPoints(),
+                offer.pointsType(),
+                offer.amount(),
+                offer.limitedStack(),
+                offer.orderNumber(),
+                offer.offerIdClient(),
+                offer.songId(),
+                offer.extradata(),
+                offer.haveOffer(),
+                offer.clubOnly());
+        return new CatalogVersionSnapshot(original.version(), original.pages(), List.of(changed));
     }
 
     private final class FakeVersionRepository implements CatalogVersionRepository {
@@ -216,12 +294,25 @@ class CatalogPublicationServiceTest {
     private final class FakeProjection implements CatalogLiveProjection {
         private int calls;
         private SQLException failure;
+        private CatalogVersionSnapshot snapshot;
 
         @Override
         public void replace(Connection ignored, CatalogVersionSnapshot snapshot) throws SQLException {
             calls++;
+            this.snapshot = snapshot;
             events.add("project");
             if (failure != null) throw failure;
+        }
+    }
+
+    private final class FakeReconciler implements CatalogLiveReconciler {
+        private CatalogLiveReconciliationResult result;
+
+        @Override
+        public CatalogLiveReconciliationResult reconcile(
+                Connection ignored, CatalogVersionSnapshot active, CatalogVersionSnapshot draft, int actorId) {
+            events.add("reconcile");
+            return result == null ? new CatalogLiveReconciliationResult(draft, 0, List.of()) : result;
         }
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogSnapshotThreeWayMergeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogSnapshotThreeWayMergeTest.java
@@ -1,0 +1,98 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import com.google.gson.Gson;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CatalogSnapshotThreeWayMergeTest {
+    private final CatalogSnapshotThreeWayMerge merger = new CatalogSnapshotThreeWayMerge(new Gson());
+
+    @Test
+    void mergesIndependentLiveAndDraftChanges() {
+        CatalogVersionSnapshot base = snapshot(page("Shop"), offer(10));
+        CatalogVersionSnapshot live = snapshot(page("Shop"), offer(25));
+        CatalogVersionSnapshot draft = snapshot(page("Edited in Studio"), offer(10));
+
+        CatalogSnapshotMergeResult result = merger.merge(base, live, draft);
+
+        assertTrue(result.conflicts().isEmpty());
+        assertEquals(
+                "Edited in Studio",
+                result.snapshot().page(CatalogPageType.NORMAL, 1).orElseThrow().caption());
+        assertEquals(
+                25,
+                result.snapshot()
+                        .offer(CatalogPageType.NORMAL, 10)
+                        .orElseThrow()
+                        .costCredits());
+        assertEquals(1, result.importedChanges().size());
+        assertEquals(
+                CatalogEntityType.OFFER, result.importedChanges().getFirst().entityType());
+        assertEquals(
+                CatalogChangeOperation.UPDATE,
+                result.importedChanges().getFirst().operation());
+    }
+
+    @Test
+    void mergesDifferentFieldsChangedOnTheSameOffer() {
+        CatalogVersionSnapshot base = snapshot(page("Shop"), offer("Chair", 10));
+        CatalogVersionSnapshot live = snapshot(page("Shop"), offer("Chair", 25));
+        CatalogVersionSnapshot draft = snapshot(page("Shop"), offer("Studio Chair", 10));
+
+        CatalogSnapshotMergeResult result = merger.merge(base, live, draft);
+
+        assertTrue(result.conflicts().isEmpty());
+        CatalogOfferSnapshot merged =
+                result.snapshot().offer(CatalogPageType.NORMAL, 10).orElseThrow();
+        assertEquals("Studio Chair", merged.catalogName());
+        assertEquals(25, merged.costCredits());
+    }
+
+    @Test
+    void reportsTheFieldWhenLiveAndDraftChangedItDifferently() {
+        CatalogVersionSnapshot base = snapshot(page("Shop"), offer(10));
+        CatalogVersionSnapshot live = snapshot(page("Shop"), offer(25));
+        CatalogVersionSnapshot draft = snapshot(page("Shop"), offer(40));
+
+        CatalogSnapshotMergeResult result = merger.merge(base, live, draft);
+
+        assertEquals(1, result.conflicts().size());
+        CatalogMergeConflict conflict = result.conflicts().getFirst();
+        assertEquals(CatalogEntityType.OFFER, conflict.entityType());
+        assertEquals(10, conflict.entityId());
+        assertEquals("costCredits", conflict.field());
+    }
+
+    private static CatalogVersionSnapshot snapshot(CatalogPageSnapshot page, CatalogOfferSnapshot offer) {
+        CatalogVersion version = new CatalogVersion(
+                2,
+                CatalogVersionStatus.DRAFT,
+                1L,
+                5,
+                "Shared draft",
+                7,
+                Instant.parse("2026-08-21T10:00:00Z"),
+                null,
+                null);
+        return new CatalogVersionSnapshot(version, List.of(page), List.of(offer));
+    }
+
+    private static CatalogPageSnapshot page(String caption) {
+        return new CatalogPageSnapshot(
+                1, -1, "shop", caption, "root", 0, 0, 1, 0, true, true, false, "NORMAL", false, "", "", "", "", "", "",
+                "", 0, "");
+    }
+
+    private static CatalogOfferSnapshot offer(int credits) {
+        return offer("Chair", credits);
+    }
+
+    private static CatalogOfferSnapshot offer(String catalogName, int credits) {
+        return new CatalogOfferSnapshot(10, "100", 1, catalogName, credits, 0, 0, 1, 0, 0, 10, 0, "", true, false);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogStudioPublicationIT.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogStudioPublicationIT.java
@@ -22,6 +22,60 @@ class CatalogStudioPublicationIT {
     private static final int ACTOR_ID = 7;
 
     @Test
+    void publicationAutomaticallyVersionsExternalLiveCatalogChanges() throws Exception {
+        requireDocker();
+        try (HikariDataSource dataSource = TestDatabase.freshDatabase("catalog_studio_live_reconciliation")) {
+            MigrationRunner.migrate(dataSource);
+            Gson gson = new Gson();
+            JdbcCatalogVersionRepository versions = new JdbcCatalogVersionRepository();
+            JdbcCatalogLockRepository locks = new JdbcCatalogLockRepository(dataSource);
+            JdbcCatalogChangeJournal journal = new JdbcCatalogChangeJournal();
+            JdbcCatalogSnapshotWriter writer = new JdbcCatalogSnapshotWriter(gson);
+            CatalogRuntimeState initial = runtimeState(dataSource, versions);
+            CatalogVersionSnapshot draft = snapshot(dataSource, versions, initial.draftVersionId());
+            CatalogOfferSnapshot offer = draft.offers().stream()
+                    .filter(candidate -> candidate.catalogType() == CatalogPageType.NORMAL)
+                    .findFirst()
+                    .orElseThrow();
+            int externalPrice = offer.costCredits() + 31;
+            updateOperationalPrice(dataSource, offer.offerId(), externalPrice);
+
+            CatalogLiveReconciliationService reconciliation = new CatalogLiveReconciliationService(
+                    new JdbcCatalogLiveSnapshotRepository(),
+                    new CatalogSnapshotThreeWayMerge(gson),
+                    versions,
+                    writer,
+                    journal);
+            CatalogPublicationService publication = new CatalogPublicationService(
+                    dataSource,
+                    versions,
+                    new JdbcCatalogValidationDataRepository(),
+                    reconciliation,
+                    new JdbcCatalogLiveProjection(),
+                    locks,
+                    (published, nextDraftId) -> {});
+
+            CatalogPublicationResult result = publication.publish(new CatalogPublicationRequest(
+                    initial.draftVersionId(), draft.version().revision(), ACTOR_ID, "Draft after live sync"));
+
+            assertTrue(result.published());
+            assertEquals(1, result.importedChanges());
+            assertEquals(
+                    externalPrice,
+                    snapshot(dataSource, versions, result.activeVersionId())
+                            .offer(CatalogPageType.NORMAL, offer.offerId())
+                            .orElseThrow()
+                            .costCredits());
+            assertEquals(
+                    externalPrice,
+                    snapshot(dataSource, versions, result.draftVersionId())
+                            .offer(CatalogPageType.NORMAL, offer.offerId())
+                            .orElseThrow()
+                            .costCredits());
+        }
+    }
+
+    @Test
     void publicationReloadsOperationalOffersAndArchivedVersionsCanBeRestored() throws Exception {
         requireDocker();
         try (HikariDataSource dataSource = TestDatabase.freshDatabase("catalog_studio_publication")) {
@@ -150,6 +204,16 @@ class CatalogStudioPublicationIT {
                 if (!resultSet.next()) throw new AssertionError("Operational catalog offer is missing: " + offerId);
                 return resultSet.getInt("cost_credits");
             }
+        }
+    }
+
+    private static void updateOperationalPrice(HikariDataSource dataSource, int offerId, int credits) throws Exception {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement statement =
+                        connection.prepareStatement("UPDATE catalog_items SET cost_credits = ? WHERE id = ?")) {
+            statement.setInt(1, credits);
+            statement.setInt(2, offerId);
+            assertEquals(1, statement.executeUpdate());
         }
     }
 

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/catalogadmin/CatalogStudioPacketContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/catalogadmin/CatalogStudioPacketContractTest.java
@@ -23,6 +23,8 @@ import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioH
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioLockComposer;
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioOperationComposer;
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioPreviewComposer;
+import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioPublishComposer;
+import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioPublishConflict;
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioPublishedVersion;
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioSessionComposer;
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioValidationComposer;
@@ -192,6 +194,38 @@ class CatalogStudioPacketContractTest {
         assertEquals(44, payload.readInt());
         assertEquals("OFFER", readString(payload));
         assertEquals(77, payload.readInt());
+        assertFalse(payload.isReadable());
+    }
+
+    @Test
+    void publishPayloadIncludesAutomaticLiveImportsAndFieldConflicts() {
+        ByteBuf payload = new CatalogStudioPublishComposer(
+                        "op-publish",
+                        false,
+                        "LIVE_SYNC_CONFLICT",
+                        "External catalog changes conflict with the draft",
+                        8,
+                        List.of(new CatalogStudioChangedEntity("OFFER", 77)),
+                        2,
+                        List.of(new CatalogStudioPublishConflict("NORMAL", "OFFER", 77, "costCredits")))
+                .compose()
+                .get();
+
+        assertHeader(payload, Outgoing.CatalogStudioPublishComposer);
+        assertEquals("op-publish", readString(payload));
+        assertFalse(payload.readBoolean());
+        assertEquals("LIVE_SYNC_CONFLICT", readString(payload));
+        assertEquals("External catalog changes conflict with the draft", readString(payload));
+        assertEquals(8, payload.readInt());
+        assertEquals(1, payload.readInt());
+        assertEquals("OFFER", readString(payload));
+        assertEquals(77, payload.readInt());
+        assertEquals(2, payload.readInt());
+        assertEquals(1, payload.readInt());
+        assertEquals("NORMAL", readString(payload));
+        assertEquals("OFFER", readString(payload));
+        assertEquals(77, payload.readInt());
+        assertEquals("costCredits", readString(payload));
         assertFalse(payload.isReadable());
     }
 


### PR DESCRIPTION
Automatically reconciles direct catalog_pages, catalog_items, catalog_pages_bc, and catalog_items_bc changes when Catalog Studio publishes. Uses a field-level three-way merge against the active version, journals imported changes as LIVE_SYNC, blocks same-field conflicts, preserves operational limited_sells values, and avoids redundant versions when no changes exist. Companion PRs: renderer https://github.com/duckietm/Nitro_Render_V3/pull/179 and UI https://github.com/duckietm/Nitro-V3/pull/400. Compatibility: [x] Packet extension is backward-compatible for existing clients. [x] Database changes use a new Polaris migration and preserve supported upgrades. Manual testing: Publish with an external-only catalog price change; then verify a same-field live/draft conflict blocks publication. Verification: mvn test (1565 passed, 7 skipped); mvn spotless:check; focused reconciliation and packet tests (22 passed).