### PR TITLE
fix(catalog): raise the index offer cap to 4000

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListComposer.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 public class CatalogPagesListComposer extends MessageComposer {
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogPagesListComposer.class);
 
-    private static final int MAX_OFFERS = 1000;
+    private static final int MAX_OFFERS = 4000;
     private static final int MAX_CHILDREN = 500;
     private static final int MAX_DEPTH = 20;
 

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListOfferIndexTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/catalog/CatalogPagesListOfferIndexTest.java
@@ -71,7 +71,7 @@ class CatalogPagesListOfferIndexTest {
         GameEnvironment environment = mock(GameEnvironment.class);
         CatalogManager catalogManager = mock(CatalogManager.class);
         CatalogPage page = mock(CatalogPage.class);
-        int[] offers = new int[1005];
+        int[] offers = new int[4005];
         for (int index = 0; index < offers.length; index++) offers[index] = index + 1;
 
         when(environment.getCatalogManager()).thenReturn(catalogManager);
@@ -98,8 +98,8 @@ class CatalogPagesListOfferIndexTest {
             assertEquals(1, packet.readInt());
 
             skipNodeHeader(packet);
-            assertEquals(1000, packet.readInt());
-            for (int offerId = 1; offerId <= 1000; offerId++) assertEquals(offerId, packet.readInt());
+            assertEquals(4000, packet.readInt());
+            for (int offerId = 1; offerId <= 4000; offerId++) assertEquals(offerId, packet.readInt());
             assertEquals(0, packet.readInt());
 
             assertFalse(packet.readBoolean());


### PR DESCRIPTION
## Problem

`CatalogPagesListComposer.MAX_OFFERS` truncates the per-page offer id list in the catalog index packet. It has to stay in lockstep with the Nitro renderer's `NodeData` parser, which **throws — killing the whole catalog — when a page declares more offers than its own ceiling**. At 1000 both sides are too low for real catalogs.

On a live hotel here:

```
WARN [GamePacketHandler-8-3] CatalogPagesListCom... | Catalog page 3017 has 1605 offers; limiting the index packet to 1000
```

The 605 dropped ids never reach the client's `offerId -> page` map, so deep-linking those offers to their page stops working. Browsing the page is unaffected — `CatalogPageComposer` sends the full item list uncapped.

## Change

`MAX_OFFERS: 1000 -> 4000`, and the test that pins the cap moves with it (now feeds 4005 offers and asserts 4000 written plus an intact packet suffix).

4000 ids is 16 KB for the worst page, well inside the 500 KB `MAX_FRAME_SIZE`. The truncation + warning still guard against a pathological page.

## Pairing

Requires duckietm/Octane-Renderer#186, which raises the same constant on the parser side. **Merge the renderer PR first** — a client that accepts 4000 works against an old server that sends at most 1000, but an updated server against an old client would throw on the index packet.

## Verification

`mvn -Dtest=CatalogPagesListOfferIndexTest test` — green (both cases).