### PR TITLE
perf(catalog): read only the offers a save can reach

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationService.java
@@ -194,7 +194,7 @@ public final class CatalogLiveMutationService {
             connection.setAutoCommit(false);
             try {
                 CatalogRuntimeState state = versions.lockRuntimeState(connection);
-                CatalogVersionSnapshot active = loadPhysicalLive(connection, state);
+                CatalogVersionSnapshot active = loadPhysicalLive(connection, state, CatalogMutationScope.of(requests));
                 if (active.version().status() != CatalogVersionStatus.PUBLISHED) {
                     throw new IllegalStateException("Live catalog state is not available");
                 }
@@ -478,6 +478,24 @@ public final class CatalogLiveMutationService {
         return liveSnapshots == null
                 ? versions.loadSnapshot(connection, state.activeVersionId())
                 : liveSnapshots.loadForRead(connection, version);
+    }
+
+    /**
+     * Reads what a batch of mutations can reach, rather than the whole catalog.
+     *
+     * <p>Every page is still read - the rules that judge a page walk the tree around it, and pages
+     * are cheap. Offers are not: a live catalog holds 112,000 of them and a save touches a handful,
+     * so reading and locking all of them cost about 200 ms per edit for nothing.
+     */
+    private CatalogVersionSnapshot loadPhysicalLive(
+            Connection connection, CatalogRuntimeState state, CatalogMutationScope scope) throws SQLException {
+        CatalogVersion version = versions.loadVersion(connection, state.activeVersionId());
+        if (version.status() != CatalogVersionStatus.PUBLISHED) {
+            throw new IllegalStateException("Live catalog state is not available");
+        }
+        return liveSnapshots == null
+                ? versions.loadSnapshot(connection, state.activeVersionId())
+                : liveSnapshots.loadForMutation(connection, version, scope);
     }
 
     private CatalogVersionSnapshot loadPhysicalLive(Connection connection, CatalogRuntimeState state)

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSnapshotRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveSnapshotRepository.java
@@ -12,4 +12,15 @@ public interface CatalogLiveSnapshotRepository {
     default CatalogVersionSnapshot loadForRead(Connection connection, CatalogVersion version) throws SQLException {
         return load(connection, version);
     }
+
+    /**
+     * Reads every page, and only the offers the given mutations can reach, locking what it reads.
+     *
+     * <p>Defaults to the full locking read, so an implementation that cannot narrow stays correct -
+     * a snapshot with more offers than needed is never wrong, only slower.
+     */
+    default CatalogVersionSnapshot loadForMutation(
+            Connection connection, CatalogVersion version, CatalogMutationScope scope) throws SQLException {
+        return load(connection, version);
+    }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogMutationScope.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogMutationScope.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.habbohotel.catalog.versioning;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPageType;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The offers a batch of mutations can reach.
+ *
+ * <p>A save used to read and lock the whole catalog - 112,000 offers on a live hotel - to change one
+ * row. Pages are cheap and are always read in full, because the rules that judge a page walk the
+ * tree. Offers are not: an offer is only read when the batch names it, or when it sits on a page the
+ * batch creates or deletes, which is the only way a page edit can change an offer's verdict or block
+ * a delete.
+ */
+public final class CatalogMutationScope {
+
+    private final Map<CatalogPageType, Set<Integer>> offerIds = new EnumMap<>(CatalogPageType.class);
+    private final Map<CatalogPageType, Set<Integer>> pageIds = new EnumMap<>(CatalogPageType.class);
+
+    private CatalogMutationScope() {}
+
+    public static CatalogMutationScope of(Collection<CatalogLiveMutationRequest> requests) {
+        CatalogMutationScope scope = new CatalogMutationScope();
+
+        for (CatalogLiveMutationRequest request : requests) {
+            Map<CatalogPageType, Set<Integer>> target =
+                    request.entityType() == CatalogEntityType.PAGE ? scope.pageIds : scope.offerIds;
+            target.computeIfAbsent(request.catalogType(), ignored -> new HashSet<>())
+                    .add(request.entityId());
+        }
+
+        return scope;
+    }
+
+    /** Offers named directly by the batch. */
+    public Set<Integer> offerIds(CatalogPageType catalogType) {
+        return Set.copyOf(offerIds.getOrDefault(catalogType, Set.of()));
+    }
+
+    /** Pages named by the batch; their offers are read so a page edit still sees them. */
+    public Set<Integer> pageIds(CatalogPageType catalogType) {
+        return Set.copyOf(pageIds.getOrDefault(catalogType, Set.of()));
+    }
+
+    public boolean isEmpty(CatalogPageType catalogType) {
+        return offerIds(catalogType).isEmpty() && pageIds(catalogType).isEmpty();
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveSnapshotRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/catalog/versioning/JdbcCatalogLiveSnapshotRepository.java
@@ -15,18 +15,20 @@ public final class JdbcCatalogLiveSnapshotRepository implements CatalogLiveSnaps
             + "page_headline, page_teaser, COALESCE(page_special, '') AS page_special, page_text1, page_text2, "
             + "page_text_details, page_text_teaser, COALESCE(room_id, 0) AS room_id, includes "
             + "FROM catalog_pages ORDER BY id";
-    static final String READ_NORMAL_OFFERS_SQL = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
+    static final String NORMAL_OFFERS_SELECT = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
             + "cost_credits, cost_points, points_type, amount, limited_stack, order_number, offer_id AS offer_id_client, "
-            + "song_id, extradata, have_offer, club_only FROM catalog_items ORDER BY id";
+            + "song_id, extradata, have_offer, club_only FROM catalog_items";
+    static final String READ_NORMAL_OFFERS_SQL = NORMAL_OFFERS_SELECT + " ORDER BY id";
     static final String READ_BUILDER_PAGES_SQL = "SELECT id AS page_id, parent_id, '' AS caption_save, caption, "
             + "page_layout, icon_color, icon_image, 1 AS min_rank, order_num, visible, enabled, 0 AS club_only, "
             + "'BUILDER' AS catalog_mode, 0 AS vip_only, page_headline, page_teaser, "
             + "COALESCE(page_special, '') AS page_special, page_text1, page_text2, page_text_details, "
             + "page_text_teaser, 0 AS room_id, '' AS includes FROM catalog_pages_bc ORDER BY id";
-    static final String READ_BUILDER_OFFERS_SQL = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
+    static final String BUILDER_OFFERS_SELECT = "SELECT id AS offer_id, item_ids, page_id, catalog_name, "
             + "0 AS cost_credits, 0 AS cost_points, 0 AS points_type, 1 AS amount, 0 AS limited_stack, order_number, "
             + "-1 AS offer_id_client, 0 AS song_id, extradata, 1 AS have_offer, 0 AS club_only "
-            + "FROM catalog_items_bc ORDER BY id";
+            + "FROM catalog_items_bc";
+    static final String READ_BUILDER_OFFERS_SQL = BUILDER_OFFERS_SELECT + " ORDER BY id";
     static final String LOAD_NORMAL_PAGES_SQL = READ_NORMAL_PAGES_SQL + FOR_UPDATE;
     static final String LOAD_NORMAL_OFFERS_SQL = READ_NORMAL_OFFERS_SQL + FOR_UPDATE;
     static final String LOAD_BUILDER_PAGES_SQL = READ_BUILDER_PAGES_SQL + FOR_UPDATE;
@@ -59,6 +61,56 @@ public final class JdbcCatalogLiveSnapshotRepository implements CatalogLiveSnaps
                 READ_NORMAL_OFFERS_SQL,
                 READ_BUILDER_PAGES_SQL,
                 READ_BUILDER_OFFERS_SQL);
+    }
+
+    /**
+     * Reads every page and only the offers the batch can reach.
+     *
+     * <p>Pages are read whole because the rules that judge one walk the tree around it, and they are
+     * cheap - a live catalog of 112,000 offers had 2,236 pages. The offers are the cost, and a save
+     * needs a handful of them: the ones it names, plus the ones sitting on a page it creates or
+     * deletes.
+     */
+    @Override
+    public CatalogVersionSnapshot loadForMutation(
+            Connection connection, CatalogVersion version, CatalogMutationScope scope) throws SQLException {
+        List<CatalogPageSnapshot> pages =
+                new ArrayList<>(loadPages(connection, LOAD_NORMAL_PAGES_SQL, CatalogPageType.NORMAL));
+        pages.addAll(loadPages(connection, LOAD_BUILDER_PAGES_SQL, CatalogPageType.BUILDER));
+
+        List<CatalogOfferSnapshot> offers =
+                new ArrayList<>(loadScopedOffers(connection, NORMAL_OFFERS_SELECT, CatalogPageType.NORMAL, scope));
+        offers.addAll(loadScopedOffers(connection, BUILDER_OFFERS_SELECT, CatalogPageType.BUILDER, scope));
+
+        return new CatalogVersionSnapshot(version, pages, offers);
+    }
+
+    private static List<CatalogOfferSnapshot> loadScopedOffers(
+            Connection connection, String selectSql, CatalogPageType catalogType, CatalogMutationScope scope)
+            throws SQLException {
+        if (scope.isEmpty(catalogType)) return List.of();
+
+        List<Integer> offerIds = new ArrayList<>(scope.offerIds(catalogType));
+        List<Integer> pageIds = new ArrayList<>(scope.pageIds(catalogType));
+        List<String> clauses = new ArrayList<>(2);
+        if (!offerIds.isEmpty()) clauses.add("id IN (" + placeholders(offerIds.size()) + ")");
+        if (!pageIds.isEmpty()) clauses.add("page_id IN (" + placeholders(pageIds.size()) + ")");
+
+        String sql = selectSql + " WHERE " + String.join(" OR ", clauses) + " ORDER BY id" + FOR_UPDATE;
+        List<CatalogOfferSnapshot> offers = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            for (int offerId : offerIds) statement.setInt(index++, offerId);
+            for (int pageId : pageIds) statement.setInt(index++, pageId);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) offers.add(readOffer(resultSet, catalogType));
+            }
+        }
+        return offers;
+    }
+
+    private static String placeholders(int count) {
+        return String.join(",", java.util.Collections.nCopies(count, "?"));
     }
 
     private static CatalogVersionSnapshot load(
@@ -120,25 +172,30 @@ public final class JdbcCatalogLiveSnapshotRepository implements CatalogLiveSnaps
         try (PreparedStatement statement = connection.prepareStatement(sql);
                 ResultSet resultSet = statement.executeQuery()) {
             while (resultSet.next()) {
-                offers.add(new CatalogOfferSnapshot(
-                        catalogType,
-                        resultSet.getInt("offer_id"),
-                        resultSet.getString("item_ids"),
-                        resultSet.getInt("page_id"),
-                        resultSet.getString("catalog_name"),
-                        resultSet.getInt("cost_credits"),
-                        resultSet.getInt("cost_points"),
-                        resultSet.getInt("points_type"),
-                        resultSet.getInt("amount"),
-                        resultSet.getInt("limited_stack"),
-                        resultSet.getInt("order_number"),
-                        resultSet.getInt("offer_id_client"),
-                        resultSet.getInt("song_id"),
-                        resultSet.getString("extradata"),
-                        JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "have_offer"),
-                        JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "club_only")));
+                offers.add(readOffer(resultSet, catalogType));
             }
         }
         return offers;
