### PR TITLE
Date a chatlog line that is not from today

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolChatlogTimestamp.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolChatlogTimestamp.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.outgoing.modtool;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * How a chat line is stamped in the moderation tool.
+ *
+ * <p>Every chatlog used to read {@code HH:mm} and nothing else, so a moderator reading a report
+ * about yesterday saw "12:04" with no way to tell which day it belonged to. The day is added only
+ * when the line is not from today, which keeps a live room's log as short as it was.
+ *
+ * <p>The field is a free-form string on the wire, so this changes what is written in it and not the
+ * shape of any packet.
+ */
+public final class ModToolChatlogTimestamp {
+
+    private static final ZoneId ZONE = ZoneId.systemDefault();
+    private static final DateTimeFormatter TIME =
+            DateTimeFormatter.ofPattern("HH:mm").withZone(ZONE);
+    private static final DateTimeFormatter DATE_AND_TIME =
+            DateTimeFormatter.ofPattern("dd/MM HH:mm").withZone(ZONE);
+
+    private ModToolChatlogTimestamp() {}
+
+    /** @param epochSeconds when the line was said */
+    public static String format(long epochSeconds) {
+        return format(Instant.ofEpochSecond(epochSeconds));
+    }
+
+    public static String format(Instant instant) {
+        if (instant == null) return "";
+
+        return LocalDate.ofInstant(instant, ZONE).equals(LocalDate.now(ZONE))
+                ? TIME.format(instant)
+                : DATE_AND_TIME.format(instant);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolIssueChatlogComposer.java
@@ -11,7 +11,6 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -108,7 +107,7 @@ public class ModToolIssueChatlogComposer extends MessageComposer {
     }
 
     static String formatTimestamp(int timestamp) {
-        return TIMESTAMP_FORMATTER.format(Instant.ofEpochSecond(timestamp));
+        return ModToolChatlogTimestamp.format(timestamp);
     }
 
     public ModToolIssue getIssue() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolRoomChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolRoomChatlogComposer.java
@@ -5,10 +5,7 @@ import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 
 public class ModToolRoomChatlogComposer extends MessageComposer {
     private final Room room;
@@ -31,11 +28,9 @@ public class ModToolRoomChatlogComposer extends MessageComposer {
         this.response.appendByte(1);
         this.response.appendInt(this.room.getId());
 
-        SimpleDateFormat formatDate = new SimpleDateFormat("HH:mm");
-
         this.response.appendShort(this.chatlog.size());
         for (ModToolChatLog line : this.chatlog) {
-            this.response.appendString(formatDate.format(new Date((line.timestamp * 1000L))));
+            this.response.appendString(ModToolChatlogTimestamp.format(line.timestamp));
             this.response.appendInt(line.habboId);
             this.response.appendString(line.username);
             this.response.appendString(line.message);

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/modtool/ModToolUserChatlogComposer.java
@@ -6,7 +6,6 @@ import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -55,7 +54,7 @@ public class ModToolUserChatlogComposer extends MessageComposer {
     }
 
     static String formatTimestamp(int timestamp) {
-        return TIMESTAMP_FORMATTER.format(Instant.ofEpochSecond(timestamp));
+        return ModToolChatlogTimestamp.format(timestamp);
     }
 
     public ArrayList<ModToolRoomVisit> getSet() {

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolChatlogTimestampTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolChatlogTimestampTest.java
@@ -1,0 +1,51 @@
+package com.eu.habbo.messages.outgoing.modtool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+
+class ModToolChatlogTimestampTest {
+
+    private static final ZoneId ZONE = ZoneId.systemDefault();
+
+    @Test
+    void aLineFromTodayIsJustTheTime() {
+        Instant today =
+                LocalDate.now(ZONE).atTime(LocalTime.of(12, 4)).atZone(ZONE).toInstant();
+
+        assertEquals("12:04", ModToolChatlogTimestamp.format(today));
+    }
+
+    /** A report about yesterday used to read "12:04" with no way to tell which day that was. */
+    @Test
+    void anOlderLineCarriesTheDay() {
+        Instant yesterday = LocalDate.now(ZONE)
+                .minusDays(1)
+                .atTime(LocalTime.of(12, 4))
+                .atZone(ZONE)
+                .toInstant();
+
+        String stamped = ModToolChatlogTimestamp.format(yesterday);
+
+        assertTrue(stamped.endsWith(" 12:04"), () -> "got " + stamped);
+        assertEquals(11, stamped.length(), () -> "got " + stamped);
+    }
+
+    @Test
+    void secondsSinceTheEpochAreAcceptedToo() {
+        long epochSeconds =
+                LocalDate.now(ZONE).atTime(LocalTime.of(9, 30)).atZone(ZONE).toEpochSecond();
+
+        assertEquals("09:30", ModToolChatlogTimestamp.format(epochSeconds));
+    }
+
+    @Test
+    void aMissingInstantIsEmptyRatherThanACrash() {
+        assertEquals("", ModToolChatlogTimestamp.format((Instant) null));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/outgoing/modtool/ModToolTimestampFormattingTest.java
@@ -11,10 +11,17 @@ import org.junit.jupiter.api.Test;
 class ModToolTimestampFormattingTest {
     private static final int TIMESTAMP = 1_700_000_000;
 
+    /**
+     * A chat line carries the day when it is not from today. The timestamp above is from 2023, so
+     * both chatlogs must date it; a line from today stays the bare time it always was.
+     */
     @Test
     void preservesChatlogAndUserInfoTimestampText() {
-        assertEquals(format("HH:mm", TIMESTAMP), ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
-        assertEquals(format("HH:mm", TIMESTAMP), ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));
+        assertEquals(format("dd/MM HH:mm", TIMESTAMP), ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
+        assertEquals(format("dd/MM HH:mm", TIMESTAMP), ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));
+        int today = (int) (System.currentTimeMillis() / 1000L);
+        assertEquals(format("HH:mm", today), ModToolUserChatlogComposer.formatTimestamp(today));
+        assertEquals(format("HH:mm", today), ModToolIssueChatlogComposer.formatTimestamp(today));
         assertEquals(format("yyyy-MM-dd HH:mm", TIMESTAMP), ModToolUserInfoComposer.formatUnixTimestamp(TIMESTAMP));
         assertEquals("", ModToolUserInfoComposer.formatUnixTimestamp(0));
     }
@@ -43,7 +50,7 @@ class ModToolTimestampFormattingTest {
         try {
             ModToolUserChatlogComposer.format = new SimpleDateFormat("ss");
             ModToolIssueChatlogComposer.format = new SimpleDateFormat("ss");
-            String expected = format("HH:mm", TIMESTAMP);
+            String expected = format("dd/MM HH:mm", TIMESTAMP);
 
             assertEquals(expected, ModToolUserChatlogComposer.formatTimestamp(TIMESTAMP));
             assertEquals(expected, ModToolIssueChatlogComposer.formatTimestamp(TIMESTAMP));


### PR DESCRIPTION
## What this changes

Every chatlog line the moderation tool receives was stamped `HH:mm` and nothing else. A report about something said yesterday, or last week, showed up as "12:04" with no way to tell which day that was — and the three composers that build these logs (room, user, issue) each formatted the timestamp themselves, so the format was repeated three times.

`ModToolChatlogTimestamp` now owns it: a line from today is still `HH:mm`, and anything older carries `dd/MM HH:mm`. A live room's log is exactly as short as it was, and an old one is no longer ambiguous.

## Risk

The timestamp is a free-form string on the wire, so this changes what is written into the field and not the shape of any packet. No client change is required.

## Verification

```
./mvnw -B -Dtest='ModToolChatlogTimestampTest,ModToolTimestampFormattingTest' test
```

8 tests, all green. `ModToolChatlogTimestampTest` covers today, an older day, the epoch-seconds overload and a null instant; `ModToolTimestampFormattingTest` was updated to assert both formats rather than only `HH:mm`.
