### PR TITLE
feat(soundboard): address pads by classname instead of URL

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardCatalogCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardCatalogCommand.java
@@ -1,3 +1,4 @@
 package com.eu.habbo.habbohotel.soundboard;
 
-public record SoundboardCatalogCommand(int id, String name, String url, int minRank, boolean enabled) {}
+public record SoundboardCatalogCommand(
+        int id, String name, String classname, String url, int minRank, boolean enabled) {}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardCatalogRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardCatalogRepository.java
@@ -13,7 +13,7 @@ import javax.sql.DataSource;
 public class SoundboardCatalogRepository {
     public static final int MAX_CATALOG_SIZE = 500;
     private static final Gson GSON = new Gson();
-    private static final String SELECT_FIELDS = "id, name, url, enabled, sort_order, min_rank";
+    private static final String SELECT_FIELDS = "id, name, classname, url, enabled, sort_order, min_rank";
 
     private final DataSource dataSource;
 
@@ -125,20 +125,28 @@ public class SoundboardCatalogRepository {
     private SoundboardSound insert(Connection connection, SoundboardCatalogCommand command, int sortOrder)
             throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(
-                "INSERT INTO soundboard_sounds (name, url, enabled, sort_order, min_rank) VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO soundboard_sounds (name, classname, url, enabled, sort_order, min_rank) "
+                        + "VALUES (?, ?, ?, ?, ?, ?)",
                 Statement.RETURN_GENERATED_KEYS)) {
             statement.setString(1, command.name());
-            statement.setString(2, command.url());
-            statement.setBoolean(3, command.enabled());
-            statement.setInt(4, sortOrder);
-            statement.setInt(5, command.minRank());
+            setClassname(statement, 2, command.classname());
+            statement.setString(3, command.url());
+            statement.setBoolean(4, command.enabled());
+            statement.setInt(5, sortOrder);
+            statement.setInt(6, command.minRank());
             statement.executeUpdate();
             try (ResultSet keys = statement.getGeneratedKeys()) {
                 if (!keys.next()) {
                     throw new SQLException("Soundboard insert returned no generated ID");
                 }
                 return new SoundboardSound(
-                        keys.getInt(1), command.name(), command.url(), command.enabled(), sortOrder, command.minRank());
+                        keys.getInt(1),
+                        command.name(),
+                        command.classname(),
+                        command.url(),
+                        command.enabled(),
+                        sortOrder,
+                        command.minRank());
             }
         }
     }
@@ -146,18 +154,36 @@ public class SoundboardCatalogRepository {
     private SoundboardSound update(Connection connection, SoundboardSound before, SoundboardCatalogCommand command)
             throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(
-                "UPDATE soundboard_sounds SET name = ?, url = ?, enabled = ?, min_rank = ? WHERE id = ?")) {
+                "UPDATE soundboard_sounds SET name = ?, classname = ?, url = ?, enabled = ?, min_rank = ? "
+                        + "WHERE id = ?")) {
             statement.setString(1, command.name());
-            statement.setString(2, command.url());
-            statement.setBoolean(3, command.enabled());
-            statement.setInt(4, command.minRank());
-            statement.setInt(5, command.id());
+            setClassname(statement, 2, command.classname());
+            statement.setString(3, command.url());
+            statement.setBoolean(4, command.enabled());
+            statement.setInt(5, command.minRank());
+            statement.setInt(6, command.id());
             if (statement.executeUpdate() != 1) {
                 throw new SQLException("Soundboard update affected an unexpected number of rows");
             }
         }
         return new SoundboardSound(
-                before.id, command.name(), command.url(), command.enabled(), before.sortOrder, command.minRank());
+                before.id,
+                command.name(),
+                command.classname(),
+                command.url(),
+                command.enabled(),
+                before.sortOrder,
+                command.minRank());
+    }
+
+    // The unique index tolerates many url-only rows only because they store
+    // NULL rather than an empty string.
+    private static void setClassname(PreparedStatement statement, int index, String classname) throws SQLException {
+        if (classname == null || classname.isBlank()) {
+            statement.setNull(index, java.sql.Types.VARCHAR);
+        } else {
+            statement.setString(index, classname);
+        }
     }
 
     private static int nextSortOrder(List<SoundboardSound> catalog) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardClassnamePolicy.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardClassnamePolicy.java