+    }
+
+    private static CatalogOfferSnapshot readOffer(ResultSet resultSet, CatalogPageType catalogType)
+            throws SQLException {
+        return new CatalogOfferSnapshot(
+                catalogType,
+                resultSet.getInt("offer_id"),
+                resultSet.getString("item_ids"),
+                resultSet.getInt("page_id"),
+                resultSet.getString("catalog_name"),
+                resultSet.getInt("cost_credits"),
+                resultSet.getInt("cost_points"),
+                resultSet.getInt("points_type"),
+                resultSet.getInt("amount"),
+                resultSet.getInt("limited_stack"),
+                resultSet.getInt("order_number"),
+                resultSet.getInt("offer_id_client"),
+                resultSet.getInt("song_id"),
+                resultSet.getString("extradata"),
+                JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "have_offer"),
+                JdbcCatalogVersionRepository.readStrictBoolean(resultSet, "club_only"));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationServiceTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/catalog/versioning/CatalogLiveMutationServiceTest.java
@@ -2,6 +2,7 @@ package com.eu.habbo.habbohotel.catalog.versioning;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -101,7 +102,8 @@ class CatalogLiveMutationServiceTest {
     void recordsTheClientOperationIdInTheSameLiveTransaction() throws Exception {
         CatalogVersionSnapshot physicalLive = new CatalogVersionSnapshot(
                 versions.loadVersion(connection, ACTIVE_VERSION_ID), List.of(page(true)), List.of());
-        when(liveSnapshots.load(eq(connection), any(CatalogVersion.class))).thenReturn(physicalLive);
+        when(liveSnapshots.loadForMutation(eq(connection), any(CatalogVersion.class), any(CatalogMutationScope.class)))
+                .thenReturn(physicalLive);
         when(operations.findForUpdate(connection, "save-page-1", 7)).thenReturn(Optional.empty());
         CatalogLiveMutationService physicalService = new CatalogLiveMutationService(
                 serviceDataSource(), versions, journal, snapshots, liveSnapshots, live, hook, null, operations, gson);
@@ -393,6 +395,60 @@ class CatalogLiveMutationServiceTest {
                         99,
                         CatalogChangeOperation.UPDATE,
                         gson.toJson(page(false))))));
