### PR TITLE
test(wired): refresh the plugin surface baseline

### DIFF
--- a/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
+++ b/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
@@ -3502,6 +3502,7 @@ METHOD public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraV
 
 TYPE public com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem extends com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#CODE:int
+FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#MAX_LEVEL:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#MODE_EXPONENTIAL:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#MODE_LINEAR:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.extra.WiredExtraVariableLevelUpSystem#MODE_MANUAL:int
@@ -5115,6 +5116,7 @@ METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomBan(int):v
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomDiagnostics(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomDiagnosticsLogs(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomExecutionCaches(int):void throws -
+METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomIndexCaches(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomRateLimiters(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomRecursionDepth(int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredEngine#clearRoomSourceStackCache(int):void throws -


### PR DESCRIPTION
`WiredEngine.clearRoomIndexCaches(int)` and `WiredExtraVariableLevelUpSystem.MAX_LEVEL` landed without regenerating `public-surface-v1.txt`, so `WiredPublicSurfaceCompatibilityTest` fails.

Compatibility review, which the test requires before regenerating: the surface goes from 5779 to 5781 entries — **two additions, zero removals**. No public or protected descriptor changed, so existing plugins keep linking. Regenerated with `-Dpolaris.wired.api.regenerate=true`.

Verified: `WiredPublicSurfaceCompatibilityTest` 1/1 on `dev` + this commit.

---
`dev` currently has four independent contract failures, so this branch's CI still shows the ones the other PRs fix. Only the check named below is in scope here.