### PR TITLE
fix(catalog): store the full snapshot when an offer edit updates the live catalog

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationService.java
@@ -1,6 +1,8 @@
 package com.eu.habbo.habbohotel.catalog.versioning;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -526,7 +528,6 @@ public final class CatalogLiveMutationService {
                                 .orElseThrow(() -> new IllegalArgumentException(
                                         "Live catalog offer not found: " + request.entityId()));
                 };
-        validateIdentity(request);
         return new CatalogChangeEntry(
                 0,
                 request.entityType(),
@@ -534,7 +535,7 @@ public final class CatalogLiveMutationService {
                 request.entityId(),
                 request.operation(),
                 beforeJson,
-                request.operation() == CatalogChangeOperation.DELETE ? null : request.afterJson());
+                request.operation() == CatalogChangeOperation.DELETE ? null : canonicalAfterJson(request));
     }
 
     private CatalogChangeEntry buildCreate(Connection connection, CatalogLiveMutationRequest request)
@@ -569,19 +570,46 @@ public final class CatalogLiveMutationService {
         };
     }
 
-    private void validateIdentity(CatalogLiveMutationRequest request) {
-        if (request.operation() == CatalogChangeOperation.DELETE) return;
-        boolean valid =
-                switch (request.entityType()) {
-                    case PAGE -> {
-                        CatalogPageSnapshot page = gson.fromJson(request.afterJson(), CatalogPageSnapshot.class);
-                        yield page.pageId() == request.entityId() && page.catalogType() == request.catalogType();
-                    }
-                    case OFFER -> {
-                        CatalogOfferSnapshot offer = gson.fromJson(request.afterJson(), CatalogOfferSnapshot.class);
-                        yield offer.offerId() == request.entityId() && offer.catalogType() == request.catalogType();
-                    }
-                };
-        if (!valid) throw new IllegalArgumentException("Live catalog payload identity does not match the request");
+    /**
+     * Rewrites the payload as the full snapshot the change journal and the live writer read back.
+     *
+     * <p>The editor sends a draft: {@link CatalogDraftOfferData} and {@link CatalogDraftPageData}
+     * carry the editable fields but no identity, because the request already names the catalog and
+     * the entity. Creation has always rebuilt the snapshot from that draft; updates stored the draft
+     * verbatim, so anything reading the entry back as a snapshot - {@code JdbcCatalogLiveEntityWriter},
+     * {@code CatalogLiveValidationGuard}, and the identity check that used to live here - hit a
+     * payload with a null {@code catalogType} and an offer id of zero.
+     *
+     * <p>A payload that does carry its own identity is still checked against the request rather than
+     * silently overwritten.
+     */
+    private String canonicalAfterJson(CatalogLiveMutationRequest request) {
+        JsonObject payload = JsonParser.parseString(request.afterJson()).getAsJsonObject();
+        validateIdentity(request, payload);
+        return switch (request.entityType()) {
+            case PAGE ->
+                gson.toJson(gson.fromJson(payload, CatalogDraftPageData.class)
+                        .withId(request.catalogType(), request.entityId()));
+            case OFFER ->
+                gson.toJson(gson.fromJson(payload, CatalogDraftOfferData.class)
+                        .withId(request.catalogType(), request.entityId()));
+        };
+    }
+
+    private void validateIdentity(CatalogLiveMutationRequest request, JsonObject payload) {
+        String idField = request.entityType() == CatalogEntityType.PAGE ? "pageId" : "offerId";
+        boolean mismatch = payload.has(idField)
+                && !payload.get(idField).isJsonNull()
+                && payload.get(idField).getAsInt() != request.entityId();
+        if (!mismatch
+                && payload.has("catalogType")
+                && !payload.get("catalogType").isJsonNull()) {
+            mismatch = !request.catalogType()
+                    .name()
+                    .equals(payload.get("catalogType").getAsString());
+        }
+        if (mismatch) {
+            throw new IllegalArgumentException("Live catalog payload identity does not match the request");
+        }
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminCreateOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminCreateOfferEvent.java
@@ -93,9 +93,7 @@ public class CatalogAdminCreateOfferEvent extends MessageHandler {
                     result,
                     this.client.getHabbo().getHabboInfo().getUsername(),
                     gson));
-        } catch (IllegalArgumentException
-                | com.eu.habbo.habbohotel.catalog.versioning.CatalogConcurrentModificationException
-                | com.eu.habbo.habbohotel.catalog.versioning.CatalogUndoConflictException exception) {
+        } catch (RuntimeException exception) {
             this.client.sendResponse(CatalogAdminSmartSaveResponder.failure(
                     operationId,
                     "createOffer",

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminCreatePageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminCreatePageEvent.java
@@ -150,9 +150,7 @@ public class CatalogAdminCreatePageEvent extends MessageHandler {
                     result,
                     this.client.getHabbo().getHabboInfo().getUsername(),
                     gson));
-        } catch (IllegalArgumentException
-                | com.eu.habbo.habbohotel.catalog.versioning.CatalogConcurrentModificationException
-                | com.eu.habbo.habbohotel.catalog.versioning.CatalogUndoConflictException exception) {
+        } catch (RuntimeException exception) {
             this.client.sendResponse(CatalogAdminSmartSaveResponder.failure(
                     operationId,
                     "createPage",

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSaveOfferEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSaveOfferEvent.java
@@ -108,9 +108,7 @@ public class CatalogAdminSaveOfferEvent extends MessageHandler {
                     result,
                     this.client.getHabbo().getHabboInfo().getUsername(),
                     gson));
-        } catch (IllegalArgumentException
-                | com.eu.habbo.habbohotel.catalog.versioning.CatalogConcurrentModificationException
-                | com.eu.habbo.habbohotel.catalog.versioning.CatalogUndoConflictException exception) {
+        } catch (RuntimeException exception) {
             this.client.sendResponse(CatalogAdminSmartSaveResponder.failure(
                     operationId,
                     "saveOffer",

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSavePageEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSavePageEvent.java
@@ -153,9 +153,7 @@ public class CatalogAdminSavePageEvent extends MessageHandler {
                     result,
                     this.client.getHabbo().getHabboInfo().getUsername(),
                     gson));
-        } catch (IllegalArgumentException
-                | com.eu.habbo.habbohotel.catalog.versioning.CatalogConcurrentModificationException
-                | com.eu.habbo.habbohotel.catalog.versioning.CatalogUndoConflictException exception) {
+        } catch (RuntimeException exception) {
             this.client.sendResponse(CatalogAdminSmartSaveResponder.failure(
                     operationId,
                     "savePage",

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSmartSaveResponder.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSmartSaveResponder.java
@@ -9,8 +9,12 @@ import com.eu.habbo.messages.outgoing.catalog.catalogadmin.CatalogAdminSmartSave
 import com.google.gson.Gson;
 import java.util.Map;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class CatalogAdminSmartSaveResponder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CatalogAdminSmartSaveResponder.class);
+
     private CatalogAdminSmartSaveResponder() {}
 
     static String operationId(CatalogStudioMutationEnvelope envelope, String action) {
@@ -37,13 +41,30 @@ final class CatalogAdminSmartSaveResponder {
                 switch (exception) {
                     case CatalogConcurrentModificationException ignored -> "CONFLICT";
                     case CatalogUndoConflictException ignored -> "CONFLICT";
-                    default -> "VALIDATION_FAILED";
+                    case IllegalArgumentException ignored -> "VALIDATION_FAILED";
+                    default -> "INTERNAL_ERROR";
                 };
-        String fieldErrors =
-                code.equals("VALIDATION_FAILED") ? gson.toJson(Map.of("_form", exception.getMessage())) : "{}";
+        // Anything other than a rejected edit is a defect, not operator error: it must reach the
+        // server log, and the operator must still get an answer instead of a save that never
+        // resolves. getMessage() is null on plenty of runtime exceptions, and both the payload and
+        // Map.of below would throw on it.
+        String message =
+                exception.getMessage() == null || exception.getMessage().isBlank()
+                        ? exception.getClass().getSimpleName()
+                        : exception.getMessage();
+        if (code.equals("INTERNAL_ERROR")) {
+            LOGGER.error(
+                    "Catalog admin {} failed unexpectedly for {} {} #{}",
+                    action,
+                    catalogType,
+                    entityType,
+                    entityId,
+                    exception);
+        }
+        String fieldErrors = code.equals("CONFLICT") ? "{}" : gson.toJson(Map.of("_form", message));
         return new CatalogAdminResultComposer(
                 false,
-                exception.getMessage(),
+                message,
                 CatalogAdminSmartSavePayload.failure(
                         operationId,
                         action,

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationServiceTest.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.habbohotel.catalog.versioning;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -349,6 +350,49 @@ class CatalogLiveMutationServiceTest {
         assertEquals(42, committed.offerId());
         assertEquals(CatalogPageType.NORMAL, committed.catalogType());
         assertEquals(0, committed.costPoints());
+    }
+
+    @Test
+    void updatesAPageFromEitherPayloadShape() throws Exception {
+        // Save page sends a full snapshot, save offer sends a draft. Both are accepted, and both
+        // are stored as the snapshot the live writer and the validation guard read back.
+        CatalogPageSnapshot snapshotShape = page(false);
+        CatalogDraftPageData draftShape = gson.fromJson(gson.toJson(snapshotShape), CatalogDraftPageData.class);
+
+        for (String payload : List.of(gson.toJson(snapshotShape), gson.toJson(draftShape))) {
+            service.applyBatch(List.of(new CatalogLiveMutationRequest(
+                    -1,
+                    7,
+                    "Change visibility",
+                    CatalogEntityType.PAGE,
+                    CatalogPageType.NORMAL,
+                    17,
+                    CatalogChangeOperation.UPDATE,
+                    payload)));
+        }
+
+        ArgumentCaptor<CatalogChangeEntry> change = ArgumentCaptor.forClass(CatalogChangeEntry.class);
+        verify(live, org.mockito.Mockito.times(2)).apply(eq(connection), change.capture());
+        for (CatalogChangeEntry entry : change.getAllValues()) {
+            CatalogPageSnapshot committed = gson.fromJson(entry.afterJson(), CatalogPageSnapshot.class);
+            assertEquals(17, committed.pageId());
+            assertEquals(CatalogPageType.NORMAL, committed.catalogType());
+        }
+    }
+
+    @Test
+    void rejectsAPayloadWhoseOwnIdentityContradictsTheRequest() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> service.applyBatch(List.of(new CatalogLiveMutationRequest(
+                        -1,
+                        7,
+                        "Change visibility",
+                        CatalogEntityType.PAGE,
+                        CatalogPageType.NORMAL,
+                        99,
+                        CatalogChangeOperation.UPDATE,
+                        gson.toJson(page(false))))));
     }
 
     private static CatalogPageSnapshot page(boolean visible) {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationServiceTest.java
@@ -309,6 +309,48 @@ class CatalogLiveMutationServiceTest {
         assertEquals(9, committed.orderNumber());
     }
 
+    @Test
+    void updatesAnOfferFromTheDraftPayloadTheEditorSends() throws Exception {
+        CatalogOfferSnapshot offer = new CatalogOfferSnapshot(
+                CatalogPageType.NORMAL, 42, "12", 17, "chair", 5, 50, 5, 1, 0, 99, -1, 0, "", true, false);
+        when(versions.loadSnapshot(connection, ACTIVE_VERSION_ID))
+                .thenReturn(new CatalogVersionSnapshot(
+                        new CatalogVersion(
+                                ACTIVE_VERSION_ID,
+                                CatalogVersionStatus.PUBLISHED,
+                                null,
+                                4,
+                                "Live",
+                                1,
+                                Instant.EPOCH,
+                                1,
+                                Instant.EPOCH),
+                        List.of(page(true)),
+                        List.of(offer)));
+
+        // What CatalogAdminSaveOfferEvent puts on the wire: the draft carries no
+        // catalogType and no offer id - the request supplies both.
+        CatalogDraftOfferData draft =
+                new CatalogDraftOfferData("12", 17, "chair", 5, 0, 0, 1, 0, 99, -1, 0, "", true, false);
+
+        service.applyBatch(List.of(new CatalogLiveMutationRequest(
+                -1,
+                7,
+                "Updated offer: chair",
+                CatalogEntityType.OFFER,
+                CatalogPageType.NORMAL,
+                42,
+                CatalogChangeOperation.UPDATE,
+                gson.toJson(draft))));
+
+        ArgumentCaptor<CatalogChangeEntry> change = ArgumentCaptor.forClass(CatalogChangeEntry.class);
+        verify(live).apply(eq(connection), change.capture());
+        CatalogOfferSnapshot committed = gson.fromJson(change.getValue().afterJson(), CatalogOfferSnapshot.class);
+        assertEquals(42, committed.offerId());
+        assertEquals(CatalogPageType.NORMAL, committed.catalogType());
+        assertEquals(0, committed.costPoints());
+    }
+
     private static CatalogPageSnapshot page(boolean visible) {
         return new CatalogPageSnapshot(
                 CatalogPageType.NORMAL,

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSmartSaveFailureTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/catalog/catalogadmin/CatalogAdminSmartSaveFailureTest.java
@@ -1,0 +1,38 @@
+package com.eu.habbo.messages.incoming.catalog.catalogadmin;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.eu.habbo.habbohotel.catalog.versioning.CatalogConcurrentModificationException;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+class CatalogAdminSmartSaveFailureTest {
+
+    private static final Gson GSON = new Gson();
+
+    /**
+     * A defect in the save path must still answer the operator. The editor shows nothing at all when
+     * the handler throws, because the packet loop logs the exception and sends no response.
+     */
+    @Test
+    void answersEvenWhenTheFailureCarriesNoMessage() {
+        assertNotNull(assertDoesNotThrow(() -> failure(new NullPointerException())));
+    }
+
+    @Test
+    void answersOnAnUnexpectedRuntimeFailure() {
+        assertNotNull(assertDoesNotThrow(() -> failure(new IllegalStateException("live catalog is closed"))));
+    }
+
+    @Test
+    void stillAnswersOnTheExpectedRejections() {
+        assertNotNull(assertDoesNotThrow(() -> failure(new IllegalArgumentException("Offer not found: 42"))));
+        assertNotNull(assertDoesNotThrow(() -> failure(new CatalogConcurrentModificationException(12L, 4L))));
+    }
+
+    private static Object failure(RuntimeException exception) {
+        return CatalogAdminSmartSaveResponder.failure(
+                "saveOffer-test-1", "saveOffer", 12L, 4L, "OFFER", "NORMAL", 42, exception, GSON);
+    }
+}


### PR DESCRIPTION
Saving an offer from the catalog editor crashed for every edit:

```
java.lang.RuntimeException: Failed to invoke constructor 'CatalogOfferSnapshot(...)'
  with args [null, 0, 1100001627, 121, clothing_r17_daveycrockett, 5, 0, ...]
Caused by: java.lang.NullPointerException: catalogType
  at CatalogLiveMutationService.validateIdentity(CatalogLiveMutationService.java:581)
  at CatalogLiveMutationService.buildChange(CatalogLiveMutationService.java:529)
```

## Why

`CatalogAdminSaveOfferEvent` sends a `CatalogDraftOfferData`: the editable fields,
no identity, because the request already names the catalog and the offer id.

Creation always rebuilt the snapshot from that draft (`buildCreate` →
`withId(catalogType, offerId)`). Update stored the draft verbatim, so everything
that reads the change entry back as a `CatalogOfferSnapshot` — the identity check,
`JdbcCatalogLiveEntityWriter`, `CatalogLiveValidationGuard` — got a null
`catalogType` and an offer id of zero. The record's `requireNonNull` then threw
inside Gson's record adapter.

The price in the report ("5 coins & 50 diamonds" → "5 coins") is incidental: any
offer update took the same path.

## Changes

**Update rebuilds the snapshot, like create does.** A payload that carries its own
identity is still checked against the request rather than silently rewritten from
it, so the three paths that send a full snapshot — save page, move page, reorder
offers — are unaffected.

**An unexpected failure now reaches the operator.** The four smart-save handlers
caught `IllegalArgumentException` and the two catalog conflict exceptions; anything
else reached `PacketManager`, which logs and sends no response, leaving the editor
with a save that neither succeeded nor failed. They now catch `RuntimeException`:
rejected edits keep reporting `VALIDATION_FAILED` / `CONFLICT`, unexpected ones are
reported as `INTERNAL_ERROR` and logged with the entity being saved. The message
falls back to the exception class when `getMessage()` is null — which also fixes
the error path itself, since `Map.of` threw on a null message.

**Both payload shapes are pinned by tests.** Only the snapshot shape was covered,
which is why a crash on every offer edit shipped without a red test.

## Risks

- The failure code `INTERNAL_ERROR` is new. The client carries the code but does not
  branch on it, so nothing downstream changes shape.
- Normalising through the draft record is lossless: each snapshot is exactly its
  draft plus `catalogType` and the entity id, verified field by field for both
  pages and offers.

## Not in this change

Catalog mutations still run on the packet thread and take `lockRuntimeState`
(`FOR UPDATE`) there — visible in the reported stack as `GamePacketHandler-8-18`.
Moving them onto the dedicated executor is worth doing, but it changes concurrency
and response timing on the write path, so it belongs in its own change rather than
riding along with a crash fix.

## Verification

- `./mvnw -B -Dtest=CatalogLiveMutationServiceTest test` — 12/12. The added case
  reproduces the reported crash exactly before the fix.
- `./mvnw -B -Dtest=CatalogAdminSmartSaveFailureTest test` — 3/3.
- `./mvnw -B -Dtest='Catalog*,Jdbc*,FrozenArchitectureBaselineTest' test` — 147/147.
- `./mvnw -B spotless:check` — clean.
