### PR TITLE
Accept extended avatar signs

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/users/RoomUserSignEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/users/RoomUserSignEvent.java
@@ -12,30 +12,33 @@ import com.eu.habbo.plugin.events.users.UserSignEvent;
 
 public class RoomUserSignEvent extends MessageHandler {
     private static final int MIN_SIGN_ID = 0;
-    private static final int MAX_SIGN_ID = 10;
+    private static final int MAX_SIGN_ID = 17;
+
+    static boolean isValidSignId(int signId) {
+        return signId >= MIN_SIGN_ID && signId <= MAX_SIGN_ID;
+    }
 
     @Override
     public void handle() throws Exception {
         int signId = this.packet.readInt();
 
-        if (signId < MIN_SIGN_ID || signId > MAX_SIGN_ID)
-            return;
+        if (!isValidSignId(signId)) return;
 
         Room room = this.client.getHabbo().getHabboInfo().getCurrentRoom();
 
-        if (room == null)
-            return;
+        if (room == null) return;
 
         UserSignEvent event = new UserSignEvent(this.client.getHabbo(), signId);
         if (!Emulator.getPluginManager().fireEvent(event).isCancelled()) {
             this.client.getHabbo().getRoomUnit().setStatus(RoomUnitStatus.SIGN, event.sign + "");
             this.client.getHabbo().getHabboInfo().getCurrentRoom().unIdle(this.client.getHabbo());
-            WiredManager.triggerUserPerformsAction(room, this.client.getHabbo().getRoomUnit(), WiredUserActionType.SIGN, event.sign);
+            WiredManager.triggerUserPerformsAction(
+                    room, this.client.getHabbo().getRoomUnit(), WiredUserActionType.SIGN, event.sign);
 
             int userId = this.client.getHabbo().getHabboInfo().getId();
             for (HabboItem item : room.getRoomSpecialTypes().getItemsOfType(InteractionVoteCounter.class)) {
                 if (item instanceof InteractionVoteCounter) {
-                    ((InteractionVoteCounter)item).vote(room, userId, signId);
+                    ((InteractionVoteCounter) item).vote(room, userId, signId);
                 }
             }
         }

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/users/RoomUserSignGuardContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/rooms/users/RoomUserSignGuardContractTest.java
@@ -1,16 +1,27 @@
 package com.eu.habbo.messages.incoming.rooms.users;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 class RoomUserSignGuardContractTest {
 
+    @Test
+    void supportsEverySignExposedByTheAvatarMenu() {
+        assertTrue(RoomUserSignEvent.isValidSignId(0));
+        assertTrue(RoomUserSignEvent.isValidSignId(10));
+        assertTrue(RoomUserSignEvent.isValidSignId(11));
+        assertTrue(RoomUserSignEvent.isValidSignId(17));
+        assertFalse(RoomUserSignEvent.isValidSignId(-1));
+        assertFalse(RoomUserSignEvent.isValidSignId(18));
+    }
+
     private static String source() throws Exception {
-        return Files.readString(Path.of("src/main/java/com/eu/habbo/messages/incoming/rooms/users/RoomUserSignEvent.java"));
+        return Files.readString(
+                Path.of("src/main/java/com/eu/habbo/messages/incoming/rooms/users/RoomUserSignEvent.java"));
     }
 
     @Test
@@ -18,7 +29,7 @@ class RoomUserSignGuardContractTest {
         String source = source();
 
         int signRead = source.indexOf("int signId = this.packet.readInt()");
-        int guard = source.indexOf("signId < MIN_SIGN_ID || signId > MAX_SIGN_ID", signRead);
+        int guard = source.indexOf("if (!isValidSignId(signId))", signRead);
         int status = source.indexOf("setStatus(RoomUnitStatus.SIGN", signRead);
         int wired = source.indexOf("WiredManager.triggerUserPerformsAction", signRead);
 
@@ -32,7 +43,7 @@ class RoomUserSignGuardContractTest {
     void voteCountersOnlyReceiveValidatedSigns() throws Exception {
         String source = source();
 
-        int guard = source.indexOf("signId < MIN_SIGN_ID || signId > MAX_SIGN_ID");
+        int guard = source.indexOf("if (!isValidSignId(signId))");
         int vote = source.indexOf(".vote(room, userId, signId)");
 
         assertTrue(guard > -1, "Sign id range guard must exist");


### PR DESCRIPTION
## Summary
- accept avatar sign IDs from 0 through 17, including the heart sign
- reject invalid IDs before room, plugin, wired, or vote state can be mutated
- add boundary regression coverage for accepted and rejected sign IDs

## Verification
- mvn test (1566 tests, 0 failures, 0 errors)
- mvn spotless:check
- mvn -Dmaven.test.skip=true package