### PR TITLE
feat(commands): give every command a description in the ":commands" list

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandsCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandsCommand.java
@@ -32,10 +32,10 @@ public class CommandsCommand extends Command {
         return true;
     }
 
-    private static String text(String key) {
-        String value = Emulator.getTexts().getValueQuietly(key, "");
+    private static String text(String textKey) {
+        String value = Emulator.getTexts().getValueQuietly(textKey, "");
 
-        return value.equals(key) ? "" : value;
+        return value.equals(textKey) ? "" : value;
     }
 
     /**

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandsCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/CommandsCommand.java
@@ -2,41 +2,62 @@ package com.eu.habbo.habbohotel.commands;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
-
 import java.util.List;
 
 public class CommandsCommand extends Command {
     public CommandsCommand() {
-        super("cmd_commands", Emulator.getTexts().getValue("commands.keys.cmd_commands").split(";"));
+        super(
+                "cmd_commands",
+                Emulator.getTexts().getValue("commands.keys.cmd_commands").split(";"));
     }
 
     @Override
     public boolean handle(GameClient gameClient, String[] params) throws Exception {
         StringBuilder message = new StringBuilder(Emulator.getTexts().getValue("commands.generic.cmd_commands.text"));
-        List<Command> commands = Emulator.getGameEnvironment().getCommandHandler().getCommandsForRank(gameClient.getHabbo().getHabboInfo().getRank().getId());
+        List<Command> commands = Emulator.getGameEnvironment()
+                .getCommandHandler()
+                .getCommandsForRank(
+                        gameClient.getHabbo().getHabboInfo().getRank().getId());
         message.append("(").append(commands.size()).append("):\r\n");
 
         for (Command c : commands) {
-            String textKey = "commands.description." + c.permission;
-            String commandText = Emulator.getTexts().getValueQuietly(textKey, "");
-            String commandLine = ":" + c.keys[0];
-            String description = "";
-
-            if (commandText.startsWith(":")) {
-                commandLine = commandText;
-            } else if (!commandText.isEmpty() && !commandText.equals(textKey)) {
-                description = commandText;
-            }
-
-            message.append(commandLine).append("\r");
-
-            if (!description.isEmpty()) {
-                message.append(description).append("\r");
-            }
+            message.append(formatEntry(
+                    ":" + c.keys[0],
+                    text("commands.description." + c.permission),
+                    text("commands.help." + c.permission)));
         }
 
-        gameClient.getHabbo().alert(new String[]{message.toString()});
+        gameClient.getHabbo().alert(new String[] {message.toString()});
 
         return true;
+    }
+
+    private static String text(String key) {
+        String value = Emulator.getTexts().getValueQuietly(key, "");
+
+        return value.equals(key) ? "" : value;
+    }
+
+    /**
+     * Builds the lines for one command. {@code commands.description.*} usually holds the usage
+     * line - it starts with ':' and replaces the plain command - while {@code commands.help.*}
+     * holds the sentence describing what the command does. A description already written into
+     * {@code commands.description.*} still wins, so hotels keep any wording they customised.
+     */
+    static String formatEntry(String fallbackCommandLine, String descriptionText, String helpText) {
+        String commandLine = fallbackCommandLine;
+        String description = "";
+
+        if (descriptionText.startsWith(":")) {
+            commandLine = descriptionText;
+        } else if (!descriptionText.isEmpty()) {
+            description = descriptionText;
+        }
+
+        if (description.isEmpty()) {
+            description = helpText;
+        }
+
+        return description.isEmpty() ? commandLine + "\r" : commandLine + "\r" + description + "\r";
     }
 }

