### PR TITLE
⚠️ Security update wired

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ContractTerm.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/chest/ContractTerm.java
@@ -5,16 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * One PAY/RECEIVE term on a wired contract extra.
- * <p>
- * Wire encoding (v2, 5 ints/term): {@code [dir, kind, a, b, amount]} where
- * {@code kind=0} currency ({@code a=currencyType}, {@code b=0}),
- * {@code kind=1} furni ({@code a=wall?1:0}, {@code b=baseItemId}).
- * Legacy v1 (3 ints/term): {@code [dir, currencyType, amount]}.
- * Wall poster ids ride in the contract {@code stringParam} as {@code index=poster} pairs.
- * </p>
- */
 public class ContractTerm {
     public static final int DIR_PAY = 0;
     public static final int DIR_RECEIVE = 1;
@@ -78,7 +68,7 @@ public class ContractTerm {
         }
 
         int stride = detectStride(params, count);
-        List<String> posters = parsePosters(stringParam);
+        List<String> posters = parsePosters(stringParam, count);
 
         List<ContractTerm> terms = new ArrayList<>();
         for (int i = 0; i < count; i++) {
@@ -166,8 +156,8 @@ public class ContractTerm {
         return STRIDE_V1;
     }
 
-    private static List<String> parsePosters(String stringParam) {
-        List<String> posters = new ArrayList<>();
+    private static List<String> parsePosters(String stringParam, int count) {
+        List<String> posters = new ArrayList<>(Collections.nCopies(count, ""));
         if (stringParam == null || stringParam.isEmpty()) {
             return posters;
         }
@@ -181,11 +171,10 @@ public class ContractTerm {
             }
             try {
                 int index = Integer.parseInt(part.substring(0, eq).trim());
-                String poster = part.substring(eq + 1);
-                while (posters.size() <= index) {
-                    posters.add("");
+                if (index < 0 || index >= count) {
+                    continue;
                 }
-                posters.set(index, poster);
+                posters.set(index, part.substring(eq + 1));
             } catch (NumberFormatException ignored) {
                 WiredCompatibilityDiagnostics.record(
                         WiredCompatibilityDiagnostics.FailurePoint.CONTRACT_POSTER_INDEX, ignored);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableLevelUpSystem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraVariableLevelUpSystem.java
@@ -33,6 +33,8 @@ public class WiredExtraVariableLevelUpSystem extends InteractionWiredExtra {
 
     private static final int DEFAULT_STEP_SIZE = 100;
     private static final int DEFAULT_MAX_LEVEL = 10;
+
+    public static final int MAX_LEVEL = 10_000;
     private static final int DEFAULT_FIRST_LEVEL_XP = 100;
     private static final int DEFAULT_INCREASE_FACTOR = 100;
     private static final int MAX_MANUAL_TEXT_LENGTH = 4096;
@@ -214,7 +216,7 @@ public class WiredExtraVariableLevelUpSystem extends InteractionWiredExtra {
     }
 
     private static int normalizeMaxLevel(int value) {
-        return Math.max(1, (value > 0) ? value : DEFAULT_MAX_LEVEL);
+        return Math.min(MAX_LEVEL, Math.max(1, (value > 0) ? value : DEFAULT_MAX_LEVEL));
     }
 
     private static String normalizeInterpolationText(String value) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextInputCaptureSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredTextInputCaptureSupport.java
@@ -21,6 +21,7 @@ public final class WiredTextInputCaptureSupport {
     private static final int MATCH_EXACT = 1;
     private static final int MATCH_ALL_WORDS = 2;
     private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("#([^#]+)#");
+    private static final int MAX_TEMPLATE_PLACEHOLDERS = 8;
 
     private WiredTextInputCaptureSupport() {
     }
@@ -319,14 +320,29 @@ public final class WiredTextInputCaptureSupport {
         StringBuilder regex = new StringBuilder();
         List<String> placeholderNames = new ArrayList<>();
         int cursor = 0;
+        boolean unsafe = false;
 
         while (matcher.find()) {
+            if (matcher.start() == cursor && !placeholderNames.isEmpty()) {
+                unsafe = true;
+                break;
+            }
+
             regex.append(Pattern.quote(template.substring(cursor, matcher.start())));
             regex.append(hasPlaceholderAfter(template, matcher.end()) ? "(.+?)" : "(.+)");
 
             String placeholderName = matcher.group(1) != null ? matcher.group(1).trim().toLowerCase() : "";
             placeholderNames.add(placeholderName);
             cursor = matcher.end();
+
+            if (placeholderNames.size() > MAX_TEMPLATE_PLACEHOLDERS) {
+                unsafe = true;
+                break;
+            }
+        }
+
+        if (unsafe) {
+            return new TemplatePattern(Pattern.compile(Pattern.quote(template), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE), new ArrayList<>());
         }
 
         regex.append(Pattern.quote(template.substring(cursor)));

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredVariableLevelSystemSupport.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredVariableLevelSystemSupport.java
@@ -49,10 +49,6 @@ public final class WiredVariableLevelSystemSupport {
         return null;
     }
 
-    /**
-     * Find the co-located derived-variable box (the level-up box OR any {@link WiredDerivedVariableBox},
-     * e.g. a quest box) for a base variable definition. At most one box per definition; first wins.
-     */
     public static InteractionWiredExtra getDerivedBox(Room room, InteractionWiredExtra definition) {
         if (room == null || definition == null || room.getRoomSpecialTypes() == null) {
             return null;
@@ -494,7 +490,7 @@ public final class WiredVariableLevelSystemSupport {
             Integer level = parseInteger(line.substring(0, separatorIndex));
             Integer xp = parseInteger(line.substring(separatorIndex + 1));
 
-            if (level == null || xp == null || level <= 0 || xp < 0) {
+            if (level == null || xp == null || level <= 0 || xp < 0 || level > WiredExtraVariableLevelUpSystem.MAX_LEVEL) {
                 continue;
             }
 


### PR DESCRIPTION
1. Contract poster index — CRITICAL, remotely-triggerable heap exhaustion. ContractTerm.parsePosters grew its backing list up to a user-supplied index (while (posters.size() <= index) posters.add("")), so stringParam="2000000000=x" OOM'd the packet thread, and "-1=x" threw an uncaught IndexOutOfBoundsException out of the save handler. Since the list is only ever read at indices [0, count) and count is already bounded by the wired int-param cap, it now sizes the list to count and ignores any index outside that window. Both attack strings are inert.

2. Level-up maxLevel / anchors — HIGH, room-thread hang. The threshold table is rebuilt on every variable read, so an unbounded maxLevel (or a manual anchor like 999999999=1) pegged the thread. Added a MAX_LEVEL = 10000 cap, applied both in normalizeMaxLevel and to anchor levels in parseAnchors.

3. Keyword template ReDoS — HIGH, catastrophic regex backtracking. A raw keyword with many/adjacent #placeholder# tokens compiled into a lazy-group regex run against every chat message in the room. buildPattern now caps capture groups at 8 and falls back to a literal match when placeholders are adjacent (the all-adjacent case was already handled by the adjacency DP path), so the exponential shapes can't be compiled.

Describe the complete change and its operator or developer impact.

Compatibility:
- [ ] The public API, fields, live collections, packet layouts, and plugin behavior remain compatible.
- [ ] Plugin-facing or packaging changes exercise precompiled fixtures and the assembled jar.
- [ ] Database changes use a new Polaris migration and preserve supported upgrades.

Manual testing:
- None, or list only the hotel actions a reviewer must perform.
