### PR TITLE
fix(catalog): accept the currencies the hotel has, not a fixed 0..100 range

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogValidationDataRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogValidationDataRepository.java
@@ -10,18 +10,56 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public final class JdbcCatalogValidationDataRepository implements CatalogValidationDataRepository {
+
+    static final String ITEM_DEFINITIONS_SQL = "SELECT id FROM items_base";
+    static final String HELD_CURRENCY_TYPES_SQL = "SELECT DISTINCT type FROM users_currency";
+    static final String CONFIGURED_CURRENCY_TYPES_SQL =
+            "SELECT `value` FROM emulator_settings WHERE `key` LIKE '%points.type%'";
+    static final String LIMITED_SELLS_SQL = "SELECT id, limited_sells FROM catalog_items WHERE limited_sells > 0";
+
     @Override
     public CatalogValidationReferenceData load(Connection connection) throws SQLException {
         return new CatalogValidationReferenceData(
-                loadIntegerColumn(connection, "SELECT id FROM items_base", "id"),
-                IntStream.rangeClosed(0, 100).boxed().collect(Collectors.toUnmodifiableSet()),
+                loadIntegerColumn(connection, ITEM_DEFINITIONS_SQL, "id"),
+                loadCurrencyTypes(connection),
                 loadLimitedSells(connection),
                 java.util.Arrays.stream(CatalogPageLayouts.values())
                         .map(Enum::name)
                         .collect(Collectors.toUnmodifiableSet()));
+    }
+
+    /**
+     * The currency types this hotel actually has.
+     *
+     * <p>There is no registry of currencies in the emulator - {@code getCurrencyAmount(int)} takes
+     * any integer - so the accepted set has to be read from the hotel rather than assumed. It used
+     * to be the fixed range 0..100, which flagged every offer priced in a higher-numbered currency
+     * even when players were holding it, and passed every offer priced in a currency nobody can
+     * hold as long as the number was small enough.
+     *
+     * <p>Type 0 is always accepted: it is the baseline currency every user has. Beyond that, a type
+     * counts as real if some user holds it, or if the hotel is configured to pay it out - the second
+     * source matters for a currency that has just been introduced and has no holders yet.
+     */
+    private static Set<Integer> loadCurrencyTypes(Connection connection) throws SQLException {
+        Set<Integer> types = new HashSet<>();
+        types.add(0);
+        types.addAll(loadIntegerColumn(connection, HELD_CURRENCY_TYPES_SQL, "type"));
+        try (PreparedStatement statement = connection.prepareStatement(CONFIGURED_CURRENCY_TYPES_SQL);
+                ResultSet resultSet = statement.executeQuery()) {
+            while (resultSet.next()) {
+                String value = resultSet.getString("value");
+                if (value == null) continue;
+                try {
+                    types.add(Integer.parseInt(value.trim()));
+                } catch (NumberFormatException ignored) {
+                    // A setting whose value is not a number simply names no currency.
+                }
+            }
+        }
+        return Set.copyOf(types);
     }
 
     private static Set<Integer> loadIntegerColumn(Connection connection, String sql, String column)
@@ -36,8 +74,7 @@ public final class JdbcCatalogValidationDataRepository implements CatalogValidat
 
     private static Map<Integer, Integer> loadLimitedSells(Connection connection) throws SQLException {
         Map<Integer, Integer> values = new HashMap<>();
-        try (PreparedStatement statement = connection.prepareStatement(
-                        "SELECT id, limited_sells FROM catalog_items WHERE limited_sells > 0");
+        try (PreparedStatement statement = connection.prepareStatement(LIMITED_SELLS_SQL);
                 ResultSet resultSet = statement.executeQuery()) {
             while (resultSet.next()) {
                 values.put(resultSet.getInt("id"), resultSet.getInt("limited_sells"));

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogValidationDataRepositoryTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogValidationDataRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class JdbcCatalogValidationDataRepositoryTest {
+
+    @Test
+    void acceptsTheCurrenciesTheHotelActuallyHas() throws Exception {
+        Connection connection = mock(Connection.class);
+        stubIntegerColumn(connection, JdbcCatalogValidationDataRepository.ITEM_DEFINITIONS_SQL, "id");
+        stubIntegerColumn(connection, JdbcCatalogValidationDataRepository.HELD_CURRENCY_TYPES_SQL, "type", 5, 101, 102);
+        stubStringColumn(connection, JdbcCatalogValidationDataRepository.CONFIGURED_CURRENCY_TYPES_SQL, "value");
+        stubEmpty(connection, JdbcCatalogValidationDataRepository.LIMITED_SELLS_SQL);
+
+        Set<Integer> currencies =
+                new JdbcCatalogValidationDataRepository().load(connection).currencyTypes();
+
+        // 101 and 102 are held by players; the old fixed range 0..100 rejected them.
+        assertTrue(currencies.containsAll(Set.of(0, 5, 101, 102)), () -> "got " + currencies);
+        // 104 is priced in the catalog but nobody holds it and nothing pays it out.
+        assertFalse(currencies.contains(104), () -> "got " + currencies);
+    }
+
+    @Test
+    void acceptsACurrencyTheHotelPaysOutBeforeAnyoneHoldsIt() throws Exception {
+        Connection connection = mock(Connection.class);
+        stubIntegerColumn(connection, JdbcCatalogValidationDataRepository.ITEM_DEFINITIONS_SQL, "id");
+        stubIntegerColumn(connection, JdbcCatalogValidationDataRepository.HELD_CURRENCY_TYPES_SQL, "type");
+        stubStringColumn(
+                connection,
+                JdbcCatalogValidationDataRepository.CONFIGURED_CURRENCY_TYPES_SQL,
+                "value",
+                "7",
+                "not a number",
+                null);
+        stubEmpty(connection, JdbcCatalogValidationDataRepository.LIMITED_SELLS_SQL);
+
+        Set<Integer> currencies =
+                new JdbcCatalogValidationDataRepository().load(connection).currencyTypes();
+
+        assertTrue(currencies.containsAll(Set.of(0, 7)), () -> "got " + currencies);
+        assertFalse(currencies.contains(104), () -> "got " + currencies);
+    }
+
+    private static void stubIntegerColumn(Connection connection, String sql, String column, int... values)
+            throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        Boolean[] more = new Boolean[values.length];
+        for (int i = 0; i < values.length; i++) more[i] = true;
+        when(resultSet.next()).thenReturn(values.length > 0, appendFalse(more));
+        if (values.length > 0) {
+            Integer[] rest = new Integer[values.length - 1];
+            for (int i = 1; i < values.length; i++) rest[i - 1] = values[i];
+            when(resultSet.getInt(column)).thenReturn(values[0], rest);
+        }
+        bind(connection, sql, resultSet);
+    }
+
+    private static void stubStringColumn(Connection connection, String sql, String column, String... values)
+            throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        Boolean[] more = new Boolean[values.length];
+        for (int i = 0; i < values.length; i++) more[i] = true;
+        when(resultSet.next()).thenReturn(values.length > 0, appendFalse(more));
+        if (values.length > 0) {
+            String[] rest = new String[values.length - 1];
+            System.arraycopy(values, 1, rest, 0, values.length - 1);
+            when(resultSet.getString(column)).thenReturn(values[0], rest);
+        }
+        bind(connection, sql, resultSet);
+    }
+
+    private static void stubEmpty(Connection connection, String sql) throws Exception {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.next()).thenReturn(false);
+        bind(connection, sql, resultSet);
+    }
+
+    private static void bind(Connection connection, String sql, ResultSet resultSet) throws Exception {
+        PreparedStatement statement = mock(PreparedStatement.class);
+        when(connection.prepareStatement(sql)).thenReturn(statement);
+        when(statement.executeQuery()).thenReturn(resultSet);
+    }
+
+    private static Boolean[] appendFalse(Boolean[] more) {
+        Boolean[] result = new Boolean[more.length];
+        for (int i = 0; i < more.length - 1; i++) result[i] = true;
+        if (more.length > 0) result[more.length - 1] = false;
+        return result;
+    }
+}


### PR DESCRIPTION
The catalog manager reported 808 offers as priced in an unsupported currency on a
live hotel. 731 of them were fine.

## Why

The accepted currency types came from `IntStream.rangeClosed(0, 100)` — a number
with nothing behind it. The emulator has no registry of currencies at all:
`HabboInfo.getCurrencyAmount(int type)` takes any integer, and a hotel's
currencies are whatever its `users_currency` rows and settings say they are.

So the rule was wrong in both directions:

- **False positives.** Offers priced in types 101 and 102 were flagged even
  though players hold both — 731 findings on the hotel this was measured on.
- **Missed problems.** An offer priced in a currency nobody can hold passed, as
  long as the number was under 100.

## Change

The set is read from the hotel:

- type `0` always, the baseline currency every user has;
- every type in `users_currency`, i.e. currencies players are holding;
- every type named by an `emulator_settings` key matching `%points.type%`, so a
  currency the hotel is configured to pay out is accepted before it has any
  holders.

On the hotel this was measured on, that is `{0, 5, 101, 102}` and the report goes
from **808 findings to 77** — the 77 being offers priced in type 104, which no
user holds and no setting pays out. They sit on a visible page for up to 1,000
points each and cannot be bought by anyone.

## Risks

- A hotel that introduces a currency, pays it out through nothing, and prices
  offers in it before anyone holds it will see those offers flagged. That is the
  finding the fixed range used to hide, so it is the intended behaviour rather
  than a regression, but it is a behaviour change worth knowing about.
- `users_currency` is read once per validation load, alongside the existing
  `items_base` and `catalog_items` reads.

## Verification

- `./mvnw -B -Dtest=JdbcCatalogValidationDataRepositoryTest test` — 2/2. The first
  case fails against the old fixed range, which is the regression it guards.
- `./mvnw -B -Dtest='Catalog*,Jdbc*,FrozenArchitectureBaselineTest' test` — 163/163.
- `./mvnw -B spotless:check` — clean.
