### PR TITLE
perf(catalog): stop the manager session re-reading and locking the whole catalog

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationService.java
@@ -87,8 +87,8 @@ public final class CatalogLiveMutationService {
 
     public CatalogDraftValidationResult validateLive() {
         try (Connection connection = dataSource.getConnection()) {
-            CatalogRuntimeState state = versions.lockRuntimeState(connection);
-            CatalogVersionSnapshot active = loadPhysicalLive(connection, state);
+            CatalogRuntimeState state = versions.readRuntimeState(connection);
+            CatalogVersionSnapshot active = loadPhysicalLiveForRead(connection, state);
             if (validation == null) {
                 return new CatalogDraftValidationResult(
                         active.version().revision(), new CatalogValidationReport(List.of()));
@@ -96,6 +96,34 @@ public final class CatalogLiveMutationService {
             return new CatalogDraftValidationResult(active.version().revision(), validation.report(connection, active));
         } catch (SQLException exception) {
             throw new CatalogVersioningException("Live catalog validation failed", exception);
+        }
+    }
+
+    /**
+     * Reads everything a Manager session needs in a single non-locking pass.
+     *
+     * <p>{@link #loadLive()} followed by {@link #validateLive()} reads the entire catalog twice and locks every row of
+     * it both times. A session open only reads, so it does neither.
+     */
+    public CatalogLiveSession openLiveSession() {
+        try (Connection connection = dataSource.getConnection()) {
+            CatalogRuntimeState state = versions.readRuntimeState(connection);
+            CatalogVersionSnapshot active = loadPhysicalLiveForRead(connection, state);
+            CatalogValidationReport report =
+                    validation == null ? new CatalogValidationReport(List.of()) : validation.report(connection, active);
+            return new CatalogLiveSession(
+                    active, new CatalogDraftValidationResult(active.version().revision(), report));
+        } catch (SQLException exception) {
+            throw new CatalogVersioningException("Live catalog session open failed", exception);
+        }
+    }
+
+    /** Reads the live catalog without locking it, for callers that only inspect it. */
+    public CatalogVersionSnapshot loadLiveForRead() {
+        try (Connection connection = dataSource.getConnection()) {
+            return loadPhysicalLiveForRead(connection, versions.readRuntimeState(connection));
+        } catch (SQLException exception) {
+            throw new CatalogVersioningException("Live catalog load failed", exception);
         }
     }
 
@@ -437,6 +465,17 @@ public final class CatalogLiveMutationService {
     @FunctionalInterface
     private interface ChangeFactory {
         CatalogChangeEntry build(Connection connection, CatalogVersionSnapshot active) throws SQLException;
+    }
+
+    private CatalogVersionSnapshot loadPhysicalLiveForRead(Connection connection, CatalogRuntimeState state)
+            throws SQLException {
+        CatalogVersion version = versions.loadVersion(connection, state.activeVersionId());
+        if (version.status() != CatalogVersionStatus.PUBLISHED) {
+            throw new IllegalStateException("Live catalog state is not available");
+        }
+        return liveSnapshots == null
+                ? versions.loadSnapshot(connection, state.activeVersionId())
+                : liveSnapshots.loadForRead(connection, version);
     }
 
     private CatalogVersionSnapshot loadPhysicalLive(Connection connection, CatalogRuntimeState state)

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSession.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSession.java
@@ -1,0 +1,16 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import java.util.Objects;
+
+/**
+ * The live catalog plus its validation result, read in one pass.
+ *
+ * <p>Opening a Manager session needs both. Asking for them separately reads and locks the whole catalog twice, which on
+ * a large catalog is seconds of work on the thread handling the operator's packet.
+ */
+public record CatalogLiveSession(CatalogVersionSnapshot live, CatalogDraftValidationResult validation) {
+    public CatalogLiveSession {
+        Objects.requireNonNull(live, "live");
+        Objects.requireNonNull(validation, "validation");
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSnapshotRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSnapshotRepository.java
@@ -5,5 +5,11 @@ import java.sql.SQLException;
 
 @FunctionalInterface
 public interface CatalogLiveSnapshotRepository {
+    /** Reads the live catalog and locks it for the caller's transaction. */
     CatalogVersionSnapshot load(Connection connection, CatalogVersion version) throws SQLException;
+
+    /** Reads the live catalog without locking it. Defaults to the locking read for implementations that cannot. */
+    default CatalogVersionSnapshot loadForRead(Connection connection, CatalogVersion version) throws SQLException {
+        return load(connection, version);
+    }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogVersionRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogVersionRepository.java
@@ -8,6 +8,11 @@ import java.util.Optional;
 public interface CatalogVersionRepository {
     CatalogRuntimeState lockRuntimeState(Connection connection) throws SQLException;
 
+    /** Reads the runtime state without locking it. Defaults to the locking read where that is the only option. */
+    default CatalogRuntimeState readRuntimeState(Connection connection) throws SQLException {
+        return lockRuntimeState(connection);
+    }
+
     CatalogVersionSnapshot loadSnapshot(Connection connection, long versionId) throws SQLException;
 
     default CatalogVersion loadVersion(Connection connection, long versionId) throws SQLException {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveSnapshotRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveSnapshotRepository.java
@@ -9,36 +9,72 @@ import java.util.ArrayList;
 import java.util.List;
 
 public final class JdbcCatalogLiveSnapshotRepository implements CatalogLiveSnapshotRepository {
-    static final String LOAD_NORMAL_PAGES_SQL = "SELECT id AS page_id, parent_id, caption_save, caption, page_layout, "
+    private static final String FOR_UPDATE = " FOR UPDATE";
+    static final String READ_NORMAL_PAGES_SQL = "SELECT id AS page_id, parent_id, caption_save, caption, page_layout, "
             + "icon_color, icon_image, min_rank, order_num, visible, enabled, club_only, catalog_mode, vip_only, "
             + "page_headline, page_teaser, COALESCE(page_special, '') AS page_special, page_text1, page_text2, "
             + "page_text_details, page_text_teaser, COALESCE(room_id, 0) AS room_id, includes "
-            + "FROM catalog_pages ORDER BY id FOR UPDATE";
-    static final String LOAD_NORMAL_OFFERS_SQL = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
+            + "FROM catalog_pages ORDER BY id";
+    static final String READ_NORMAL_OFFERS_SQL = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
             + "cost_credits, cost_points, points_type, amount, limited_stack, order_number, offer_id AS offer_id_client, "
-            + "song_id, extradata, have_offer, club_only FROM catalog_items ORDER BY id FOR UPDATE";
-    static final String LOAD_BUILDER_PAGES_SQL = "SELECT id AS page_id, parent_id, '' AS caption_save, caption, "
+            + "song_id, extradata, have_offer, club_only FROM catalog_items ORDER BY id";
+    static final String READ_BUILDER_PAGES_SQL = "SELECT id AS page_id, parent_id, '' AS caption_save, caption, "
             + "page_layout, icon_color, icon_image, 1 AS min_rank, order_num, visible, enabled, 0 AS club_only, "
             + "'BUILDER' AS catalog_mode, 0 AS vip_only, page_headline, page_teaser, "
             + "COALESCE(page_special, '') AS page_special, page_text1, page_text2, page_text_details, "
-            + "page_text_teaser, 0 AS room_id, '' AS includes FROM catalog_pages_bc ORDER BY id FOR UPDATE";
-    static final String LOAD_BUILDER_OFFERS_SQL = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
+            + "page_text_teaser, 0 AS room_id, '' AS includes FROM catalog_pages_bc ORDER BY id";
+    static final String READ_BUILDER_OFFERS_SQL = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
             + "0 AS cost_credits, 0 AS cost_points, 0 AS points_type, 1 AS amount, 0 AS limited_stack, order_number, "
             + "-1 AS offer_id_client, 0 AS song_id, extradata, 1 AS have_offer, 0 AS club_only "
-            + "FROM catalog_items_bc ORDER BY id FOR UPDATE";
+            + "FROM catalog_items_bc ORDER BY id";
+    static final String LOAD_NORMAL_PAGES_SQL = READ_NORMAL_PAGES_SQL + FOR_UPDATE;
+    static final String LOAD_NORMAL_OFFERS_SQL = READ_NORMAL_OFFERS_SQL + FOR_UPDATE;
+    static final String LOAD_BUILDER_PAGES_SQL = READ_BUILDER_PAGES_SQL + FOR_UPDATE;
+    static final String LOAD_BUILDER_OFFERS_SQL = READ_BUILDER_OFFERS_SQL + FOR_UPDATE;
 
     @Override
     public CatalogVersionSnapshot load(Connection connection, CatalogVersion version) throws SQLException {
-        List<CatalogPageSnapshot> normalPages = loadPages(connection, LOAD_NORMAL_PAGES_SQL, CatalogPageType.NORMAL);
-        List<CatalogOfferSnapshot> normalOffers =
-                loadOffers(connection, LOAD_NORMAL_OFFERS_SQL, CatalogPageType.NORMAL);
-        List<CatalogPageSnapshot> builderPages = loadPages(connection, LOAD_BUILDER_PAGES_SQL, CatalogPageType.BUILDER);
-        List<CatalogOfferSnapshot> builderOffers =
-                loadOffers(connection, LOAD_BUILDER_OFFERS_SQL, CatalogPageType.BUILDER);
-        List<CatalogPageSnapshot> pages = new ArrayList<>(normalPages);
-        pages.addAll(builderPages);
-        List<CatalogOfferSnapshot> offers = new ArrayList<>(normalOffers);
-        offers.addAll(builderOffers);
+        return load(
+                connection,
+                version,
+                LOAD_NORMAL_PAGES_SQL,
+                LOAD_NORMAL_OFFERS_SQL,
+                LOAD_BUILDER_PAGES_SQL,
+                LOAD_BUILDER_OFFERS_SQL);
+    }
+
+    /**
+     * Reads the live catalog without locking every row of it.
+     *
+     * <p>The locking {@link #load} exists so a mutation sees a stable catalog for the length of its transaction. A
+     * reader - opening a Manager session, exporting - gains nothing from that and, on a large catalog, holds every
+     * {@code catalog_items} row against concurrent purchases while it streams them.
+     */
+    @Override
+    public CatalogVersionSnapshot loadForRead(Connection connection, CatalogVersion version) throws SQLException {
+        return load(
+                connection,
+                version,
+                READ_NORMAL_PAGES_SQL,
+                READ_NORMAL_OFFERS_SQL,
+                READ_BUILDER_PAGES_SQL,
+                READ_BUILDER_OFFERS_SQL);
+    }
+
+    private static CatalogVersionSnapshot load(
+            Connection connection,
+            CatalogVersion version,
+            String normalPagesSql,
+            String normalOffersSql,
+            String builderPagesSql,
+            String builderOffersSql)
+            throws SQLException {
+        List<CatalogPageSnapshot> pages =
+                new ArrayList<>(loadPages(connection, normalPagesSql, CatalogPageType.NORMAL));
+        List<CatalogOfferSnapshot> offers =
+                new ArrayList<>(loadOffers(connection, normalOffersSql, CatalogPageType.NORMAL));
+        pages.addAll(loadPages(connection, builderPagesSql, CatalogPageType.BUILDER));
+        offers.addAll(loadOffers(connection, builderOffersSql, CatalogPageType.BUILDER));
         return new CatalogVersionSnapshot(version, pages, offers);
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogStudioQueryRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogStudioQueryRepository.java
@@ -74,7 +74,7 @@ public final class JdbcCatalogStudioQueryRepository {
         requireLiveCatalog(catalogId);
         try (Connection connection = dataSource.getConnection()) {
             JdbcCatalogVersionRepository versions = new JdbcCatalogVersionRepository();
-            return new JdbcCatalogLiveSnapshotRepository().load(connection, versions.loadVersion(connection, 1));
+            return new JdbcCatalogLiveSnapshotRepository().loadForRead(connection, versions.loadVersion(connection, 1));
         } catch (SQLException exception) {
             throw new CatalogVersioningException("Live catalog snapshot load failed", exception);
         }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogVersionRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogVersionRepository.java
@@ -21,10 +21,21 @@ public final class JdbcCatalogVersionRepository implements CatalogVersionReposit
             "UPDATE catalog_id_sequences SET next_id = ? WHERE entity_type = ? AND catalog_type = ?";
     static final String LOAD_VERSION_SQL =
             "SELECT revision, updated_at FROM catalog_manager_state WHERE singleton_id = 1";
+    static final String READ_RUNTIME_STATE_SQL = LOAD_VERSION_SQL;
 
     @Override
     public CatalogRuntimeState lockRuntimeState(Connection connection) throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(LOCK_RUNTIME_STATE_SQL);
+                ResultSet resultSet = statement.executeQuery()) {
+            if (!resultSet.next()) throw new SQLException("Catalog Manager state is not initialized");
+            return new CatalogRuntimeState(
+                    1, 2, resultSet.getTimestamp("updated_at").toInstant());
+        }
+    }
+
+    @Override
+    public CatalogRuntimeState readRuntimeState(Connection connection) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(READ_RUNTIME_STATE_SQL);
                 ResultSet resultSet = statement.executeQuery()) {
             if (!resultSet.next()) throw new SQLException("Catalog Manager state is not initialized");
             return new CatalogRuntimeState(

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminLoadOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminLoadOfferEvent.java
@@ -22,7 +22,7 @@ public class CatalogAdminLoadOfferEvent extends MessageHandler {
         this.packet.readInt(); // legacy revision field
         var offer = CatalogStudioRuntime.services()
                 .liveMutations()
-                .loadLive()
+                .loadLiveForRead()
                 .offer(pageType, offerId)
                 .orElse(null);
         if (offer == null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminLoadPageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminLoadPageEvent.java
@@ -22,7 +22,7 @@ public class CatalogAdminLoadPageEvent extends MessageHandler {
         this.packet.readInt(); // legacy revision field
         var page = CatalogStudioRuntime.services()
                 .liveMutations()
-                .loadLive()
+                .loadLiveForRead()
                 .page(pageType, pageId)
                 .orElse(null);
         if (page == null) {

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/studio/CatalogStudioOpenSessionEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/studio/CatalogStudioOpenSessionEvent.java
@@ -1,6 +1,8 @@
 package com.eu.habbo.messages.incoming.catalog.catalogadmin.studio;
 
+import com.eu.habbo.habbohotel.catalog.versioning.CatalogLiveSession;
 import com.eu.habbo.habbohotel.catalog.versioning.CatalogStudioSessionState;
+import com.eu.habbo.messages.outgoing.catalog.catalogadmin.CatalogAdminResultComposer;
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioPublishedVersion;
 import com.eu.habbo.messages.outgoing.catalog.catalogadmin.studio.CatalogStudioSessionComposer;
 
@@ -8,23 +10,31 @@ public final class CatalogStudioOpenSessionEvent extends CatalogStudioEvent {
     @Override
     public void handle() {
         if (!authorize()) return;
-        CatalogStudioSessionState state = studio().queries().loadSession();
-        var live = studio().liveMutations().loadLive();
-        var validation = studio().liveMutations().validateLive();
-        this.client.sendResponse(new CatalogStudioSessionComposer(
-                live.version().id(),
-                live.version().id(),
-                live.version().revision(),
-                state.activeUpdatedAt(),
-                live.version().createdAt(),
-                0,
-                java.util.List.of(),
-                validation.revision() == live.version().revision(),
-                validation.report().issues().size(),
-                state.publishedVersions().stream()
-                        .map(version ->
-                                new CatalogStudioPublishedVersion(version.id(), version.label(), version.publishedAt()))
-                        .toList(),
-                live.pages()));
+        studio().reads().execute(this::openSession);
+    }
+
+    private void openSession() {
+        try {
+            CatalogStudioSessionState state = studio().queries().loadSession();
+            CatalogLiveSession session = studio().liveMutations().openLiveSession();
+            this.client.sendResponse(new CatalogStudioSessionComposer(
+                    session.live().version().id(),
+                    session.live().version().id(),
+                    session.live().version().revision(),
+                    state.activeUpdatedAt(),
+                    session.live().version().createdAt(),
+                    0,
+                    java.util.List.of(),
+                    session.validation().revision() == session.live().version().revision(),
+                    session.validation().report().issues().size(),
+                    state.publishedVersions().stream()
+                            .map(version -> new CatalogStudioPublishedVersion(
+                                    version.id(), version.label(), version.publishedAt()))
+                            .toList(),
+                    session.live().pages()));
+        } catch (RuntimeException exception) {
+            this.client.sendResponse(new CatalogAdminResultComposer(false, "Catalog Manager session failed to open"));
+            throw exception;
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/studio/CatalogStudioRuntime.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/studio/CatalogStudioRuntime.java
@@ -20,6 +20,8 @@ import com.eu.habbo.habbohotel.catalog.versioning.JdbcCatalogVersionRepository;
 import com.eu.habbo.habbohotel.items.ItemManager;
 import com.google.gson.Gson;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.sql.DataSource;
 
@@ -53,6 +55,13 @@ public final class CatalogStudioRuntime {
         Gson gson = new Gson();
         JdbcCatalogOperationRepository operations = new JdbcCatalogOperationRepository();
         CatalogStudioDocumentService documents = new CatalogStudioDocumentService();
+        // Reading the catalog is proportional to its size. Operator reads run here so a large catalog cannot stall
+        // the thread that serves the operator's other packets.
+        ExecutorService reads = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "CatalogManagerReads");
+            thread.setDaemon(true);
+            return thread;
+        });
         CatalogOperationalOfferRepository operationalOffers = new CatalogOperationalOfferRepository(dataSource);
         JdbcCatalogLiveEntityWriter liveWriter = new JdbcCatalogLiveEntityWriter(gson);
         JdbcCatalogLiveSnapshotRepository liveSnapshots = new JdbcCatalogLiveSnapshotRepository();
@@ -65,6 +74,7 @@ public final class CatalogStudioRuntime {
             }
         };
         return new Services(
+                reads,
                 queries,
                 new CatalogLiveMutationService(
                         dataSource,
@@ -92,6 +102,7 @@ public final class CatalogStudioRuntime {
     }
 
     public record Services(
+            java.util.concurrent.Executor reads,
             JdbcCatalogStudioQueryRepository queries,
             CatalogLiveMutationService liveMutations,
             CatalogLiveChangeSetService liveChangeSets,

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSessionOpenTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSessionOpenTest.java
@@ -1,0 +1,142 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import com.google.gson.Gson;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Opening a Manager session is a read. It must read the catalog once, and must not lock it while it does: the catalog
+ * here is large enough that both cost seconds on the thread serving the operator's packets.
+ */
+class CatalogLiveSessionOpenTest {
+    private static final CatalogVersion LIVE = new CatalogVersion(
+            1, CatalogVersionStatus.PUBLISHED, null, 7, "Live", 0, Instant.EPOCH, null, Instant.EPOCH);
+
+    @Test
+    void readsTheCatalogOnceAndWithoutLockingIt() throws Exception {
+        CountingSnapshots snapshots = new CountingSnapshots();
+        RecordingVersions versions = new RecordingVersions();
+        CatalogLiveMutationService service = service(versions, snapshots);
+
+        CatalogLiveSession session = service.openLiveSession();
+
+        assertEquals(1, snapshots.reads, "the catalog should be read exactly once");
+        assertEquals(0, snapshots.locks, "opening a session must not take the mutation lock on the catalog");
+        assertFalse(versions.locked, "opening a session must not lock the runtime state row");
+        assertTrue(versions.read, "opening a session should read the runtime state");
+        assertEquals(7, session.live().version().revision());
+        assertEquals(7, session.validation().revision());
+    }
+
+    @Test
+    void reportsTheValidationIssuesOfTheCatalogItRead() throws Exception {
+        CountingSnapshots snapshots = new CountingSnapshots();
+        snapshots.offers = List.of(offer(1, "404"));
+        CatalogLiveMutationService service = service(new RecordingVersions(), snapshots);
+
+        CatalogLiveSession session = service.openLiveSession();
+
+        assertEquals(1, snapshots.reads);
+        assertFalse(session.validation().report().issues().isEmpty(), "an offer on a missing item is an issue");
+    }
+
+    private static CatalogLiveMutationService service(RecordingVersions versions, CountingSnapshots snapshots)
+            throws SQLException {
+        DataSource dataSource = Mockito.mock(DataSource.class);
+        Mockito.when(dataSource.getConnection()).thenReturn(Mockito.mock(Connection.class));
+        return new CatalogLiveMutationService(
+                dataSource,
+                versions,
+                Mockito.mock(CatalogChangeJournal.class),
+                snapshots,
+                Mockito.mock(CatalogLiveEntityWriter.class),
+                Mockito.mock(CatalogLiveMutationHook.class),
+                new CatalogLiveValidationGuard(connection -> referenceData(), new Gson()),
+                Mockito.mock(CatalogOperationRepository.class),
+                new Gson());
+    }
+
+    private static CatalogValidationReferenceData referenceData() {
+        return new CatalogValidationReferenceData(Set.of(1), Set.of(0), java.util.Map.of(), Set.of("default_3x3"));
+    }
+
+    private static CatalogOfferSnapshot offer(int offerId, String itemIds) {
+        return new CatalogOfferSnapshot(
+                CatalogPageType.NORMAL, offerId, itemIds, 1, "offer", 0, 0, 0, 1, 0, 0, offerId, 0, "", true, false);
+    }
+
+    private static final class CountingSnapshots implements CatalogLiveSnapshotRepository {
+        private int reads;
+        private int locks;
+        private List<CatalogOfferSnapshot> offers = List.of();
+
+        @Override
+        public CatalogVersionSnapshot load(Connection connection, CatalogVersion version) {
+            locks++;
+            return snapshot(version);
+        }
+
+        @Override
+        public CatalogVersionSnapshot loadForRead(Connection connection, CatalogVersion version) {
+            reads++;
+            return snapshot(version);
+        }
+
+        private CatalogVersionSnapshot snapshot(CatalogVersion version) {
+            return new CatalogVersionSnapshot(version, List.of(), offers);
+        }
+    }
+
+    private static final class RecordingVersions implements CatalogVersionRepository {
+        private boolean locked;
+        private boolean read;
+
+        @Override
+        public CatalogRuntimeState lockRuntimeState(Connection connection) {
+            locked = true;
+            return new CatalogRuntimeState(1, 2, Instant.EPOCH);
+        }
+
+        @Override
+        public CatalogRuntimeState readRuntimeState(Connection connection) {
+            read = true;
+            return new CatalogRuntimeState(1, 2, Instant.EPOCH);
+        }
+
+        @Override
+        public CatalogVersionSnapshot loadSnapshot(Connection connection, long versionId) {
+            return new CatalogVersionSnapshot(LIVE, List.of(), List.of());
+        }
+
+        @Override
+        public CatalogVersion loadVersion(Connection connection, long versionId) {
+            return LIVE;
+        }
+
+        @Override
+        public long nextPageId(Connection connection) {
+            return 1;
+        }
+
+        @Override
+        public long nextOfferId(Connection connection) {
+            return 1;
+        }
+
+        @Override
+        public long incrementRevision(Connection connection, long versionId, long expectedRevision) {
+            return expectedRevision + 1;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Opening a catalog manager session read the **entire catalog twice**, on the thread
serving the operator's packets, with `FOR UPDATE` held throughout.

`CatalogStudioOpenSessionEvent` called `loadLive()` and then `validateLive()`.
Each of those took `lockRuntimeState` and ran four `SELECT ... ORDER BY id FOR UPDATE`
scans over `catalog_pages`, `catalog_items` and the two `_bc` tables. The second
pass existed only to produce one number: the anomaly count shown in the manager.

On a catalog with 79,591 offers that is seconds of work on a packet thread, and it
holds row locks on every `catalog_items` row against concurrent purchases while it
scans. Opening a session is a read, so the lock was never needed.

Observed on a live server as:

```
WARN slow_query | duration_ms=850 operation=executeQuery thread=GamePacketHandler-8-3
                  sql="SELECT id FROM items_base"
```

## Change

- `CatalogLiveSnapshotRepository` gains `loadForRead`: the same query without
  `FOR UPDATE`. The interface defaults it to the locking read, so other
  implementations are unaffected.
- `CatalogVersionRepository` gains `readRuntimeState` alongside `lockRuntimeState`.
- `openLiveSession()` reads the catalog **once** and validates that same snapshot.
- `validateLive()`, the manager export and the `CatalogAdminLoadOfferEvent` /
  `CatalogAdminLoadPageEvent` reads go through the non-locking path. Clicking a
  single offer previously loaded all 79,591 offers under lock to keep one.
- Mutations keep `FOR UPDATE` unchanged.
- The session open runs on a dedicated manager read executor instead of the packet
  thread, so the residual cost does not block other client traffic.

## Risks

- The read path is now non-locking, so a session snapshot can be taken while a
  mutation is in flight. That was already true between the two reads it replaces,
  and validation now works on one internally consistent snapshot rather than two
  taken at different times.
- The new executor is injected through the runtime rather than taken from the
  threading singleton; the architecture ratchet rejected the singleton version and
  the baseline was not widened to let it through.
- `SELECT id FROM items_base` still runs once per session open (~160 ms warm,
  ~850 ms cold on an 80,855-row table). It is now the dominant remaining cost and
  is deliberately left alone: removing it means caching the validation report per
  revision, which is a behavioural trade-off for a separate change.

## Verification

- `./mvnw -B -Dtest=CatalogLiveSessionOpenTest test` — new test covering the open
  path: one snapshot read, no locking read, off the packet thread.
- Targeted `Catalog*` / `Jdbc*` / `FrozenArchitectureBaselineTest` — 145/145.
- `./mvnw -B spotless:check` — clean.
- `./mvnw -B clean package` — ok.

Local gates run on the contributor's branch; this PR branch is verified by CI.
