### PR TITLE
fix(catalog): stop reporting folder pages as broken ancestors

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidator.java
@@ -119,23 +119,28 @@ public final class CatalogValidator {
         }
     }
 
+    /**
+     * A page is reachable in the client when every ancestor is visible: the index only descends into
+     * visible children. A visible ancestor that is disabled is not a defect - that is how a folder
+     * node is expressed, shown in the tree but sent with id -1 so it expands instead of opening.
+     */
     private void validateAncestors(
             CatalogVersionSnapshot snapshot, CatalogPageSnapshot page, List<CatalogValidationIssue> issues) {
-        if (!page.visible() && !page.enabled()) return;
+        if (!page.visible()) return;
         Set<Integer> visited = new HashSet<>();
         int parentId = page.parentId();
         while (parentId > 0 && visited.add(parentId)) {
             CatalogPageSnapshot parent =
                     snapshot.page(page.catalogType(), parentId).orElse(null);
             if (parent == null) return;
-            if (!parent.visible() || !parent.enabled()) {
+            if (!parent.visible()) {
                 add(
                         issues,
                         "PAGE_ANCESTOR_NOT_AVAILABLE",
                         CatalogEntityType.PAGE,
                         page.pageId(),
                         "parentId",
-                        "Visible and enabled page has a hidden or disabled ancestor");
+                        "Visible page is unreachable: ancestor page " + parent.pageId() + " is hidden");
                 return;
             }
             parentId = parent.parentId();

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidatorTest.java
@@ -100,6 +100,25 @@ class CatalogValidatorTest {
                 "OFFER_LIMITED_STACK_BELOW_SALES");
     }
 
+    @Test
+    void treatsAVisibleButDisabledAncestorAsAFolderAndNotAnError() {
+        CatalogVersionSnapshot snapshot = snapshot(
+                List.of(
+                        page(1, -1, 0, true, true, "root", ""),
+                        page(2, 1, 0, true, false, "default_3x3", ""),
+                        page(3, 2, 0, true, true, "default_3x3", ""),
+                        page(4, -1, 1, false, true, "root", ""),
+                        page(5, 4, 0, true, true, "default_3x3", "")),
+                List.of());
+
+        CatalogValidationReport report = validator(Set.of(), Set.of(), Map.of()).validate(snapshot);
+
+        assertCodes(report, "PAGE_ANCESTOR_NOT_AVAILABLE");
+        assertEquals(
+                List.of(5),
+                report.issues().stream().map(CatalogValidationIssue::entityId).toList());
+    }
+
     private static CatalogValidator validator(
             Set<Integer> itemIds, Set<Integer> currencyTypes, Map<Integer, Integer> liveLimitedSells) {
         return new CatalogValidator(itemIds, currencyTypes, liveLimitedSells, Set.of("root", "default_3x3"));


### PR DESCRIPTION
## Problem

The catalog manager reported every page nested under a folder node as having an
unavailable ancestor. On a live 2,236-page catalog that was 342 direct hits, and
**none of them were real**.

`visible` and `enabled` are not the same thing for a catalog page:

- `visible` decides reachability. `CatalogManager.getCatalogPages()` filters children
  on `visible` alone, so the client never descends into a hidden page.
- `enabled` decides whether the page can be *opened*. `CatalogPagesListComposer`
  sends `enabled ? id : -1`, so a page with `visible=1, enabled=0` is a folder node:
  it shows in the tree and expands, but is not itself a page.

`validateAncestors` treated a disabled ancestor as breakage, so every child of every
folder was flagged. Measured on a live catalog: 342 flagged pages, 342 of them with a
parent that was visible with `enabled=0`, 0 with a hidden parent.

Default catalogs are full of folder nodes — `Classic Furniture`, `Builders Club`,
`Clothing by Type`, and the `Staff` / `VIP` roots — so a fresh database reports
hundreds of problems that are not problems.

## Change

- Ancestor validation follows `visible` only, matching what the index actually does.
- The rule now runs for visible pages; a hidden page under a hidden parent is not a
  finding on its own.
- The message names the page that breaks the chain (`ancestor page 874 is hidden`)
  instead of the ambiguous "hidden or disabled ancestor".

Genuinely hidden ancestors are still reported. The added test covers both cases in
one snapshot: a page reachable through a disabled folder is clean, a page under a
hidden parent is still flagged.

## Verification

- `./mvnw -B -Dtest=CatalogValidatorTest test` — new test fails before the change
  (`expected: <[5]> but was: <[3, 5]>`), passes after.
- `./mvnw -B -Dtest='Catalog*,Jdbc*,FrozenArchitectureBaselineTest' test` — 146/146.
- `./mvnw -B spotless:check` — clean.
