### PR TITLE
fix(wired): bound the malformed highscore id diagnostic

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/highscores/WiredHighscoreDataEntry.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/highscores/WiredHighscoreDataEntry.java
@@ -43,6 +43,7 @@ public class WiredHighscoreDataEntry {
             return ids;
         }
 
+        int skipped = 0;
         for (String token : raw.split(",")) {
             String trimmed = token.trim();
             if (trimmed.isEmpty()) {
@@ -51,10 +52,16 @@ public class WiredHighscoreDataEntry {
             try {
                 ids.add(Integer.valueOf(trimmed));
             } catch (NumberFormatException malformed) {
-                // Skip the malformed id rather than poisoning the whole load,
-                // but emit a bounded diagnostic (length only, value redacted).
-                LOGGER.warn("Skipping malformed highscore user id (length {})", trimmed.length());
+                // Skip the malformed id rather than poisoning the whole load, but
+                // count it so the row is not discarded in complete silence.
+                skipped++;
             }
+        }
+
+        if (skipped > 0) {
+            // Bounded and redacted on purpose: one line per row, counts only, so a
+            // corrupted column cannot flood the log or echo its contents back.
+            LOGGER.debug("Skipped {} malformed highscore user id(s) while loading a wired highscore row", skipped);
         }
 
         return ids;


### PR DESCRIPTION
## What changed since the first revision

This PR originally proposed reporting skipped highscore ids instead of swallowing them. `dev` has since done exactly that — but with **one `LOGGER.warn` per malformed id**.

That is the part worth revisiting. `parseIds` walks a comma-separated column; if that column is corrupted, the ids are malformed *together*, so a single bad row becomes a burst of WARN lines. A diagnostic whose cost scales with the corruption is the one you end up regretting during an incident.

## Approach

Count the skipped ids and emit **one DEBUG per row**:

```java
int skipped = 0;
...
} catch (NumberFormatException malformed) {
    skipped++;
}
...
if (skipped > 0) {
    LOGGER.debug("Skipped {} malformed highscore user id(s) while loading a wired highscore row", skipped);
}
```

Same guarantee `dev` wanted — the row is no longer discarded in silence — but bounded by construction, and still redacted: counts only, never the offending value, not even its length.

Rebased on current `dev`, so the conflict with the per-id version is resolved in favour of this one.

## Verification

`mvn -Dtest='WiredHighscore*,WiredPublicSurface*,MavenBuildEnvironment*' test` — green.