### PR TITLE
test: align the Maven wrapper contract with 3.9.16

### DIFF
--- a/Emulator/src/test/java/com/eu/habbo/build/MavenBuildEnvironmentContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/build/MavenBuildEnvironmentContractTest.java
@@ -53,7 +53,7 @@ class MavenBuildEnvironmentContractTest {
 
         assertTrue(Files.isRegularFile(Path.of("mvnw")));
         assertTrue(Files.isRegularFile(Path.of("mvnw.cmd")));
-        assertTrue(properties.getProperty("distributionUrl").contains("apache-maven/3.9.11/"));
+        assertTrue(properties.getProperty("distributionUrl").contains("apache-maven/3.9.16/"));
         assertTrue(properties.getProperty("distributionSha256Sum").matches("[a-f0-9]{64}"));
     }
 


### PR DESCRIPTION
The wrapper is pinned to Maven 3.9.16, but `MavenBuildEnvironmentContractTest` still asserts `apache-maven/3.9.11/`, so the pin check fails on every branch.

Aligns the assertion with the pinned distribution. No build behaviour changes.

Verified: `MavenBuildEnvironmentContractTest` 3/3 on `dev` + this commit.

---
`dev` currently has four independent contract failures, so this branch's CI still shows the ones the other PRs fix. Only the check named below is in scope here.