### PR TITLE
fix(db): stop editing the applied baseline migration

### DIFF
--- a/Emulator/src/main/resources/db/migration/V20260518000000__base_database.sql
+++ b/Emulator/src/main/resources/db/migration/V20260518000000__base_database.sql
@@ -15222,8 +15222,6 @@ INSERT INTO `emulator_settings` (`key`, `value`, `comment`) VALUES
 	('wired.tick.thread.priority', '6', ''),
 	('wired.tick.workers', '6', ''),
 	('ws.nitro.host', '0.0.0.0', ''),
-	('ws.ip.header.trusted', '0.0.0.0', 'If you use your own proxy server like Traefik then put the proxy IP here if not leave blanc'),
-	('ws.whitelist', '', 'Place here the API domainname'),
 	('ws.nitro.ip.header', 'X-Forwarded-For', ''),
 	('ws.nitro.port', '2096', '');
 /*!40000 ALTER TABLE `emulator_settings` ENABLE KEYS */;

--- a/Emulator/src/main/resources/db/migration/V20260824200000__ws_proxy_settings.sql
+++ b/Emulator/src/main/resources/db/migration/V20260824200000__ws_proxy_settings.sql
@@ -1,0 +1,9 @@
+-- ws.ip.header.trusted and ws.whitelist were added directly to the applied
+-- baseline, which changes its Flyway checksum and makes every existing hotel
+-- fail validation on the next start. The baseline is restored and the two
+-- settings move forward into this migration instead.
+-- ON DUPLICATE KEY UPDATE value=value keeps any tuned value intact.
+INSERT INTO `emulator_settings` (`key`, `value`, `comment`) VALUES
+	('ws.ip.header.trusted', '0.0.0.0', 'If you use your own proxy server like Traefik then put the proxy IP here if not leave blanc'),
+	('ws.whitelist', '', 'Place here the API domainname')
+ON DUPLICATE KEY UPDATE `value` = `value`;


### PR DESCRIPTION
`ws.ip.header.trusted` and `ws.whitelist` were appended to `V20260518000000__base_database.sql`, which is already applied on every hotel. Editing it changes its Flyway checksum, so **existing installations fail validation on the next start**. That is what `CatalogMigrationImmutabilityContractTest` guards, and it is currently red.

- Restores the baseline to its recorded checksum (`2ADF4D31…`).
- Reintroduces both settings through a forward migration, `V20260824200000__ws_proxy_settings.sql`, idempotent via `ON DUPLICATE KEY UPDATE`.

No setting is lost: a fresh install gets them from the new migration, and an existing hotel picks them up on the next start without a checksum break.

Verified: `CatalogMigrationImmutabilityContractTest` 1/1 on `dev` + this commit.

---
`dev` currently has four independent contract failures, so this branch's CI still shows the ones the other PRs fix. Only the check named below is in scope here.