+    }
+
+    @Test
+    void aSaveReadsOnlyTheOffersTheBatchCanReach() throws Exception {
+        CatalogOfferSnapshot existing = new CatalogOfferSnapshot(
+                CatalogPageType.NORMAL, 42, "12", 17, "chair", 3, 0, 0, 1, 0, 1, -1, 0, "", true, false);
+        CatalogVersionSnapshot physicalLive = new CatalogVersionSnapshot(
+                versions.loadVersion(connection, ACTIVE_VERSION_ID), List.of(page(true)), List.of(existing));
+        ArgumentCaptor<CatalogMutationScope> scope = ArgumentCaptor.forClass(CatalogMutationScope.class);
+        when(liveSnapshots.loadForMutation(eq(connection), any(CatalogVersion.class), scope.capture()))
+                .thenReturn(physicalLive);
+        CatalogDraftOfferData offer =
+                new CatalogDraftOfferData("12", 17, "chair", 3, 0, 0, 1, 0, 1, -1, 0, "", true, false);
+        CatalogLiveMutationService physicalService = new CatalogLiveMutationService(
+                serviceDataSource(), versions, journal, snapshots, liveSnapshots, live, hook, null, gson);
+
+        physicalService.applyBatch(List.of(new CatalogLiveMutationRequest(
+                -1,
+                7,
+                "Update offer",
+                CatalogEntityType.OFFER,
+                CatalogPageType.NORMAL,
+                42,
+                CatalogChangeOperation.UPDATE,
+                gson.toJson(offer))));
+
+        // The whole catalog is never read for one edit; only what the batch names.
+        verify(liveSnapshots, org.mockito.Mockito.never()).load(eq(connection), any(CatalogVersion.class));
+        assertEquals(java.util.Set.of(42), scope.getValue().offerIds(CatalogPageType.NORMAL));
+        assertTrue(scope.getValue().pageIds(CatalogPageType.NORMAL).isEmpty());
+    }
+
+    @Test
+    void aPageEditAlsoReachesTheOffersSittingOnIt() throws Exception {
+        CatalogVersionSnapshot physicalLive = new CatalogVersionSnapshot(
+                versions.loadVersion(connection, ACTIVE_VERSION_ID), List.of(page(true)), List.of());
+        ArgumentCaptor<CatalogMutationScope> scope = ArgumentCaptor.forClass(CatalogMutationScope.class);
+        when(liveSnapshots.loadForMutation(eq(connection), any(CatalogVersion.class), scope.capture()))
+                .thenReturn(physicalLive);
+        CatalogLiveMutationService physicalService = new CatalogLiveMutationService(
+                serviceDataSource(), versions, journal, snapshots, liveSnapshots, live, hook, null, gson);
+
+        physicalService.applyBatch(List.of(new CatalogLiveMutationRequest(
+                -1,
+                7,
+                "Change visibility",
+                CatalogEntityType.PAGE,
+                CatalogPageType.NORMAL,
+                17,
+                CatalogChangeOperation.UPDATE,
+                gson.toJson(page(false)))));
+
+        // A page edit can orphan or free the offers on that page, so they are read with it.
+        assertEquals(java.util.Set.of(17), scope.getValue().pageIds(CatalogPageType.NORMAL));
     }
 
     private static CatalogPageSnapshot page(boolean visible) {


### PR DESCRIPTION
Saving one offer read and locked the whole live catalog: four
`SELECT ... FOR UPDATE` scans, **112,246 offers** on the hotel this was measured
against, about **200 ms** of every edit before any work was done.

## Change

`applyBatch` now asks for what the batch can reach.

- **Pages are still read whole.** The rules that judge a page walk the tree around
  it — descendants, siblings, includers — and there are 2,236 of them against
  112,246 offers, so they are not the cost (6 ms measured).
- **Offers are read when the batch names them**, or when they sit on a page the
  batch creates or deletes. That is the only way a page edit can change an
  offer's verdict, and it is what `CatalogAdminDeletePageEvent`'s precondition
  needs — it scans for offers still sitting on the page being removed.

Every consumer of the snapshot was checked before narrowing: the four admin
preconditions (`DeleteOffer`, `DeletePage`, `ReorderOffers`, `SaveOffer`),
`buildChange`'s before-image lookup, and the validation guard.

`loadForMutation` defaults to the full locking read, so an implementation that
cannot narrow stays correct — a snapshot with more offers than needed is never
wrong, only slower. `loadLive()` and the undo path keep reading everything.

## Risks

- A mutation snapshot no longer contains every offer. Anything added to the
  mutation path in future must ask itself whether the offer it wants is in
  scope; the two new tests state the rule.
- The `FOR UPDATE` now covers the rows the save touches instead of the whole
  table. Mutations are already serialized by the runtime-state lock, so this
  narrows blast radius rather than protection.

## Verification

- `./mvnw -B -Dtest=CatalogLiveMutationServiceTest test` — 14/14, including two
  new cases: a save names its offer and no page, a page edit reaches the offers
  sitting on it, and neither goes through the full read
  (`verify(never()).load(...)`).
- `./mvnw -B -Dtest='Catalog*,Jdbc*,FrozenArchitectureBaselineTest' test` — 168/168.
- `./mvnw -B spotless:check` — clean.

The end-to-end saving time is not measured here: that needs a running emulator,
which this machine cannot start. What is measured is the read it removes —
113 ms for `catalog_items` alone, on the real catalog.
