### PR TITLE
fix: restore a green build on dev

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/highscores/WiredHighscoreDataEntry.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/highscores/WiredHighscoreDataEntry.java
@@ -4,8 +4,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WiredHighscoreDataEntry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WiredHighscoreDataEntry.class);
+
     private final int itemId;
     private final List<Integer> userIds;
     private final int score;
@@ -39,6 +43,7 @@ public class WiredHighscoreDataEntry {
             return ids;
         }
 
+        int skipped = 0;
         for (String token : raw.split(",")) {
             String trimmed = token.trim();
             if (trimmed.isEmpty()) {
@@ -46,9 +51,17 @@ public class WiredHighscoreDataEntry {
             }
             try {
                 ids.add(Integer.valueOf(trimmed));
-            } catch (NumberFormatException ignored) {
-                // skip the malformed id rather than poisoning the whole load
+            } catch (NumberFormatException malformed) {
+                // Skip the malformed id rather than poisoning the whole load, but
+                // count it so the row is not discarded in complete silence.
+                skipped++;
             }
+        }
+
+        if (skipped > 0) {
+            // Bounded and redacted on purpose: one line per row, counts only, so a
+            // corrupted column cannot flood the log or echo its contents back.
+            LOGGER.debug("Skipped {} malformed highscore user id(s) while loading a wired highscore row", skipped);
         }
 
         return ids;

--- a/Emulator/src/main/resources/db/migration/V20260518000000__base_database.sql
+++ b/Emulator/src/main/resources/db/migration/V20260518000000__base_database.sql
@@ -15222,8 +15222,6 @@ INSERT INTO `emulator_settings` (`key`, `value`, `comment`) VALUES
 	('wired.tick.thread.priority', '6', ''),
 	('wired.tick.workers', '6', ''),
 	('ws.nitro.host', '0.0.0.0', ''),
-	('ws.ip.header.trusted', '0.0.0.0', 'If you use your own proxy server like Traefik then put the proxy IP here if not leave blanc'),
-	('ws.whitelist', '', 'Place here the API domainname'),
 	('ws.nitro.ip.header', 'X-Forwarded-For', ''),
 	('ws.nitro.port', '2096', '');
 /*!40000 ALTER TABLE `emulator_settings` ENABLE KEYS */;

--- a/Emulator/src/main/resources/db/migration/V20260824200000__ws_proxy_settings.sql
+++ b/Emulator/src/main/resources/db/migration/V20260824200000__ws_proxy_settings.sql
@@ -1,0 +1,9 @@
+-- ws.ip.header.trusted and ws.whitelist were added directly to the applied
+-- baseline, which changes its Flyway checksum and makes every existing hotel
+-- fail validation on the next start. The baseline is restored and the two
+-- settings move forward into this migration instead.
+-- ON DUPLICATE KEY UPDATE value=value keeps any tuned value intact.
+INSERT INTO `emulator_settings` (`key`, `value`, `comment`) VALUES
+	('ws.ip.header.trusted', '0.0.0.0', 'If you use your own proxy server like Traefik then put the proxy IP here if not leave blanc'),
+	('ws.whitelist', '', 'Place here the API domainname')
+ON DUPLICATE KEY UPDATE `value` = `value`;

--- a/Emulator/src/test/java/com/eu/habbo/build/MavenBuildEnvironmentContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/build/MavenBuildEnvironmentContractTest.java
@@ -53,7 +53,7 @@ class MavenBuildEnvironmentContractTest {
 
         assertTrue(Files.isRegularFile(Path.of("mvnw")));
         assertTrue(Files.isRegularFile(Path.of("mvnw.cmd")));
-        assertTrue(properties.getProperty("distributionUrl").contains("apache-maven/3.9.11/"));
+        assertTrue(properties.getProperty("distributionUrl").contains("apache-maven/3.9.16/"));
         assertTrue(properties.getProperty("distributionSha256Sum").matches("[a-f0-9]{64}"));
     }
 

--- a/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
+++ b/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
@@ -3502,6 +3502,7 @@ METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraV
 
 TYPE public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem extends com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#CODE:int
+FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#MAX_LEVEL:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#MODE_EXPONENTIAL:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#MODE_LINEAR:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#MODE_MANUAL:int
@@ -5115,6 +5116,7 @@ METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomBan(int):v
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomDiagnostics(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomDiagnosticsLogs(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomExecutionCaches(int):void throws -
+METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomIndexCaches(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomRateLimiters(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomRecursionDepth(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomSourceStackCache(int):void throws -


### PR DESCRIPTION
Four contract tests are red on `dev` itself, so every open PR inherits a failing `Build + unit + integration` and `JDK 26 package compatibility`.

**1. Maven wrapper contract.** The wrapper is pinned to Maven 3.9.16 but `MavenBuildEnvironmentContractTest` still asserts `apache-maven/3.9.11/`. Aligns the assertion with the pinned distribution.

**2. Wired plugin surface baseline.** `WiredEngine.clearRoomIndexCaches(int)` and `WiredExtraVariableLevelUpSystem.MAX_LEVEL` landed without regenerating `public-surface-v1.txt`. Compatibility review, as the test requires before regenerating: 5779 → 5781 entries, **two additions, zero removals**, so no plugin-visible descriptor changed.

**3. Applied baseline was edited.** `ws.ip.header.trusted` and `ws.whitelist` were appended to `V20260518000000__base_database.sql`, which is already applied everywhere. That changes its Flyway checksum, so **every existing hotel fails validation on the next start** — exactly what `CatalogMigrationImmutabilityContractTest` guards. The baseline is restored to its recorded checksum and both settings move forward into `V20260824200000__ws_proxy_settings.sql`, idempotent via `ON DUPLICATE KEY UPDATE`. No setting is lost.

**4. Silent wired catch block.** `WiredHighscoreDataEntry.parseUserIds` swallowed `NumberFormatException` with an empty body. Now counts the skipped ids and emits one bounded, redacted debug line per row; the defensive parsing behaviour is unchanged.

Verified locally on this branch (`dev` + these commits): `MavenBuildEnvironmentContractTest` 3/3, `WiredPublicSurfaceCompatibilityTest` 1/1, `CatalogMigrationImmutabilityContractTest` 1/1, `WiredModernizationQualityGateTest` 3/3, `spotless:check` clean.