### PR TITLE
perf(catalog): validate only what an edit can actually break

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveValidationGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveValidationGuard.java
@@ -27,8 +27,10 @@ public final class CatalogLiveValidationGuard {
     public void rejectIntroducedProblems(
             Connection connection, CatalogVersionSnapshot live, List<CatalogChangeEntry> changes) throws SQLException {
         CatalogVersionSnapshot candidate = apply(live, changes);
+        // Scoped to the changed entities and what reads them: validating the whole live catalog
+        // twice costs about 600 ms on a 112,000-offer catalog, per save.
         CatalogValidationReport introduced =
-                validationData.load(connection).validator().validateChanges(live, candidate);
+                validationData.load(connection).validator().validateChanges(live, candidate, changes);
         if (!introduced.valid()) throw new CatalogLiveValidationException(introduced);
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidator.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidator.java
@@ -1,6 +1,10 @@
 package com.eu.habbo.habbohotel.catalog.versioning;
 
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -26,26 +30,168 @@ public final class CatalogValidator {
     }
 
     public CatalogValidationReport validate(CatalogVersionSnapshot snapshot) {
-        Objects.requireNonNull(snapshot, "snapshot");
-        List<CatalogValidationIssue> issues = new ArrayList<>();
-        validatePages(snapshot, issues);
-        validateOffers(snapshot, issues);
-        return new CatalogValidationReport(issues);
+        return validate(snapshot, null);
     }
 
     public CatalogValidationReport validateChanges(CatalogVersionSnapshot baseline, CatalogVersionSnapshot candidate) {
+        return validateChanges(baseline, candidate, null);
+    }
+
+    /**
+     * Reports the problems the candidate introduces, looking only at the entities the changes can
+     * reach.
+     *
+     * <p>Validating a whole live catalog twice per save is the dominant cost of an edit: on a
+     * 112,000-offer catalog the two passes take roughly 600 ms, while the edit itself touches one
+     * row. Passing the changes narrows both passes to the entities that can actually change verdict:
+     * the edited ones, and the ones whose rules read them - descendants, siblings, pages that
+     * include them, and the offers sitting on them. Ancestors are not in scope: an edit cannot
+     * change their verdict, and the rules that walk upwards read the snapshot directly.
+     *
+     * <p>A null {@code changes} validates everything, which is what a full catalog check does.
+     */
+    public CatalogValidationReport validateChanges(
+            CatalogVersionSnapshot baseline, CatalogVersionSnapshot candidate, Collection<CatalogChangeEntry> changes) {
         Objects.requireNonNull(baseline, "baseline");
         Objects.requireNonNull(candidate, "candidate");
-        Set<CatalogValidationIssue> inherited = new HashSet<>(validate(baseline).issues());
-        List<CatalogValidationIssue> introduced = validate(candidate).issues().stream()
+        Scope scope = changes == null ? null : scopeOf(changes, baseline, candidate);
+        Set<CatalogValidationIssue> inherited =
+                new HashSet<>(validate(baseline, scope).issues());
+        List<CatalogValidationIssue> introduced = validate(candidate, scope).issues().stream()
                 .filter(issue -> !inherited.contains(issue))
                 .toList();
         return new CatalogValidationReport(introduced);
     }
 
-    private void validatePages(CatalogVersionSnapshot snapshot, List<CatalogValidationIssue> issues) {
-        Map<ParentOrder, List<Integer>> siblingOrders = new HashMap<>();
+    private CatalogValidationReport validate(CatalogVersionSnapshot snapshot, Scope scope) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        List<CatalogValidationIssue> issues = new ArrayList<>();
+        validatePages(snapshot, issues, scope);
+        validateOffers(snapshot, issues, scope);
+        return new CatalogValidationReport(issues);
+    }
+
+    private record EntityKey(CatalogPageType catalogType, int entityId) {}
+
+    /** The entities whose verdict the changes can alter. A null scope means the whole catalog. */
+    private record Scope(Set<EntityKey> pages, Set<EntityKey> offers) {}
+
+    private Scope scopeOf(
+            Collection<CatalogChangeEntry> changes, CatalogVersionSnapshot baseline, CatalogVersionSnapshot candidate) {
+        Set<EntityKey> pages = new HashSet<>();
+        Set<EntityKey> offers = new HashSet<>();
+        for (CatalogChangeEntry change : changes) {
+            EntityKey key = new EntityKey(change.catalogType(), change.entityId());
+            if (change.entityType() == CatalogEntityType.PAGE) {
+                pages.add(key);
+            } else {
+                offers.add(key);
+            }
+        }
+        // An entity can be present in one snapshot and gone from the other, so both are walked from
+        // the same seeds: expanding from an already grown set would pull the tree in sideways.
+        Set<EntityKey> seeds = Set.copyOf(pages);
+        expand(baseline, seeds, pages);
+        expand(candidate, seeds, pages);
+
+        // An offer only reads whether its page exists - not whether it is visible - so editing a
+        // page leaves every offer's verdict untouched. Only pages that appear or disappear pull
+        // their offers in, which is what turns a subtree edit from ~100,000 offers into none.
+        Set<EntityKey> appearing = new HashSet<>();
+        for (EntityKey key : pages) {
+            boolean inBaseline =
+                    baseline.page(key.catalogType(), key.entityId()).isPresent();
+            boolean inCandidate =
+                    candidate.page(key.catalogType(), key.entityId()).isPresent();
+            if (inBaseline != inCandidate) appearing.add(key);
+        }
+        if (!appearing.isEmpty()) {
+            collectOffers(baseline, appearing, offers);
+            collectOffers(candidate, appearing, offers);
+        }
+        return new Scope(Set.copyOf(pages), Set.copyOf(offers));
+    }
+
+    private void expand(CatalogVersionSnapshot snapshot, Set<EntityKey> seeds, Set<EntityKey> pages) {
+        Map<EntityKey, List<CatalogPageSnapshot>> children = new HashMap<>();
         for (CatalogPageSnapshot page : snapshot.pages()) {
+            children.computeIfAbsent(new EntityKey(page.catalogType(), page.parentId()), ignored -> new ArrayList<>())
+                    .add(page);
+        }
+
+        // Only an edited page can take or free an order slot, so siblings are collected for the
+        // seeds alone. Doing it for every page reached would re-scan one parent's children once per
+        // child, which is quadratic on a wide branch.
+        for (EntityKey seed : seeds) {
+            CatalogPageSnapshot page =
+                    snapshot.page(seed.catalogType(), seed.entityId()).orElse(null);
+            if (page == null) continue;
+            EntityKey parent = new EntityKey(page.catalogType(), page.parentId());
+            for (CatalogPageSnapshot sibling : children.getOrDefault(parent, List.of())) {
+                pages.add(new EntityKey(sibling.catalogType(), sibling.pageId()));
+            }
+        }
+
+        // Descendants read the availability of everything above them, so they follow an edit down.
+        Deque<EntityKey> pending = new ArrayDeque<>(seeds);
+        while (!pending.isEmpty()) {
+            EntityKey key = pending.poll();
+            for (CatalogPageSnapshot child : children.getOrDefault(key, List.of())) {
+                EntityKey childKey = new EntityKey(child.catalogType(), child.pageId());
+                if (pages.add(childKey)) pending.add(childKey);
+            }
+        }
+
+        Set<Integer> pageIds = new HashSet<>();
+        for (EntityKey key : pages) pageIds.add(key.entityId());
+        for (CatalogPageSnapshot page : snapshot.pages()) {
+            if (includesAnyOf(page, pageIds)) {
+                pages.add(new EntityKey(page.catalogType(), page.pageId()));
+            }
+        }
+    }
+
+    private static void collectOffers(CatalogVersionSnapshot snapshot, Set<EntityKey> pages, Set<EntityKey> offers) {
+        for (CatalogOfferSnapshot offer : snapshot.offers()) {
+            if (pages.contains(new EntityKey(offer.catalogType(), offer.pageId()))) {
+                offers.add(new EntityKey(offer.catalogType(), offer.offerId()));
+            }
+        }
+    }
+
+    private static boolean includesAnyOf(CatalogPageSnapshot page, Set<Integer> pageIds) {
+        if (page.includes() == null || page.includes().isBlank()) return false;
+        for (String rawId : page.includes().split(";", -1)) {
+            try {
+                if (pageIds.contains(Integer.parseInt(rawId.trim()))) return true;
+            } catch (NumberFormatException ignored) {
+                // An unparsable include is reported by validateIncludes, not here.
+            }
+        }
+        return false;
+    }
+
+    private static List<CatalogPageSnapshot> pagesInScope(CatalogVersionSnapshot snapshot, Scope scope) {
+        if (scope == null) return snapshot.pages();
+        List<CatalogPageSnapshot> selected = new ArrayList<>(scope.pages().size());
+        for (EntityKey key : scope.pages()) {
+            snapshot.page(key.catalogType(), key.entityId()).ifPresent(selected::add);
+        }
+        return selected;
+    }
+
+    private static List<CatalogOfferSnapshot> offersInScope(CatalogVersionSnapshot snapshot, Scope scope) {
+        if (scope == null) return snapshot.offers();
+        List<CatalogOfferSnapshot> selected = new ArrayList<>(scope.offers().size());
+        for (EntityKey key : scope.offers()) {
+            snapshot.offer(key.catalogType(), key.entityId()).ifPresent(selected::add);
+        }
+        return selected;
+    }
+
+    private void validatePages(CatalogVersionSnapshot snapshot, List<CatalogValidationIssue> issues, Scope scope) {
+        Map<ParentOrder, List<Integer>> siblingOrders = new HashMap<>();
+        for (CatalogPageSnapshot page : pagesInScope(snapshot, scope)) {
             if (page.parentId() > 0
                     && snapshot.page(page.catalogType(), page.parentId()).isEmpty()) {
                 add(
@@ -88,7 +234,7 @@ public final class CatalogValidator {
             }
         });
 
-        detectCycles(snapshot, issues);
+        detectCycles(snapshot, issues, scope);
     }
 
     private void validateIncludes(
@@ -147,9 +293,9 @@ public final class CatalogValidator {
         }
     }
 
-    private void detectCycles(CatalogVersionSnapshot snapshot, List<CatalogValidationIssue> issues) {
+    private void detectCycles(CatalogVersionSnapshot snapshot, List<CatalogValidationIssue> issues, Scope scope) {
         Set<String> reported = new HashSet<>();
-        for (CatalogPageSnapshot page : snapshot.pages()) {
+        for (CatalogPageSnapshot page : pagesInScope(snapshot, scope)) {
             Map<Integer, Integer> positions = new HashMap<>();
             List<Integer> path = new ArrayList<>();
             int currentId = page.pageId();
@@ -178,8 +324,8 @@ public final class CatalogValidator {
         }
     }
 
-    private void validateOffers(CatalogVersionSnapshot snapshot, List<CatalogValidationIssue> issues) {
-        for (CatalogOfferSnapshot offer : snapshot.offers()) {
+    private void validateOffers(CatalogVersionSnapshot snapshot, List<CatalogValidationIssue> issues, Scope scope) {
+        for (CatalogOfferSnapshot offer : offersInScope(snapshot, scope)) {
             if (snapshot.page(offer.catalogType(), offer.pageId()).isEmpty()) {
                 add(
                         issues,

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidatorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogValidatorTest.java
@@ -119,6 +119,167 @@ class CatalogValidatorTest {
                 report.issues().stream().map(CatalogValidationIssue::entityId).toList());
     }
 
+    @Test
+    void reportsAProblemTheChangeIntroducesOnADifferentPage() {
+        // Hiding page 1 breaks page 2, which is not itself edited. Any scoped
+        // validation has to follow that edge or it will pass a broken catalog.
+        List<CatalogPageSnapshot> baselinePages =
+                List.of(page(1, -1, 0, true, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+        List<CatalogPageSnapshot> draftPages =
+                List.of(page(1, -1, 0, false, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+
+        CatalogValidationReport report = validator(Set.of(), Set.of(), Map.of())
+                .validateChanges(snapshot(baselinePages, List.of()), snapshot(draftPages, List.of()));
+
+        assertEquals(
+                List.of(new CatalogValidationIssue(
+                        "PAGE_ANCESTOR_NOT_AVAILABLE",
+                        CatalogEntityType.PAGE,
+                        2,
+                        "parentId",
+                        "Visible page is unreachable: ancestor page 1 is hidden")),
+                report.issues());
+    }
+
+    @Test
+    void reportsAnOfferBrokenByDeletingThePageItSitsOn() {
+        List<CatalogPageSnapshot> pages =
+                List.of(page(1, -1, 0, true, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+        List<CatalogOfferSnapshot> offers = List.of(offer(10, 2, "100", 5, 0, 0, 0));
+
+        CatalogValidationReport report = validator(Set.of(100), Set.of(5), Map.of())
+                .validateChanges(snapshot(pages, offers), snapshot(List.of(pages.getFirst()), offers));
+
+        assertCodes(report, "OFFER_PAGE_MISSING");
+    }
+
+    @Test
+    void staysSilentOnAProblemThatWasAlreadyThere() {
+        List<CatalogPageSnapshot> pages =
+                List.of(page(1, -1, 0, false, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+        CatalogVersionSnapshot baseline = snapshot(pages, List.of());
+        CatalogVersionSnapshot draft = snapshot(pages, List.of(offer(10, 2, "100", 5, 0, 0, 0)));
+
+        CatalogValidationReport report =
+                validator(Set.of(100), Set.of(5), Map.of()).validateChanges(baseline, draft);
+
+        assertTrue(report.valid(), () -> "unchanged problems must not block a save: " + report.issues());
+    }
+
+    @Test
+    void reportsASiblingOrderClashTheChangeCreates() {
+        List<CatalogPageSnapshot> baselinePages = List.of(
+                page(1, -1, 0, true, true, "root", ""),
+                page(2, 1, 0, true, true, "default_3x3", ""),
+                page(3, 1, 1, true, true, "default_3x3", ""));
+        List<CatalogPageSnapshot> draftPages = List.of(
+                page(1, -1, 0, true, true, "root", ""),
+                page(2, 1, 0, true, true, "default_3x3", ""),
+                page(3, 1, 0, true, true, "default_3x3", ""));
+
+        CatalogValidationReport report = validator(Set.of(), Set.of(), Map.of())
+                .validateChanges(snapshot(baselinePages, List.of()), snapshot(draftPages, List.of()));
+
+        assertCodes(report, "PAGE_SIBLING_ORDER_DUPLICATE");
+    }
+
+    @Test
+    void scopedValidationStillSeesTheProblemOnTheUneditedPage() {
+        List<CatalogPageSnapshot> baselinePages =
+                List.of(page(1, -1, 0, true, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+        List<CatalogPageSnapshot> draftPages =
+                List.of(page(1, -1, 0, false, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+
+        // Only page 1 was edited; the breakage lands on page 2.
+        CatalogValidationReport report = validator(Set.of(), Set.of(), Map.of())
+                .validateChanges(
+                        snapshot(baselinePages, List.of()), snapshot(draftPages, List.of()), List.of(pageChange(1)));
+
+        assertCodes(report, "PAGE_ANCESTOR_NOT_AVAILABLE");
+        assertEquals(
+                List.of(2),
+                report.issues().stream().map(CatalogValidationIssue::entityId).toList());
+    }
+
+    @Test
+    void scopedValidationStillSeesASiblingOrderClash() {
+        List<CatalogPageSnapshot> baselinePages = List.of(
+                page(1, -1, 0, true, true, "root", ""),
+                page(2, 1, 0, true, true, "default_3x3", ""),
+                page(3, 1, 1, true, true, "default_3x3", ""));
+        List<CatalogPageSnapshot> draftPages = List.of(
+                page(1, -1, 0, true, true, "root", ""),
+                page(2, 1, 0, true, true, "default_3x3", ""),
+                page(3, 1, 0, true, true, "default_3x3", ""));
+
+        CatalogValidationReport report = validator(Set.of(), Set.of(), Map.of())
+                .validateChanges(
+                        snapshot(baselinePages, List.of()), snapshot(draftPages, List.of()), List.of(pageChange(3)));
+
+        assertCodes(report, "PAGE_SIBLING_ORDER_DUPLICATE");
+    }
+
+    @Test
+    void scopedValidationStillSeesAnOfferOrphanedByItsPage() {
+        List<CatalogPageSnapshot> pages =
+                List.of(page(1, -1, 0, true, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+        List<CatalogOfferSnapshot> offers = List.of(offer(10, 2, "100", 5, 0, 0, 0));
+
+        CatalogValidationReport report = validator(Set.of(100), Set.of(5), Map.of())
+                .validateChanges(
+                        snapshot(pages, offers), snapshot(List.of(pages.getFirst()), offers), List.of(pageChange(2)));
+
+        assertCodes(report, "OFFER_PAGE_MISSING");
+    }
+
+    @Test
+    void scopedValidationStillIgnoresAProblemThatWasAlreadyThere() {
+        List<CatalogPageSnapshot> pages =
+                List.of(page(1, -1, 0, false, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+        CatalogVersionSnapshot baseline = snapshot(pages, List.of());
+        CatalogVersionSnapshot draft = snapshot(pages, List.of(offer(10, 2, "100", 5, 0, 0, 0)));
+
+        CatalogValidationReport report =
+                validator(Set.of(100), Set.of(5), Map.of()).validateChanges(baseline, draft, List.of(offerChange(10)));
+
+        assertTrue(report.valid(), () -> "unchanged problems must not block a save: " + report.issues());
+    }
+
+    @Test
+    void scopedValidationOnAnOfferStillJudgesThatOffer() {
+        List<CatalogPageSnapshot> pages =
+                List.of(page(1, -1, 0, true, true, "root", ""), page(2, 1, 0, true, true, "default_3x3", ""));
+        CatalogVersionSnapshot baseline = snapshot(pages, List.of(offer(10, 2, "100", 5, 0, 0, 0)));
+        CatalogVersionSnapshot draft = snapshot(pages, List.of(offer(10, 2, "404", 5, 0, 0, 0)));
+
+        CatalogValidationReport report =
+                validator(Set.of(100), Set.of(5), Map.of()).validateChanges(baseline, draft, List.of(offerChange(10)));
+
+        assertCodes(report, "OFFER_ITEM_MISSING");
+    }
+
+    private static CatalogChangeEntry pageChange(int pageId) {
+        return new CatalogChangeEntry(
+                0,
+                CatalogEntityType.PAGE,
+                com.eu.habbo.habbohotel.catalog.CatalogPageType.NORMAL,
+                pageId,
+                CatalogChangeOperation.UPDATE,
+                "{}",
+                "{}");
+    }
+
+    private static CatalogChangeEntry offerChange(int offerId) {
+        return new CatalogChangeEntry(
+                0,
+                CatalogEntityType.OFFER,
+                com.eu.habbo.habbohotel.catalog.CatalogPageType.NORMAL,
+                offerId,
+                CatalogChangeOperation.UPDATE,
+                "{}",
+                "{}");
+    }
+
     private static CatalogValidator validator(
             Set<Integer> itemIds, Set<Integer> currencyTypes, Map<Integer, Integer> liveLimitedSells) {
         return new CatalogValidator(itemIds, currencyTypes, liveLimitedSells, Set.of("root", "default_3x3"));


### PR DESCRIPTION
Every catalog save validates the whole live catalog **twice** — once as the
baseline, once as the candidate — to work out which problems the edit introduced.
On a live catalog of 2,236 pages and 112,246 offers that is about **640 ms** of
pure rule evaluation to change one row, on the thread serving the operator's
packets and with the catalog locked.

## Change

`validateChanges` now takes the changes and judges only the entities whose
verdict they can alter:

- the edited entities themselves,
- the descendants that read their availability,
- the siblings that share their order slot,
- the pages that include them.

Two things are deliberately **not** in scope, and both matter for the cost:

- **Ancestors.** An edit cannot change an ancestor's verdict, and the rules that
  walk upwards still read the whole snapshot. Pulling ancestors in also dragged
  their subtrees along, which is what made the first attempt slower than the full
  pass on a root page.
- **Offers under an edited page.** An offer reads whether its page *exists*,
  never whether it is visible, so editing a page leaves every offer's verdict
  untouched. Offers are pulled in only when a page appears or disappears. That is
  the difference between ~100,000 offers in scope and none.

The two-argument overload still validates everything, so a full catalog check is
unchanged.

## Measured

Live catalog, best of five, against 638 ms for the full pass:

| scenario | scoped |
| --- | --- |
| one offer | <1 ms |
| batch of 50 offers | <1 ms |
| page with the most offers (1,605) | 1 ms |
| batch of 20 pages | 5 ms |
| largest root page (969 descendants) | 4 ms |

## Risks

The scope decides what gets *judged*; every rule still reads the full snapshot,
so a narrower scope cannot make a lookup wrong — only make a finding go
unreported. That is what the tests are aimed at.

Characterization tests were written against the unmodified validator first and
then re-asserted through the scoped path, including the case that matters most:
an edit to one page that breaks a different, unedited one. Also covered: a
sibling-order clash created by an edit, an offer orphaned by deleting its page,
and a pre-existing problem that must stay unreported.

## Verification

- `./mvnw -B -Dtest=CatalogValidatorTest test` — 14/14.
- `./mvnw -B -Dtest='Catalog*,Jdbc*,FrozenArchitectureBaselineTest' test` — 161/161.
- `./mvnw -B spotless:check` — clean.
