### PR TITLE
fix(catalog): give pages sharing an order slot a fixed sequence

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPage.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/CatalogPage.java
@@ -315,7 +315,13 @@ public abstract class CatalogPage implements Comparable<CatalogPage>, ISerialize
     @SuppressWarnings("NullableProblems")
     @Override
     public int compareTo(CatalogPage page) {
-        return this.getOrderNum() - page.getOrderNum();
+        // Pages sharing an order slot used to fall back to the iteration order of the child HashMap,
+        // which is not the order they were added in and shifts as pages come and go. The stock
+        // database ships eight pet pages at order 99 under one parent, so this was visible out of
+        // the box: the same catalog, a different sequence after a restart. The id keeps them steady.
+        int byOrder = Integer.compare(this.getOrderNum(), page.getOrderNum());
+
+        return byOrder != 0 ? byOrder : Integer.compare(this.getId(), page.getId());
     }
 
     @Override

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPageOrderingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/CatalogPageOrderingTest.java
@@ -1,0 +1,65 @@
+package com.eu.habbo.habbohotel.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CatalogPageOrderingTest {
+
+    /**
+     * The stock database ships eight pet pages at order 99 under the same parent, so pages sharing
+     * an order slot are the normal case rather than an edge one. They must still come out in one
+     * fixed sequence.
+     */
+    @Test
+    void pagesSharingAnOrderSlotComeOutInIdOrder() {
+        List<CatalogPage> pages = new ArrayList<>(List.of(page(96, 99), page(90, 99), page(85, 99), page(93, 99)));
+
+        Collections.sort(pages);
+
+        assertEquals(
+                List.of(85, 90, 93, 96), pages.stream().map(CatalogPage::getId).toList());
+    }
+
+    @Test
+    void theOrderSlotStillDecidesFirst() {
+        List<CatalogPage> pages = new ArrayList<>(List.of(page(10, 3), page(99, 1), page(50, 2)));
+
+        Collections.sort(pages);
+
+        assertEquals(List.of(99, 50, 10), pages.stream().map(CatalogPage::getId).toList());
+    }
+
+    /** The sequence must not depend on the order the pages happened to arrive in. */
+    @Test
+    void theResultDoesNotDependOnTheInputOrder() {
+        List<CatalogPage> one = new ArrayList<>(List.of(page(96, 99), page(85, 99), page(90, 99)));
+        List<CatalogPage> other = new ArrayList<>(List.of(page(90, 99), page(96, 99), page(85, 99)));
+
+        Collections.sort(one);
+        Collections.sort(other);
+
+        assertEquals(
+                one.stream().map(CatalogPage::getId).toList(),
+                other.stream().map(CatalogPage::getId).toList());
+    }
+
+    private static CatalogPage page(int id, int orderNum) {
+        return new TestPage(id, orderNum);
+    }
+
+    private static final class TestPage extends CatalogPage {
+        private TestPage(int id, int orderNum) {
+            this.id = id;
+            this.orderNum = orderNum;
+        }
+
+        @Override
+        public void serialize(com.eu.habbo.messages.ServerMessage message) {
+            // not exercised by ordering
+        }
+    }
+}


### PR DESCRIPTION
Catalog pages that share an order slot come out in an arbitrary sequence that can
change after a restart.

## Why

`CatalogPage.compareTo` compared order numbers and nothing else:

```java
return this.getOrderNum() - page.getOrderNum();
```

`Collections.sort` is stable, so pages with equal order keep the order they
arrived in — and that is the iteration order of `childPages`, a plain `HashMap`.
That is not the order they were added in, and it shifts as pages are added or
removed.

This is not an edge case. The packaged base database seeds eight pet pages at
order 99 under parent 680:

```
(85, 680, 'chick',     'Chick',       'pets', 1, 107, 1, 99, ...)
(90, 680, 'bunny',     'Bunny',       'pets', 1, 148, 1, 99, ...)
(91, 680, 'bunny_bad', 'Bunny - Bad', 'pets', 1, 151, 1, 99, ...)
```

So a stock hotel shows those pages in a sequence nobody chose, and the catalog
manager reports each of them as a duplicate order — correctly, because the order
really is ambiguous.

## Change

Ties break on the page id, so the sequence is fixed:

```java
int byOrder = Integer.compare(this.getOrderNum(), page.getOrderNum());

return byOrder != 0 ? byOrder : Integer.compare(this.getId(), page.getId());
```

`Integer.compare` rather than subtraction, which overflows on distant order
numbers.

## Scope

This makes the display order stable and predictable; it does not remove the
underlying ambiguity. An operator still cannot choose the relative order of
pages sharing a slot, and the manager still reports them — renumbering that data
is a separate, per-hotel job.

## Verification

- `./mvnw -B -Dtest=CatalogPageOrderingTest test` — 3/3: pages sharing a slot come
  out in id order, an explicit order still decides first, and the result does not
  depend on the order the pages arrived in.
- `./mvnw -B -Dtest='Catalog*,Jdbc*,FrozenArchitectureBaselineTest' test` — 166/166.
- `./mvnw -B spotless:check` — clean.