--- a/Emulator/src/main/resources/db/migration/V20260826210000__command_help_texts.sql
+++ b/Emulator/src/main/resources/db/migration/V20260826210000__command_help_texts.sql
@@ -1,0 +1,41 @@
+-- Descriptions for the ":commands" listing.
+--
+-- commands.description.<permission> holds the usage line - it starts with ':' and
+-- replaces the plain command name - so there was nowhere to say what a command
+-- actually does. On a stock database 112 of the listed commands showed a usage
+-- line and no description at all.
+--
+-- permission_definitions.comment already carries that sentence for every command,
+-- written for the permission editor. This copies it into the texts table under a
+-- new commands.help.<permission> key: user-facing copy belongs there, and hotel
+-- owners can reword or translate it without touching permissions.
+
+-- Collected first so the insert never selects from the table it writes to.
+CREATE TEMPORARY TABLE `command_help_seed` (
+    `key` VARCHAR(100) NOT NULL,
+    `value` VARCHAR(4096) NOT NULL,
+    PRIMARY KEY (`key`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+-- The join against commands.keys.* keeps this to permissions that really are
+-- commands, rather than every permission in the table.
+INSERT INTO `command_help_seed` (`key`, `value`)
+SELECT CONCAT('commands.help.', `definition`.`permission_key`), TRIM(`definition`.`comment`)
+FROM `permission_definitions` AS `definition`
+JOIN `emulator_texts` AS `command_key`
+    ON `command_key`.`key` = CONCAT('commands.keys.', `definition`.`permission_key`)
+WHERE `definition`.`comment` IS NOT NULL
+    AND TRIM(`definition`.`comment`) <> '';
+
+-- Keeping the existing value on duplicate means a reworded help text survives.
+INSERT INTO `emulator_texts` (`key`, `value`)
+SELECT `key`, `value` FROM `command_help_seed`
+ON DUPLICATE KEY UPDATE `value` = `emulator_texts`.`value`;
+
+DROP TEMPORARY TABLE `command_help_seed`;
+
+-- Two commands never had a usage line, so they listed as a bare command name.
+INSERT INTO `emulator_texts` (`key`, `value`) VALUES
+    ('commands.description.cmd_softkick', ':softkick <username>'),
+    ('commands.description.cmd_subscription', ':subscription <username> <subscription> <add|remove> [seconds]')
+ON DUPLICATE KEY UPDATE `value` = `emulator_texts`.`value`;

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/commands/CommandsCommandFormatTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/commands/CommandsCommandFormatTest.java
@@ -1,0 +1,43 @@
+package com.eu.habbo.habbohotel.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class CommandsCommandFormatTest {
+
+    @Test
+    void keepsTheUsageLineOnItsOwnWhenNoHelpTextExists() {
+        assertEquals(
+                ":alert <username> <message>\r",
+                CommandsCommand.formatEntry(":alert", ":alert <username> <message>", ""));
+    }
+
+    @Test
+    void putsTheHelpTextUnderTheUsageLine() {
+        assertEquals(
+                ":alert <username> <message>\rSends a hotel alert to one user.\r",
+                CommandsCommand.formatEntry(
+                        ":alert", ":alert <username> <message>", "Sends a hotel alert to one user."));
+    }
+
+    @Test
+    void describesACommandThatOnlyHasHelpText() {
+        assertEquals(
+                ":bots\rLists the bots placed in the room.\r",
+                CommandsCommand.formatEntry(":bots", "", "Lists the bots placed in the room."));
+    }
+
+    @Test
+    void keepsADescriptionAlreadyWrittenAsProseInsteadOfTheHelpText() {
+        assertEquals(
+                ":tradelock\rEnables / Disables the tradelock for a user.\r",
+                CommandsCommand.formatEntry(
+                        ":tradelock", "Enables / Disables the tradelock for a user.", "Something else entirely."));
+    }
+
+    @Test
+    void fallsBackToThePlainCommandWhenNoTextExists() {
+        assertEquals(":coords\r", CommandsCommand.formatEntry(":coords", "", ""));
+    }
+}


### PR DESCRIPTION
## Problem

The `:commands` listing showed a usage line for each command and nothing else.
On a stock database 112 of the listed commands had no description at all.

That is structural, not missing data: `commands.description.<permission>` *is*
the usage line — it starts with `:` and replaces the plain command name — so
there was nowhere to put a sentence saying what the command does.

Meanwhile `permission_definitions.comment` already carries exactly that sentence
for 115 of the 116 registered commands, written for the permission editor.

## Change

- New text key `commands.help.<permission>`, printed under the usage line.
- Migration seeds it from `permission_definitions.comment`, joined against
  `commands.keys.*` so only real commands are covered (123 rows on a stock
  database). It collects into a temporary table first, so the insert never
  selects from the table it writes to, and `ON DUPLICATE KEY UPDATE value =
  value` leaves an existing row alone — reworded copy survives a re-run.
- A prose description already written into `commands.description` still wins, so
  hotels that used that field keep their wording.
- Adds the usage line for `:softkick` and `:subscription`, which had none.
- The per-command formatting moved into `CommandsCommand.formatEntry`, a pure
  static method, so it is testable without a game client.

## Risks

- User-facing copy now comes from the permission comment verbatim, so it reads
  "Allows using :alert to …" rather than an imperative. It is accurate and
  uniform, and owners can reword any line in `emulator_texts`.
- The migration only inserts; nothing is updated or deleted.

## Verification

- `./mvnw -B -Dtest=CommandsCommandFormatTest test` — 5/5, covering usage-only,
  usage plus help, help-only, prose-wins and the bare fallback.
- `./mvnw -B -Dtest='CommandsCommandFormatTest,MigrationOptionsTest,MigrationRunnerConfigurationTest,CatalogMigrationImmutabilityContractTest' test` — 12/12.
- `./mvnw -B spotless:check` — clean.
- The seeding SELECT was dry-run against a live 116-command database: 123 rows,
  0 already present. Nothing was written — `emulator_texts` is MyISAM there, so a
  rollback would not exist.