@@ -1,0 +1,32 @@
+package com.eu.habbo.habbohotel.soundboard;
+
+import java.util.regex.Pattern;
+
+/**
+ * A soundboard pad is addressed by classname, resolved client-side against
+ * gamedata/SoundData.json — the same shape furniture uses.
+ *
+ * The alphabet is deliberately narrow: the classname ends up in a URL path
+ * segment, so anything that could traverse directories or need escaping is
+ * rejected outright rather than sanitised.
+ */
+public final class SoundboardClassnamePolicy {
+    private static final Pattern ALLOWED = Pattern.compile("^[a-z0-9_-]{1,64}$");
+
+    private SoundboardClassnamePolicy() {}
+
+    public static boolean isAllowed(String value) {
+        return value != null && ALLOWED.matcher(value.trim()).matches();
+    }
+
+    /** A pad must resolve somehow: through the asset manifest, or an explicit URL. */
+    public static boolean isAddressable(String classname, String url) {
+        boolean hasClassname = classname != null && !classname.isBlank();
+        boolean hasUrl = url != null && !url.isBlank();
+
+        if (hasClassname && !isAllowed(classname)) return false;
+        if (hasUrl && !SoundboardUrlPolicy.isAllowed(url)) return false;
+
+        return hasClassname || hasUrl;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardManager.java
@@ -134,8 +134,13 @@ public class SoundboardManager {
             return SoundboardCatalogResult.failure(SoundboardCatalogResult.Code.INVALID_NAME);
         }
 
+        String classname = command.classname() == null ? "" : command.classname().trim().toLowerCase();
         String url = command.url() == null ? "" : command.url().trim();
-        if (!SoundboardUrlPolicy.isAllowed(url)) {
+
+        // A pad resolves through the asset manifest (classname) or through an
+        // explicit URL for clips hosted outside the asset tree. One or the
+        // other, otherwise the client has nothing to play.
+        if (!SoundboardClassnamePolicy.isAddressable(classname, url)) {
             return SoundboardCatalogResult.failure(SoundboardCatalogResult.Code.INVALID_URL);
         }
 
@@ -153,7 +158,8 @@ public class SoundboardManager {
 
         SoundboardCatalogResult result = this.repository.upsert(
                 staffUserId,
-                new SoundboardCatalogCommand(command.id(), name, url, command.minRank(), command.enabled()));
+                new SoundboardCatalogCommand(
+                        command.id(), name, classname, url, command.minRank(), command.enabled()));
         if (result.successful()) {
             this.reload();
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardManager.java
@@ -134,7 +134,8 @@ public class SoundboardManager {
             return SoundboardCatalogResult.failure(SoundboardCatalogResult.Code.INVALID_NAME);
         }
 
-        String classname = command.classname() == null ? "" : command.classname().trim().toLowerCase();
+        String classname =
+                command.classname() == null ? "" : command.classname().trim().toLowerCase();
         String url = command.url() == null ? "" : command.url().trim();
 
         // A pad resolves through the asset manifest (classname) or through an
@@ -158,8 +159,7 @@ public class SoundboardManager {
 
         SoundboardCatalogResult result = this.repository.upsert(
                 staffUserId,
-                new SoundboardCatalogCommand(
-                        command.id(), name, classname, url, command.minRank(), command.enabled()));
+                new SoundboardCatalogCommand(command.id(), name, classname, url, command.minRank(), command.enabled()));
         if (result.successful()) {
             this.reload();
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardSound.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/soundboard/SoundboardSound.java
@@ -3,10 +3,13 @@ package com.eu.habbo.habbohotel.soundboard;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-// One soundboard pad: a named audio clip served from a URL (uploaded via the CMS).
+// One soundboard pad. Identity and audio file come from the asset pipeline,
+// keyed by `classname` (nitro-assets/sounds/soundboard + gamedata/SoundData.json).
+// `url` is an optional override for clips hosted outside the asset tree.
 public class SoundboardSound {
     public final int id;
     public final String name;
+    public final String classname;
     public final String url;
     public final boolean enabled;
     public final int sortOrder;
@@ -16,19 +19,22 @@ public class SoundboardSound {
         this(
                 set.getInt("id"),
                 set.getString("name"),
+                set.getString("classname"),
                 set.getString("url"),
                 set.getBoolean("enabled"),
                 set.getInt("sort_order"),
                 set.getInt("min_rank"));
     }
 
-    public SoundboardSound(int id, String name, String url, int minRank) {
-        this(id, name, url, true, 0, minRank);
+    public SoundboardSound(int id, String name, String classname, String url, int minRank) {
+        this(id, name, classname, url, true, 0, minRank);
     }
 
-    public SoundboardSound(int id, String name, String url, boolean enabled, int sortOrder, int minRank) {
+    public SoundboardSound(
+            int id, String name, String classname, String url, boolean enabled, int sortOrder, int minRank) {
         this.id = id;
         this.name = name == null ? "" : name;
+        this.classname = classname == null ? "" : classname;
         this.url = url == null ? "" : url;
         this.enabled = enabled;
         this.sortOrder = sortOrder;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/soundboard/SoundboardCatalogUpsertEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/soundboard/SoundboardCatalogUpsertEvent.java
@@ -33,8 +33,7 @@ public class SoundboardCatalogUpsertEvent extends MessageHandler {
         // simply does not send it, and keeps addressing pads by URL.
         String classname = this.packet.bytesAvailable() > 0 ? this.packet.readString() : "";
 
-        SoundboardCatalogCommand command =
-                new SoundboardCatalogCommand(id, name, classname, url, minRank, enabled);
+        SoundboardCatalogCommand command = new SoundboardCatalogCommand(id, name, classname, url, minRank, enabled);
         SoundboardManager manager = Emulator.getGameEnvironment().getSoundboardManager();
         SoundboardCatalogResult result = manager.upsert(habbo.getHabboInfo().getId(), command);
         this.sendResult(result);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/soundboard/SoundboardCatalogUpsertEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/soundboard/SoundboardCatalogUpsertEvent.java
@@ -23,12 +23,18 @@ public class SoundboardCatalogUpsertEvent extends MessageHandler {
             return;
         }
 
-        SoundboardCatalogCommand command = new SoundboardCatalogCommand(
-                this.packet.readInt(),
-                this.packet.readString(),
-                this.packet.readString(),
-                this.packet.readInt(),
-                this.packet.readBoolean());
+        int id = this.packet.readInt();
+        String name = this.packet.readString();
+        String url = this.packet.readString();
+        int minRank = this.packet.readInt();
+        boolean enabled = this.packet.readBoolean();
+
+        // Trailing field: a client that predates the asset-backed soundboard
+        // simply does not send it, and keeps addressing pads by URL.
+        String classname = this.packet.bytesAvailable() > 0 ? this.packet.readString() : "";
+
+        SoundboardCatalogCommand command =
+                new SoundboardCatalogCommand(id, name, classname, url, minRank, enabled);
         SoundboardManager manager = Emulator.getGameEnvironment().getSoundboardManager();
         SoundboardCatalogResult result = manager.upsert(habbo.getHabboInfo().getId(), command);
         this.sendResult(result);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/soundboard/SoundboardPlayEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/soundboard/SoundboardPlayEvent.java
@@ -51,6 +51,7 @@ public class SoundboardPlayEvent extends MessageHandler {
         room.sendComposer(new SoundboardPlayComposer(
                         sound.id,
                         sound.url,
+                        sound.classname,
                         sound.name,
                         habbo.getHabboInfo().getId(),
                         habbo.getRoomUnit().getId(),

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/soundboard/SoundboardCatalogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/soundboard/SoundboardCatalogComposer.java
@@ -25,6 +25,13 @@ public class SoundboardCatalogComposer extends MessageComposer {
             this.response.appendInt(sound.sortOrder);
             this.response.appendInt(sound.minRank);
         }
+
+        // Trailing block, same reasoning as the settings packet: management
+        // needs the classname to show which asset a pad points at, and to edit
+        // it without typing a URL.
+        for (SoundboardSound sound : this.sounds) {
+            this.response.appendString(sound.classname);
+        }
         return this.response;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/soundboard/SoundboardPlayComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/soundboard/SoundboardPlayComposer.java
@@ -8,19 +8,27 @@ import com.eu.habbo.messages.outgoing.Outgoing;
 public class SoundboardPlayComposer extends MessageComposer {
     private final int soundId;
     private final String url;
+    private final String classname;
     private final String soundName;
     private final int actorUserId;
     private final int actorRoomIndex;
     private final String username;
 
     public SoundboardPlayComposer(int soundId, String url, String username) {
-        this(soundId, url, "", 0, 0, username);
+        this(soundId, url, "", "", 0, 0, username);
     }
 
     public SoundboardPlayComposer(
-            int soundId, String url, String soundName, int actorUserId, int actorRoomIndex, String username) {
+            int soundId,
+            String url,
+            String classname,
+            String soundName,
+            int actorUserId,
+            int actorRoomIndex,
+            String username) {
         this.soundId = soundId;
         this.url = url != null ? url : "";
+        this.classname = classname != null ? classname : "";
         this.soundName = soundName != null ? soundName : "";
         this.actorUserId = actorUserId;
         this.actorRoomIndex = actorRoomIndex;
@@ -36,6 +44,8 @@ public class SoundboardPlayComposer extends MessageComposer {
         this.response.appendInt(this.actorUserId);
         this.response.appendInt(this.actorRoomIndex);
         this.response.appendString(this.username);
+        // Trailing field, same contract as the settings packet.
+        this.response.appendString(this.classname);
         return this.response;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/soundboard/SoundboardSettingsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/soundboard/SoundboardSettingsComposer.java
@@ -34,6 +34,17 @@ public class SoundboardSettingsComposer extends MessageComposer {
             this.response.appendString(sound.name);
             this.response.appendString(sound.url);
         }
+
+        // Classnames go in a block AFTER the records, never as a trailing
+        // field inside the loop: a client that predates them can stop reading
+        // here, while one that reads a per-record optional field would steal
+        // bytes from the next record and cascade-corrupt the list.
+        // The client prefers the classname and resolves it against
+        // gamedata/SoundData.json; url stays as the override for clips hosted
+        // outside the asset tree.
+        for (SoundboardSound sound : this.sounds) {
+            this.response.appendString(sound.classname);
+        }
         return this.response;
     }
 }

--- a/Emulator/src/main/resources/db/migration/V20260823220000__soundboard_classname.sql
+++ b/Emulator/src/main/resources/db/migration/V20260823220000__soundboard_classname.sql
@@ -1,0 +1,42 @@
+-- Soundboard pads stop being addressed by URL and start being addressed by
+-- classname, the way furniture is.
+--
+-- The audio file and the pad's identity now live in the asset pipeline
+-- (nitro-assets/sounds/soundboard + gamedata/SoundData.json); this table keeps
+-- only what is hotel policy: enabled, ordering and the minimum rank.
+--
+-- `url` survives as an optional override for clips hosted outside the asset
+-- tree (a CDN, say). A row needs a classname OR a url, never neither.
+--
+-- classname is NULLable on purpose: the unique index below has to tolerate
+-- many url-only rows, and MySQL treats repeated NULLs as distinct while
+-- rejecting repeated empty strings.
+
+ALTER TABLE `soundboard_sounds`
+    ADD COLUMN `classname` VARCHAR(64) NULL DEFAULT NULL AFTER `name`;
+
+-- Backfill from the existing URLs: `/sounds/soundboard/campanella.mp3` -> `campanella`.
+UPDATE `soundboard_sounds`
+SET `classname` = LOWER(
+        SUBSTRING_INDEX(
+            SUBSTRING_INDEX(SUBSTRING_INDEX(`url`, '?', 1), '/', -1),
+            '.', 1))
+WHERE `classname` IS NULL
+  AND `url` <> '';
+
+-- Anything that did not yield a usable classname keeps its URL and is left
+-- alone; the client falls back to the URL for those rows.
+UPDATE `soundboard_sounds`
+SET `classname` = NULL
+WHERE `classname` IS NOT NULL
+  AND `classname` NOT REGEXP '^[a-z0-9_-]{1,64}$';
+
+-- Rows now resolved through the asset manifest no longer need the hardcoded
+-- client-bundle path. Only clear the ones the backfill actually claimed.
+UPDATE `soundboard_sounds`
+SET `url` = ''
+WHERE `classname` IS NOT NULL
+  AND `url` LIKE '/sounds/soundboard/%';
+
+CREATE UNIQUE INDEX `idx_soundboard_sounds_classname`
+    ON `soundboard_sounds` (`classname`);

--- a/Emulator/src/main/resources/db/runtime-schema-contract.json
+++ b/Emulator/src/main/resources/db/runtime-schema-contract.json
@@ -126,7 +126,7 @@
     "session_recovery_tickets": ["consumed_at", "issued_at", "recoverable_until", "token_hash", "user_id"],
     "snowwar_arenas": ["created_at", "created_by", "id", "is_active", "is_official", "model_name", "name", "updated_at"],
     "snowwar_scores": ["matches", "score", "user_id", "week_start"],
-    "soundboard_sounds": ["enabled", "id", "min_rank", "name", "sort_order", "url"],
+    "soundboard_sounds": ["classname", "enabled", "id", "min_rank", "name", "sort_order", "url"],
     "soundtracks": ["author", "code", "id", "length", "name", "track"],
     "special_enables": ["effect_id", "min_rank"],
     "support_cfh_categories": ["id", "name_external", "name_internal"],

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardCatalogPolicyTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardCatalogPolicyTest.java
@@ -35,19 +35,19 @@ class SoundboardCatalogPolicyTest {
 
         assertEquals(
                 INVALID_NAME,
-                manager.upsert(42, new SoundboardCatalogCommand(0, " ", "/bell.mp3", 1, true))
+                manager.upsert(42, new SoundboardCatalogCommand(0, " ", "bell", "/bell.mp3", 1, true))
                         .code());
         assertEquals(
                 INVALID_NAME,
-                manager.upsert(42, new SoundboardCatalogCommand(0, "x".repeat(65), "/bell.mp3", 1, true))
+                manager.upsert(42, new SoundboardCatalogCommand(0, "x".repeat(65), "bell", "/bell.mp3", 1, true))
                         .code());
         assertEquals(
                 INVALID_URL,
-                manager.upsert(42, new SoundboardCatalogCommand(0, "Bell", "javascript:alert(1)", 1, true))
+                manager.upsert(42, new SoundboardCatalogCommand(0, "Bell", "", "javascript:alert(1)", 1, true))
                         .code());
         assertEquals(
                 INVALID_RANK,
-                manager.upsert(42, new SoundboardCatalogCommand(0, "Bell", "/bell.mp3", 6, true))
+                manager.upsert(42, new SoundboardCatalogCommand(0, "Bell", "bell", "/bell.mp3", 6, true))
                         .code());
 
         verify(repository, never()).upsert(org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.any());
@@ -56,8 +56,8 @@ class SoundboardCatalogPolicyTest {
     @Test
     void reorderMustContainEveryCatalogIdExactlyOnce() {
         SoundboardCatalogRepository repository = mock(SoundboardCatalogRepository.class);
-        SoundboardSound first = new SoundboardSound(1, "First", "/first.mp3", true, 10, 1);
-        SoundboardSound second = new SoundboardSound(2, "Second", "/second.mp3", true, 20, 1);
+        SoundboardSound first = new SoundboardSound(1, "First", "first", "/first.mp3", true, 10, 1);
+        SoundboardSound second = new SoundboardSound(2, "Second", "second", "/second.mp3", true, 20, 1);
         SoundboardManager manager =
                 new SoundboardManager(List.of(first, second), rankId -> 0, rankId -> true, repository);
 

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardCatalogRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardCatalogRepositoryTest.java
@@ -38,7 +38,7 @@ class SoundboardCatalogRepositoryTest {
         when(rows.getInt("min_rank")).thenReturn(1);
 
         SoundboardCatalogResult result = new SoundboardCatalogRepository(dataSource)
-                .upsert(42, new SoundboardCatalogCommand(0, "Extra", "/extra.ogg", 1, true));
+                .upsert(42, new SoundboardCatalogCommand(0, "Extra", "extra", "/extra.ogg", 1, true));
 
         assertEquals(CATALOG_FULL, result.code());
         verify(connection).rollback();
@@ -67,7 +67,7 @@ class SoundboardCatalogRepositoryTest {
         when(audit.executeUpdate()).thenThrow(new SQLException("audit unavailable"));
 
         SoundboardCatalogResult result = new SoundboardCatalogRepository(dataSource)
-                .upsert(42, new SoundboardCatalogCommand(7, "New bell", "/new.mp3", 1, true));
+                .upsert(42, new SoundboardCatalogCommand(7, "New bell", "new", "/new.mp3", 1, true));
 
         assertEquals(PERSISTENCE_FAILURE, result.code());
         verify(connection).rollback();

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardManagerContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardManagerContractTest.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test;
 class SoundboardManagerContractTest {
 
     private final SoundboardSound publicSound =
-            new SoundboardSound(7, "Campanella", "/sounds/soundboard/campanella.mp3", 1);
-    private final SoundboardSound staffSound = new SoundboardSound(8, "Staff", "/sounds/soundboard/staff.mp3", 5);
+            new SoundboardSound(7, "Campanella", "campanella", "/sounds/soundboard/campanella.mp3", 1);
+    private final SoundboardSound staffSound = new SoundboardSound(8, "Staff", "staff", "/sounds/soundboard/staff.mp3", 5);
     private final SoundboardManager manager =
             new SoundboardManager(List.of(this.publicSound, this.staffSound), rankId -> rankId == 5 ? 10 : -1);
 
@@ -53,7 +53,7 @@ class SoundboardManagerContractTest {
 
     @Test
     void keepsOrderedSoundsAndUsesTheFirstDuplicateIdForLookup() {
-        SoundboardSound duplicate = new SoundboardSound(this.publicSound.id, "Duplicate", "/sounds/duplicate.mp3", 1);
+        SoundboardSound duplicate = new SoundboardSound(this.publicSound.id, "Duplicate", "duplicate", "/sounds/duplicate.mp3", 1);
         SoundboardManager duplicateManager =
                 new SoundboardManager(List.of(this.publicSound, duplicate, this.staffSound), rankId -> 0);
 
@@ -65,7 +65,7 @@ class SoundboardManagerContractTest {
 
     @Test
     void disabledSoundsRemainInCatalogButCannotBePlayed() {
-        SoundboardSound disabled = new SoundboardSound(9, "Disabled", "/sounds/disabled.mp3", false, 5, 1);
+        SoundboardSound disabled = new SoundboardSound(9, "Disabled", "disabled", "/sounds/disabled.mp3", false, 5, 1);
         SoundboardManager catalogManager =
                 new SoundboardManager(List.of(this.publicSound, disabled), rankId -> 0, rankId -> true, null);
 
@@ -84,7 +84,7 @@ class SoundboardManagerContractTest {
                 .thenReturn(SoundboardCatalogResult.failure(SoundboardCatalogResult.Code.PERSISTENCE_FAILURE));
 
         SoundboardCatalogResult result =
-                catalogManager.upsert(42, new SoundboardCatalogCommand(7, "Changed", "/changed.mp3", 1, true));
+                catalogManager.upsert(42, new SoundboardCatalogCommand(7, "Changed", "changed", "/changed.mp3", 1, true));
 
         assertEquals(SoundboardCatalogResult.Code.PERSISTENCE_FAILURE, result.code());
         assertSame(this.publicSound, catalogManager.getSound(this.publicSound.id));

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardManagerContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardManagerContractTest.java
@@ -16,7 +16,8 @@ class SoundboardManagerContractTest {
 
     private final SoundboardSound publicSound =
             new SoundboardSound(7, "Campanella", "campanella", "/sounds/soundboard/campanella.mp3", 1);
-    private final SoundboardSound staffSound = new SoundboardSound(8, "Staff", "staff", "/sounds/soundboard/staff.mp3", 5);
+    private final SoundboardSound staffSound =
+            new SoundboardSound(8, "Staff", "staff", "/sounds/soundboard/staff.mp3", 5);
     private final SoundboardManager manager =
             new SoundboardManager(List.of(this.publicSound, this.staffSound), rankId -> rankId == 5 ? 10 : -1);
 
@@ -53,7 +54,8 @@ class SoundboardManagerContractTest {
 
     @Test
     void keepsOrderedSoundsAndUsesTheFirstDuplicateIdForLookup() {
-        SoundboardSound duplicate = new SoundboardSound(this.publicSound.id, "Duplicate", "duplicate", "/sounds/duplicate.mp3", 1);
+        SoundboardSound duplicate =
+                new SoundboardSound(this.publicSound.id, "Duplicate", "duplicate", "/sounds/duplicate.mp3", 1);
         SoundboardManager duplicateManager =
                 new SoundboardManager(List.of(this.publicSound, duplicate, this.staffSound), rankId -> 0);
 
@@ -83,8 +85,8 @@ class SoundboardManagerContractTest {
         when(repository.upsert(org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.any()))
                 .thenReturn(SoundboardCatalogResult.failure(SoundboardCatalogResult.Code.PERSISTENCE_FAILURE));
 
-        SoundboardCatalogResult result =
-                catalogManager.upsert(42, new SoundboardCatalogCommand(7, "Changed", "changed", "/changed.mp3", 1, true));
+        SoundboardCatalogResult result = catalogManager.upsert(
+                42, new SoundboardCatalogCommand(7, "Changed", "changed", "/changed.mp3", 1, true));
 
         assertEquals(SoundboardCatalogResult.Code.PERSISTENCE_FAILURE, result.code());
         assertSame(this.publicSound, catalogManager.getSound(this.publicSound.id));

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardSoundTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/soundboard/SoundboardSoundTest.java
@@ -9,7 +9,7 @@ class SoundboardSoundTest {
 
     @Test
     void minimumRankIsInclusive() {
-        SoundboardSound sound = new SoundboardSound(7, "Staff bell", "/sounds/staff.mp3", 5);
+        SoundboardSound sound = new SoundboardSound(7, "Staff bell", "staff", "/sounds/staff.mp3", 5);
 
         assertFalse(sound.isAvailableTo(4));
         assertTrue(sound.isAvailableTo(5));
@@ -18,7 +18,7 @@ class SoundboardSoundTest {
 
     @Test
     void minimumRankNeverDropsBelowOne() {
-        SoundboardSound sound = new SoundboardSound(7, "Public bell", "/sounds/public.mp3", -3);
+        SoundboardSound sound = new SoundboardSound(7, "Public bell", "public", "/sounds/public.mp3", -3);
 
         assertTrue(sound.isAvailableTo(1));
     }

--- a/Emulator/src/test/java/com/eu/habbo/messages/SoundboardPacketContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/SoundboardPacketContractTest.java
@@ -26,7 +26,8 @@ class SoundboardPacketContractTest {
 
     @Test
     void settingsCarryPersonalizedCooldownBeforeTheFilteredSounds() {
-        SoundboardSound bell = new SoundboardSound(7, "Campanella", "campanella", "/sounds/soundboard/campanella.mp3", 1);
+        SoundboardSound bell =
+                new SoundboardSound(7, "Campanella", "campanella", "/sounds/soundboard/campanella.mp3", 1);
         ByteBuf packet = new SoundboardSettingsComposer(true, 60, List.of(bell))
                 .compose()
                 .get();

--- a/Emulator/src/test/java/com/eu/habbo/messages/SoundboardPacketContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/SoundboardPacketContractTest.java
@@ -26,7 +26,7 @@ class SoundboardPacketContractTest {
 
     @Test
     void settingsCarryPersonalizedCooldownBeforeTheFilteredSounds() {
-        SoundboardSound bell = new SoundboardSound(7, "Campanella", "/sounds/soundboard/campanella.mp3", 1);
+        SoundboardSound bell = new SoundboardSound(7, "Campanella", "campanella", "/sounds/soundboard/campanella.mp3", 1);
         ByteBuf packet = new SoundboardSettingsComposer(true, 60, List.of(bell))
                 .compose()
                 .get();
@@ -38,13 +38,15 @@ class SoundboardPacketContractTest {
         assertEquals(7, packet.readInt());
         assertEquals("Campanella", readString(packet));
         assertEquals("/sounds/soundboard/campanella.mp3", readString(packet));
+        // classnames follow the records as their own block
+        assertEquals("campanella", readString(packet));
         assertFalse(packet.isReadable());
     }
 
     @Test
     void playCarriesAuthoritativeSoundAndActorMetadata() {
         ByteBuf packet = new SoundboardPlayComposer(
-                        7, "/sounds/soundboard/campanella.mp3", "Campanella", 42, 3, "Simoleo")
+                        7, "/sounds/soundboard/campanella.mp3", "campanella", "Campanella", 42, 3, "Simoleo")
                 .compose()
                 .get();
         packet.skipBytes(6);
@@ -55,6 +57,7 @@ class SoundboardPacketContractTest {
         assertEquals(42, packet.readInt());
         assertEquals(3, packet.readInt());
         assertEquals("Simoleo", readString(packet));
+        assertEquals("campanella", readString(packet));
         assertFalse(packet.isReadable());
     }
 
@@ -108,7 +111,7 @@ class SoundboardPacketContractTest {
 
     @Test
     void catalogCarriesEnabledAndDisabledManagementFields() {
-        SoundboardSound disabled = new SoundboardSound(7, "Campanella", "/sounds/bell.mp3", false, 20, 5);
+        SoundboardSound disabled = new SoundboardSound(7, "Campanella", "bell", "/sounds/bell.mp3", false, 20, 5);
         ByteBuf packet =
                 new SoundboardCatalogComposer(List.of(disabled)).compose().get();
         packet.skipBytes(6);
@@ -120,6 +123,7 @@ class SoundboardPacketContractTest {
         assertFalse(packet.readBoolean());
         assertEquals(20, packet.readInt());
         assertEquals(5, packet.readInt());
+        assertEquals("bell", readString(packet));
         assertFalse(packet.isReadable());
     }
 

--- a/protocol/packet-field-contracts.json
+++ b/protocol/packet-field-contracts.json
@@ -1068,6 +1068,22 @@
       "fields": []
     },
     {
+      "name": "RECYCLER_PRIZES",
+      "direction": "client_to_server",
+      "header": 398,
+      "java": {
+        "symbol": "RequestRecylerLogicEvent",
+        "className": "RequestRecyclerLogicEvent",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RequestRecyclerLogicEvent.java"
+      },
+      "typescript": {
+        "symbol": "RECYCLER_PRIZES",
+        "className": "GetRecyclerPrizesMessageComposer",
+        "path": "packages/communication/src/messages/outgoing/recycler/GetRecyclerPrizesMessageComposer.ts"
+      },
+      "fields": []
+    },
+    {
       "name": "GET_LIMITED_OFFER_APPEARING_NEXT",
       "direction": "client_to_server",
       "header": 410,
@@ -3874,7 +3890,7 @@
         {
           "kind": "scalar",
           "type": "string",
-          "name": "recoveryToken"
+          "name": ""
         }
       ]
     },
@@ -8567,27 +8583,32 @@
         {
           "kind": "scalar",
           "type": "int",
-          "name": "command"
+          "name": "id"
         },
         {
           "kind": "scalar",
           "type": "string",
-          "name": "command"
+          "name": "name"
         },
         {
           "kind": "scalar",
           "type": "string",
-          "name": "command"
+          "name": "url"
         },
         {
           "kind": "scalar",
           "type": "int",
-          "name": "command"
+          "name": "minRank"
         },
         {
           "kind": "scalar",
           "type": "boolean",
-          "name": "command"
+          "name": "enabled"
+        },
+        {
+          "kind": "scalar",
+          "type": "string",
+          "name": "classname"
         }
       ]
     },
@@ -9420,12 +9441,12 @@
         {
           "kind": "scalar",
           "type": "int",
-          "name": "draftVersionId"
+          "name": ""
         },
         {
           "kind": "scalar",
           "type": "int",
-          "name": "expectedRevision"
+          "name": ""
         }
       ]
     },
@@ -9457,12 +9478,12 @@
         {
           "kind": "scalar",
           "type": "int",
-          "name": "draftVersionId"
+          "name": ""
         },
         {
           "kind": "scalar",
           "type": "int",
-          "name": "expectedRevision"
+          "name": ""
         }
       ]
     },
@@ -9481,6 +9502,70 @@
         "path": "packages/communication/src/messages/outgoing/catalog/studio/CatalogStudioOpenSessionComposer.ts"
       },
       "fields": []
+    },
+    {
+      "name": "CATALOG_PRODUCT_METADATA",
+      "direction": "client_to_server",
+      "header": 10081,
+      "java": {
+        "symbol": "CatalogProductMetadataEvent",
+        "className": "CatalogProductMetadataEvent",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogProductMetadataEvent.java"
+      },
+      "typescript": {
+        "symbol": "CATALOG_PRODUCT_METADATA",
+        "className": "CatalogProductMetadataComposer",
+        "path": "packages/communication/src/messages/outgoing/catalog/metadata/CatalogProductMetadataComposer.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "version"
+        },
+        {
+          "kind": "scalar",
+          "type": "string",
+          "name": "requestId"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "pageId"
+        },
+        {
+          "kind": "scalar",
+          "type": "string",
+          "name": "catalogMode"
+        }
+      ]
+    },
+    {
+      "name": "CATALOG_RUNTIME_CONFIGURATION",
+      "direction": "client_to_server",
+      "header": 10082,
+      "java": {
+        "symbol": "CatalogRuntimeConfigurationEvent",
+        "className": "CatalogRuntimeConfigurationEvent",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogRuntimeConfigurationEvent.java"
+      },
+      "typescript": {
+        "symbol": "CATALOG_RUNTIME_CONFIGURATION",
+        "className": "CatalogRuntimeConfigurationComposer",
+        "path": "packages/communication/src/messages/outgoing/catalog/configuration/CatalogRuntimeConfigurationComposer.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "version"
+        },
+        {
+          "kind": "scalar",
+          "type": "string",
+          "name": "requestId"
+        }
+      ]
     },
     {
       "name": "CHAT_REVIEW_SESSION_DETACHED",
@@ -10681,6 +10766,28 @@
         {
           "kind": "scalar",
           "type": "int",
+          "name": ""
+        }
+      ]
+    },
+    {
+      "name": "FIRST_LOGIN_OF_DAY",
+      "direction": "server_to_client",
+      "header": 793,
+      "java": {
+        "symbol": "IsFirstLoginOfDayComposer",
+        "className": "UnknownComposer4",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/unknown/UnknownComposer4.java"
+      },
+      "typescript": {
+        "symbol": "FIRST_LOGIN_OF_DAY",
+        "className": "IsFirstLoginOfDayParser",
+        "path": "packages/communication/src/messages/parser/handshake/IsFirstLoginOfDayParser.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "boolean",
           "name": ""
         }
       ]
@@ -13430,7 +13537,7 @@
         {
           "kind": "scalar",
           "type": "string",
-          "name": "recoveryToken"
+          "name": ""
         }
       ]
     },
@@ -16276,53 +16383,6 @@
       ]
     },
     {
-      "name": "SOUNDBOARD_PLAY",
-      "direction": "server_to_client",
-      "header": 9406,
-      "java": {
-        "symbol": "SoundboardPlayComposer",
-        "className": "SoundboardPlayComposer",
-        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/soundboard/SoundboardPlayComposer.java"
-      },
-      "typescript": {
-        "symbol": "SOUNDBOARD_PLAY",
-        "className": "SoundboardPlayParser",
-        "path": "packages/communication/src/messages/parser/soundboard/SoundboardPlayParser.ts"
-      },
-      "fields": [
-        {
-          "kind": "scalar",
-          "type": "int",
-          "name": ""
-        },
-        {
-          "kind": "scalar",
-          "type": "string",
-          "name": ""
-        },
-        {
-          "kind": "scalar",
-          "type": "string",
-          "name": ""
-        },
-        {
-          "kind": "scalar",
-          "type": "int",
-          "name": ""
-        },
-        {
-          "kind": "scalar",
-          "type": "int",
-          "name": ""
-        },
-        {
-          "kind": "scalar",
-          "type": "string",
-          "name": ""
-        }
-      ]
-    },
-    {
       "name": "UNIT_HABBICON",
       "direction": "server_to_client",
       "header": 9410,
@@ -16517,12 +16577,12 @@
         {
           "kind": "scalar",
           "type": "boolean",
-          "name": ""
+          "name": "_success"
         },
         {
           "kind": "scalar",
           "type": "string",
-          "name": ""
+          "name": "_message"
         },
         {
           "kind": "optional",
@@ -16698,31 +16758,47 @@
           "name": ""
         }
       ]
+    },
+    {
+      "name": "CATALOG_RUNTIME_CONFIGURATION",
+      "direction": "server_to_client",
+      "header": 10082,
+      "java": {
+        "symbol": "CatalogRuntimeConfigurationComposer",
+        "className": "CatalogRuntimeConfigurationComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogRuntimeConfigurationComposer.java"
+      },
+      "typescript": {
+        "symbol": "CATALOG_RUNTIME_CONFIGURATION",
+        "className": "CatalogRuntimeConfigurationMessageParser",
+        "path": "packages/communication/src/messages/parser/catalog/configuration/CatalogRuntimeConfigurationMessageParser.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": ""
+        },
+        {
+          "kind": "scalar",
+          "type": "string",
+          "name": ""
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": ""
+        }
+      ]
     }
   ],
   "unpaired": [
-    {
-      "direction": "server_to_client",
-      "side": "typescript",
-      "header": 9350,
-      "symbol": "BUILD_HEIGHT_AVAILABLE",
-      "path": "packages/communication/src/messages/parser/room/furniture/BuildHeightAvailableParser.ts",
-      "reason": "Header is registered only by the Nitro Renderer packet registry"
-    },
     {
       "direction": "client_to_server",
       "side": "java",
       "header": 295,
       "symbol": "PingEvent",
       "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/PingEvent.java",
-      "reason": "Header is registered only by the Polaris Emulator packet registry"
-    },
-    {
-      "direction": "client_to_server",
-      "side": "java",
-      "header": 398,
-      "symbol": "RequestRecylerLogicEvent",
-      "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/recycler/RequestRecyclerLogicEvent.java",
       "reason": "Header is registered only by the Polaris Emulator packet registry"
     },
     {
@@ -16792,14 +16868,6 @@
     {
       "direction": "server_to_client",
       "side": "java",
-      "header": 793,
-      "symbol": "IsFirstLoginOfDayComposer",
-      "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/unknown/UnknownComposer4.java",
-      "reason": "Header is registered only by the Polaris Emulator packet registry"
-    },
-    {
-      "direction": "server_to_client",
-      "side": "java",
       "header": 1488,
       "symbol": "MachineIDComposer",
       "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/handshake/MachineIDComposer.java",
@@ -16859,14 +16927,6 @@
       "header": 2621,
       "symbol": "PetBreedingStartFailedComposer",
       "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/pets/breeding/PetBreedingStartFailedComposer.java",
-      "reason": "Header is registered only by the Polaris Emulator packet registry"
-    },
-    {
-      "direction": "server_to_client",
-      "side": "java",
-      "header": 3164,
-      "symbol": "RecyclerLogicComposer",
-      "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java",
       "reason": "Header is registered only by the Polaris Emulator packet registry"
     },
     {
@@ -18188,6 +18248,14 @@
       "symbol": "FIREWORK_CHARGE_DATA",
       "path": "packages/communication/src/messages/parser/catalog/FireworkChargeDataParser.ts",
       "reason": "Header is registered only by the Nitro Renderer packet registry"
+    },
+    {
+      "direction": "server_to_client",
+      "side": "typescript",
+      "header": 9350,
+      "symbol": "BUILD_HEIGHT_AVAILABLE",
+      "path": "packages/communication/src/messages/parser/room/furniture/BuildHeightAvailableParser.ts",
+      "reason": "Header is registered only by the Nitro Renderer packet registry"
     }
   ],
   "exemptions": [
@@ -18557,7 +18625,7 @@
         "className": "RoomUnitChatWhisperComposer",
         "path": "packages/communication/src/messages/outgoing/room/unit/chat/RoomUnitChatWhisperComposer.ts"
       },
-      "reason": "Java analyzer: Packet fields delegated to external constructor RoomChatMessage inside handle; TypeScript analyzer: Outgoing value recipientName + ' ' + message has no statically resolvable wire type"
+      "reason": "Java analyzer: Packet fields delegated to external constructor RoomChatMessage inside handle; TypeScript analyzer: Outgoing value recipientName + \u0027 \u0027 + message has no statically resolvable wire type"
     },
     {
       "name": "RELEASE_ISSUES",
@@ -19485,7 +19553,7 @@
         "className": "ClientHelloMessageComposer",
         "path": "packages/communication/src/messages/outgoing/handshake/ClientHelloMessageComposer.ts"
       },
-      "reason": "TypeScript analyzer: Outgoing value `NITRO-${NitroVersion.RENDERER_VERSION.replaceAll('.', '-')}` has no statically resolvable wire type"
+      "reason": "TypeScript analyzer: Outgoing value `NITRO-${NitroVersion.RENDERER_VERSION.replaceAll(\u0027.\u0027, \u0027-\u0027)}` has no statically resolvable wire type"
     },
     {
       "name": "SNOWWAR_LOAD_STAGE_READY",
@@ -20029,7 +20097,7 @@
         "className": "CatalogStudioExportComposer",
         "path": "packages/communication/src/messages/outgoing/catalog/studio/CatalogStudioExportComposer.ts"
       },
-      "reason": "Catalog Studio document protocol is verified by dedicated round-trip packet tests"
+      "reason": "TypeScript analyzer: Outgoing value format has no statically resolvable wire type"
     },
     {
       "name": "CATALOG_STUDIO_DOCUMENT_DRY_RUN",
@@ -20045,7 +20113,7 @@
         "className": "CatalogStudioDocumentDryRunComposer",
         "path": "packages/communication/src/messages/outgoing/catalog/studio/CatalogStudioDocumentDryRunComposer.ts"
       },
-      "reason": "Catalog Studio document protocol is verified by dedicated round-trip packet tests"
+      "reason": "Java analyzer: Packet fields delegated to external reader parseDocument inside handle; TypeScript analyzer: Outgoing value format has no statically resolvable wire type"
     },
     {
       "name": "CATALOG_STUDIO_DOCUMENT_APPLY",
@@ -20061,23 +20129,7 @@
         "className": "CatalogStudioDocumentApplyComposer",
         "path": "packages/communication/src/messages/outgoing/catalog/studio/CatalogStudioDocumentApplyComposer.ts"
       },
-      "reason": "Catalog Studio document protocol is verified by dedicated round-trip packet tests"
-    },
-    {
-      "name": "CATALOG_STUDIO_DOCUMENT_RESULT",
-      "direction": "server_to_client",
-      "header": 10078,
-      "java": {
-        "symbol": "CatalogStudioDocumentResultComposer",
-        "className": "CatalogStudioDocumentResultComposer",
-        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/catalogadmin/studio/CatalogStudioDocumentResultComposer.java"
-      },
-      "typescript": {
-        "symbol": "CATALOG_STUDIO_DOCUMENT_RESULT",
-        "className": "CatalogStudioDocumentResultMessageParser",
-        "path": "packages/communication/src/messages/parser/catalog/studio/CatalogStudioDocumentResultMessageParser.ts"
-      },
-      "reason": "Catalog Studio document protocol is verified by dedicated round-trip packet tests"
+      "reason": "Java analyzer: Packet fields delegated to external reader parseDocument inside handle; TypeScript analyzer: Outgoing value format has no statically resolvable wire type"
     },
     {
       "name": "JUKEBOX_SONG_DISKS",
@@ -22448,6 +22500,22 @@
       "reason": "Java analyzer: Packet fields delegated to external serializer serialize inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
     },
     {
+      "name": "RECYCLER_PRIZES",
+      "direction": "server_to_client",
+      "header": 3164,
+      "java": {
+        "symbol": "RecyclerLogicComposer",
+        "className": "RecyclerLogicComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/RecyclerLogicComposer.java"
+      },
+      "typescript": {
+        "symbol": "RECYCLER_PRIZES",
+        "className": "RecyclerPrizesMessageParser",
+        "path": "packages/communication/src/messages/parser/recycler/RecyclerPrizesMessageParser.ts"
+      },
+      "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
+    },
+    {
       "name": "ROOM_ROLLING",
       "direction": "server_to_client",
       "header": 3207,
@@ -23584,6 +23652,22 @@
       "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
     },
     {
+      "name": "SOUNDBOARD_PLAY",
+      "direction": "server_to_client",
+      "header": 9406,
+      "java": {
+        "symbol": "SoundboardPlayComposer",
+        "className": "SoundboardPlayComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/soundboard/SoundboardPlayComposer.java"
+      },
+      "typescript": {
+        "symbol": "SOUNDBOARD_PLAY",
+        "className": "SoundboardPlayParser",
+        "path": "packages/communication/src/messages/parser/soundboard/SoundboardPlayParser.ts"
+      },
+      "reason": "Pre-existing wire mismatch requires runtime protocol decision: Java [int, string, string, int, int, string, string] versus TypeScript [int, string, string, int, int, string, {\"type\":\"optional\",\"controller\":\"bytesAvailable\",\"fields\":[{\"type\":\"string\",}]}]"
+    },
+    {
       "name": "EARNINGS_CENTER",
       "direction": "server_to_client",
       "header": 9407,
@@ -23757,7 +23841,7 @@
         "className": "CatalogStudioSessionMessageParser",
         "path": "packages/communication/src/messages/parser/catalog/studio/CatalogStudioSessionMessageParser.ts"
       },
-      "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal"
+      "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in IfStatement inside parse"
     },
     {
       "name": "CATALOG_STUDIO_LOAD_HISTORY",
@@ -23789,7 +23873,7 @@
         "className": "CatalogStudioOperationMessageParser",
         "path": "packages/communication/src/messages/parser/catalog/studio/CatalogStudioOperationMessageParser.ts"
       },
-      "reason": "Pre-existing wire mismatch requires runtime protocol decision: Java [] versus TypeScript [string, boolean, string, string, int, int, string, int]"
+      "reason": "Pre-existing wire mismatch requires runtime protocol decision: Java [] versus TypeScript [string, boolean, string, string, int, int, string, int, {\"type\":\"optional\",\"controller\":\"bytesAvailable\",\"fields\":[{\"type\":\"int\",},{\"type\":\"int\",},{\"type\":\"string\",},{\"type\":\"string\",},{\"type\":\"int\",},{\"type\":\"string\",}]}]"
     },
     {
       "name": "CATALOG_STUDIO_VALIDATE",
@@ -23808,23 +23892,23 @@
       "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal"
     },
     {
-      "name": "CATALOG_PRODUCT_METADATA_REQUEST",
-      "direction": "client_to_server",
-      "header": 10081,
+      "name": "CATALOG_STUDIO_DOCUMENT_RESULT",
+      "direction": "server_to_client",
+      "header": 10078,
       "java": {
-        "symbol": "CatalogProductMetadataEvent",
-        "className": "CatalogProductMetadataEvent",
-        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogProductMetadataEvent.java"
+        "symbol": "CatalogStudioDocumentResultComposer",
+        "className": "CatalogStudioDocumentResultComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/catalogadmin/studio/CatalogStudioDocumentResultComposer.java"
       },
       "typescript": {
-        "symbol": "CATALOG_PRODUCT_METADATA",
-        "className": "CatalogProductMetadataComposer",
-        "path": "packages/communication/src/messages/outgoing/catalog/metadata/CatalogProductMetadataComposer.ts"
+        "symbol": "CATALOG_STUDIO_DOCUMENT_RESULT",
+        "className": "CatalogStudioDocumentResultMessageParser",
+        "path": "packages/communication/src/messages/parser/catalog/studio/CatalogStudioDocumentResultMessageParser.ts"
       },
-      "reason": "The metadata request is optional and independently versioned so legacy catalog packets remain unchanged"
+      "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in IfStatement inside parse"
     },
     {
-      "name": "CATALOG_PRODUCT_METADATA_RESPONSE",
+      "name": "CATALOG_PRODUCT_METADATA",
       "direction": "server_to_client",
       "header": 10081,
       "java": {
@@ -23837,39 +23921,7 @@
         "className": "CatalogProductMetadataMessageParser",
         "path": "packages/communication/src/messages/parser/catalog/metadata/CatalogProductMetadataMessageParser.ts"
       },
-      "reason": "The bounded response contains a dynamic list of product capability entries verified by dedicated packet tests"
-    },
-    {
-      "name": "CATALOG_RUNTIME_CONFIGURATION_REQUEST",
-      "direction": "client_to_server",
-      "header": 10082,
-      "java": {
-        "symbol": "CatalogRuntimeConfigurationEvent",
-        "className": "CatalogRuntimeConfigurationEvent",
-        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/CatalogRuntimeConfigurationEvent.java"
-      },
-      "typescript": {
-        "symbol": "CATALOG_RUNTIME_CONFIGURATION",
-        "className": "CatalogRuntimeConfigurationComposer",
-        "path": "packages/communication/src/messages/outgoing/catalog/configuration/CatalogRuntimeConfigurationComposer.ts"
-      },
-      "reason": "The optional versioned request keeps the standard recycler packets unchanged"
-    },
-    {
-      "name": "CATALOG_RUNTIME_CONFIGURATION_RESPONSE",
-      "direction": "server_to_client",
-      "header": 10082,
-      "java": {
-        "symbol": "CatalogRuntimeConfigurationComposer",
-        "className": "CatalogRuntimeConfigurationComposer",
-        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/catalog/CatalogRuntimeConfigurationComposer.java"
-      },
-      "typescript": {
-        "symbol": "CATALOG_RUNTIME_CONFIGURATION",
-        "className": "CatalogRuntimeConfigurationMessageParser",
-        "path": "packages/communication/src/messages/parser/catalog/configuration/CatalogRuntimeConfigurationMessageParser.ts"
-      },
-      "reason": "The bounded response carries emulator-authoritative catalog runtime settings without extending standard packets"
+      "reason": "Java analyzer: Data-dependent packet operations in ForStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
     }
   ]
 }


### PR DESCRIPTION
## Why

Soundboard pads are the only audio in the stack that does not come from the asset pipeline. Today the files live inside the client bundle and staff type a URL into `soundboard_sounds` by hand from the Housekeeping tab.

This moves the pad's identity into the assets — `nitro-assets/sounds/soundboard` plus a `gamedata/SoundData.json` manifest, the same split furniture has between its bundles and `FurnitureData.json` — and leaves this table with what is genuinely hotel policy: `enabled`, `sort_order`, `min_rank`.

## Schema

`classname` is added, backfilled from the basename of the existing URLs (`/sounds/soundboard/campanella.mp3` -> `campanella`), and uniquely indexed.

It is **NULLable on purpose**: the unique index has to tolerate many url-only rows, and MySQL treats repeated NULLs as distinct while rejecting repeated empty strings. Rows the backfill claimed get their now-redundant client-bundle path cleared; anything that did not yield a usable classname keeps its URL untouched.

`url` survives as an optional override for clips hosted outside the asset tree. A pad needs a classname **or** a url — never neither — which is what the new `SoundboardClassnamePolicy.isAddressable` enforces. The classname alphabet is deliberately narrow (`^[a-z0-9_-]{1,64}$`) because the value ends up in a URL path segment client-side.

## Wire shape

The settings and catalog composers append the classnames as a **block after the sound records**, not as a trailing field inside the loop. A client that predates this stops reading at the end of the records; one that reads a per-record optional field would steal bytes from the next record and cascade-corrupt the list. `SoundboardPlayComposer` is a single record, so a plain trailing field is fine there.

The upsert handler reads the trailing classname only when the client actually sent it, so an older client keeps working by URL.

## Verification

`mvn -Dtest='Soundboard*' test` — green. The packet contract tests were extended to assert the new trailing block rather than relaxed.

## Pairing

- duckietm/Octane-Renderer#191 — reads the classname off the wire (**merge first**)
- duckietm/Octane — resolves classname -> manifest -> file