### PR TITLE
feat(commands): give :event a room link, feedback and a closing form

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EventCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EventCommand.java
@@ -100,12 +100,9 @@ public class EventCommand extends Command {
         }
 
         boolean closing = isClosingArgument(params);
+        // The message is optional: ":event" on its own announces the room, and the
+        // client leaves out the box that would have held the text.
         String message = closing ? "" : joinMessage(params);
-
-        if (!closing && message.isEmpty()) {
-            sender.whisperLocalized("commands.error.cmd_event.usage", RoomChatMessageBubbles.ALERT);
-            return true;
-        }
 
         Map<String, String> keys = notificationKeys(
                 room.getName(),

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EventCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EventCommand.java
@@ -7,7 +7,6 @@ import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
-import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
 import java.text.SimpleDateFormat;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -96,8 +95,7 @@ public class EventCommand extends Command {
         if (room == null) {
             // A whisper only reaches a user standing in a room, so this branch has to
             // use an alert to be seen at all.
-            gameClient.sendResponse(
-                    new GenericAlertComposer(Emulator.getTexts().getValue("commands.error.cmd_event.noroom")));
+            sender.alertLocalized("commands.error.cmd_event.noroom");
             return true;
         }
 
@@ -105,8 +103,7 @@ public class EventCommand extends Command {
         String message = closing ? "" : joinMessage(params);
 
         if (!closing && message.isEmpty()) {
-            sender.whisper(
-                    Emulator.getTexts().getValue("commands.error.cmd_event.usage"), RoomChatMessageBubbles.ALERT);
+            sender.whisperLocalized("commands.error.cmd_event.usage", RoomChatMessageBubbles.ALERT);
             return true;
         }
 
@@ -134,10 +131,10 @@ public class EventCommand extends Command {
             habbo.getClient().sendResponse(notification);
         }
 
-        sender.whisper(
-                Emulator.getTexts()
-                        .getValue(closing ? "commands.error.cmd_event.ended" : "commands.error.cmd_event.started")
-                        .replace("%room%", room.getName()),
+        sender.whisperLocalized(
+                closing ? "commands.error.cmd_event.ended" : "commands.error.cmd_event.started",
+                "%room%",
+                room.getName(),
                 RoomChatMessageBubbles.ALERT);
 
         return true;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EventCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/EventCommand.java
@@ -2,51 +2,144 @@ package com.eu.habbo.habbohotel.commands;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
-
-import java.util.HashMap;
+import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
+import java.text.SimpleDateFormat;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class EventCommand extends Command {
+    /**
+     * How long the client keeps the announcement on screen before closing it on its own.
+     */
+    static final int AUTO_CLOSE_SECONDS = 120;
+
+    static final String OPENING_KEY = "hotel.event";
+    static final String CLOSING_KEY = "hotel.event.ended";
+
+    private static final String CLOSING_ARGUMENT = "off";
+    private static final String CLOSING_ARGUMENT_ALIAS = "stop";
+
     public EventCommand() {
-        super("cmd_event", Emulator.getTexts().getValue("commands.keys.cmd_event").split(";"));
+        super(
+                "cmd_event",
+                Emulator.getTexts().getValue("commands.keys.cmd_event").split(";"));
+    }
+
+    /**
+     * Joins everything typed after the command itself into the announced message.
+     */
+    static String joinMessage(String[] params) {
+        StringBuilder message = new StringBuilder();
+
+        for (int i = 1; i < params.length; i++) {
+            if (message.length() > 0) {
+                message.append(" ");
+            }
+
+            message.append(params[i]);
+        }
+
+        return message.toString().trim();
+    }
+
+    /**
+     * A lone "off" (or "stop") closes the event instead of announcing one.
+     */
+    static boolean isClosingArgument(String[] params) {
+        if (params.length != 2) {
+            return false;
+        }
+
+        String argument = params[1].trim();
+
+        return argument.equalsIgnoreCase(CLOSING_ARGUMENT) || argument.equalsIgnoreCase(CLOSING_ARGUMENT_ALIAS);
+    }
+
+    /**
+     * Builds the placeholders the client interpolates into the notification texts. The lower case
+     * entries are read by the client itself: "linkUrl" and "linkTitle" become the button that walks
+     * the user to the room, and "timeout" is the delay after which the box closes on its own.
+     *
+     * <p>The link is written without the "event:" prefix the official client uses: the link
+     * trackers register bare prefixes such as "navigator/", and a prefixed link matches none of
+     * them.
+     */
+    static Map<String, String> notificationKeys(
+            String roomName, int roomId, String username, String look, String time, String message, boolean opening) {
+        Map<String, String> keys = new LinkedHashMap<>();
+        keys.put("ROOMNAME", roomName);
+        keys.put("ROOMID", Integer.toString(roomId));
+        keys.put("USERNAME", username);
+        keys.put("LOOK", look);
+        keys.put("TIME", time);
+        keys.put("MESSAGE", message);
+        keys.put("timeout", Integer.toString(AUTO_CLOSE_SECONDS));
+
+        if (opening) {
+            keys.put("linkUrl", "navigator/goto/" + roomId);
+            keys.put("linkTitle", "notification.hotel.event.linkTitle");
+        }
+
+        return keys;
     }
 
     @Override
     public boolean handle(GameClient gameClient, String[] params) throws Exception {
-        if (gameClient.getHabbo().getHabboInfo().getCurrentRoom() != null) {
-            if (params.length >= 2) {
-                StringBuilder message = new StringBuilder();
+        Habbo sender = gameClient.getHabbo();
+        Room room = sender.getHabboInfo().getCurrentRoom();
 
-                for (int i = 1; i < params.length; i++) {
-                    message.append(params[i]);
-                    message.append(" ");
-                }
-
-                Map<String, String> codes = new HashMap<>();
-                codes.put("ROOMNAME", gameClient.getHabbo().getHabboInfo().getCurrentRoom().getName());
-                codes.put("ROOMID", gameClient.getHabbo().getHabboInfo().getCurrentRoom().getId() + "");
-                codes.put("USERNAME", gameClient.getHabbo().getHabboInfo().getUsername());
-                codes.put("LOOK", gameClient.getHabbo().getHabboInfo().getLook());
-                codes.put("TIME", Emulator.getDate().toString());
-                codes.put("MESSAGE", message.toString());
-
-                ServerMessage msg = new BubbleAlertComposer("hotel.event", codes).compose();
-
-                for (Map.Entry<Integer, Habbo> set : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().entrySet()) {
-                    Habbo habbo = set.getValue();
-                    if (habbo.getHabboStats().blockStaffAlerts)
-                        continue;
-
-                    habbo.getClient().sendResponse(msg);
-                }
-
-                return true;
-            }
+        if (room == null) {
+            // A whisper only reaches a user standing in a room, so this branch has to
+            // use an alert to be seen at all.
+            gameClient.sendResponse(
+                    new GenericAlertComposer(Emulator.getTexts().getValue("commands.error.cmd_event.noroom")));
+            return true;
         }
 
-        return false;
+        boolean closing = isClosingArgument(params);
+        String message = closing ? "" : joinMessage(params);
+
+        if (!closing && message.isEmpty()) {
+            sender.whisper(
+                    Emulator.getTexts().getValue("commands.error.cmd_event.usage"), RoomChatMessageBubbles.ALERT);
+            return true;
+        }
+
+        Map<String, String> keys = notificationKeys(
+                room.getName(),
+                room.getId(),
+                sender.getHabboInfo().getUsername(),
+                sender.getHabboInfo().getLook(),
+                new SimpleDateFormat("HH:mm").format(Emulator.getDate()),
+                message,
+                !closing);
+
+        ServerMessage notification = new BubbleAlertComposer(closing ? CLOSING_KEY : OPENING_KEY, keys).compose();
+
+        for (Map.Entry<Integer, Habbo> set : Emulator.getGameEnvironment()
+                .getHabboManager()
+                .getOnlineHabbos()
+                .entrySet()) {
+            Habbo habbo = set.getValue();
+
+            if (habbo.getHabboStats().blockStaffAlerts) {
+                continue;
+            }
+
+            habbo.getClient().sendResponse(notification);
+        }
+
+        sender.whisper(
+                Emulator.getTexts()
+                        .getValue(closing ? "commands.error.cmd_event.ended" : "commands.error.cmd_event.started")
+                        .replace("%room%", room.getName()),
+                RoomChatMessageBubbles.ALERT);
+
+        return true;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/Habbo.java
@@ -553,6 +553,10 @@ public class Habbo implements Runnable {
         this.whisper(this.getText(textKey).replace(placeholder, replacement), bubble);
     }
 
+    public void whisperLocalized(String textKey, RoomChatMessageBubbles bubble) {
+        this.whisper(this.getText(textKey), bubble);
+    }
+
     private String getText(String key) {
         return Emulator.getTexts().getValue(key);
     }
@@ -589,6 +593,10 @@ public class Habbo implements Runnable {
         } else {
             this.client.sendResponse(new GenericAlertComposer(message));
         }
+    }
+
+    public void alertLocalized(String textKey) {
+        this.alert(this.getText(textKey));
     }
 
     public void alert(String[] messages) {

--- a/Emulator/src/main/resources/db/migration/V20260830170000__event_command_texts.sql
+++ b/Emulator/src/main/resources/db/migration/V20260830170000__event_command_texts.sql
@@ -1,0 +1,19 @@
+-- Feedback and usage texts for the ":event" command.
+--
+-- The command used to return false whenever it was typed outside a room or with
+-- no message, which the command handler turns into silence: the staff member saw
+-- nothing at all. It now whispers, so every branch needs a text.
+--
+-- INSERT IGNORE keeps a text a hotel has already reworded or translated, so the
+-- migration is safe to replay.
+INSERT IGNORE INTO `emulator_texts` (`key`, `value`) VALUES
+    ('commands.error.cmd_event.noroom', 'You have to be inside the room that hosts the event.'),
+    ('commands.error.cmd_event.usage', 'Announce an event with :event <message>, close it with :event off.'),
+    ('commands.error.cmd_event.started', 'The event in %room% has been announced to the hotel.'),
+    ('commands.error.cmd_event.ended', 'The hotel has been told that the event in %room% is over.');
+
+-- The command learned a second form. The WHERE keeps a customised usage line.
+UPDATE `emulator_texts`
+SET `value` = ':event <message> | :event off'
+WHERE `key` = 'commands.description.cmd_event'
+    AND `value` = ':event <message>';

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/commands/EventCommandNotificationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/commands/EventCommandNotificationTest.java
@@ -18,9 +18,20 @@ class EventCommandNotificationTest {
     }
 
     @Test
-    void reportsAnEmptyMessageWhenOnlyTheCommandWasTyped() {
+    void leavesTheMessageEmptyWhenOnlyTheCommandWasTyped() {
+        // Announcing without a message is allowed, so this is a valid result and not
+        // an error the command has to report.
         assertEquals("", EventCommand.joinMessage(new String[] {":event"}));
         assertEquals("", EventCommand.joinMessage(new String[] {":event", "   "}));
+    }
+
+    @Test
+    void announcesTheRoomEvenWithNoMessageToShow() {
+        Map<String, String> keys = EventCommand.notificationKeys("Piazza", 47, "Simo", "hd-180-1", "16:43", "", true);
+
+        assertEquals("", keys.get("MESSAGE"));
+        assertEquals("navigator/goto/47", keys.get("linkUrl"));
+        assertEquals("Piazza", keys.get("ROOMNAME"));
     }
 
     @Test

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/commands/EventCommandNotificationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/commands/EventCommandNotificationTest.java
@@ -1,0 +1,72 @@
+package com.eu.habbo.habbohotel.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EventCommandNotificationTest {
+
+    @Test
+    void joinsEveryWordAfterTheCommandIntoTheMessage() {
+        assertEquals(
+                "festa in piscina alle 21",
+                EventCommand.joinMessage(new String[] {":event", "festa", "in", "piscina", "alle", "21"}));
+    }
+
+    @Test
+    void reportsAnEmptyMessageWhenOnlyTheCommandWasTyped() {
+        assertEquals("", EventCommand.joinMessage(new String[] {":event"}));
+        assertEquals("", EventCommand.joinMessage(new String[] {":event", "   "}));
+    }
+
+    @Test
+    void recognisesTheClosingArgumentRegardlessOfCase() {
+        assertTrue(EventCommand.isClosingArgument(new String[] {":event", "off"}));
+        assertTrue(EventCommand.isClosingArgument(new String[] {":event", "OFF"}));
+        assertTrue(EventCommand.isClosingArgument(new String[] {":event", "stop"}));
+    }
+
+    @Test
+    void treatsAnythingElseAsTheEventMessage() {
+        assertFalse(EventCommand.isClosingArgument(new String[] {":event", "offerta", "di", "lavoro"}));
+        assertFalse(EventCommand.isClosingArgument(new String[] {":event", "off", "topic"}));
+        assertFalse(EventCommand.isClosingArgument(new String[] {":event"}));
+    }
+
+    @Test
+    void sendsTheRoomLinkAndTheAutoCloseDelayWithAnOpeningAnnouncement() {
+        Map<String, String> keys =
+                EventCommand.notificationKeys("Piazza", 47, "Simo", "hd-180-1", "16:43", "festa in piscina", true);
+
+        // Bare prefix: the client's link trackers do not know the official "event:" scheme.
+        assertEquals("navigator/goto/47", keys.get("linkUrl"));
+        assertEquals("notification.hotel.event.linkTitle", keys.get("linkTitle"));
+        assertEquals("120", keys.get("timeout"));
+    }
+
+    @Test
+    void leavesTheClosingAnnouncementWithoutALinkButStillClosesItself() {
+        Map<String, String> keys = EventCommand.notificationKeys("Piazza", 47, "Simo", "hd-180-1", "16:43", "", false);
+
+        assertNull(keys.get("linkUrl"));
+        assertNull(keys.get("linkTitle"));
+        assertEquals("120", keys.get("timeout"));
+    }
+
+    @Test
+    void carriesTheRoomAndSenderDetailsTheTextsInterpolate() {
+        Map<String, String> keys =
+                EventCommand.notificationKeys("Piazza", 47, "Simo", "hd-180-1", "16:43", "festa in piscina", true);
+
+        assertEquals("Piazza", keys.get("ROOMNAME"));
+        assertEquals("47", keys.get("ROOMID"));
+        assertEquals("Simo", keys.get("USERNAME"));
+        assertEquals("hd-180-1", keys.get("LOOK"));
+        assertEquals("16:43", keys.get("TIME"));
+        assertEquals("festa in piscina", keys.get("MESSAGE"));
+    }
+}


### PR DESCRIPTION
## What

`:event` announced a hotel event through a notification whose key nothing
localises, so the client drew the raw `notification.hotel.event.title` and
`notification.hotel.event.message` as the window title and body. The command
also failed in silence: typed outside a room, or with no message at all, it
returned `false` and the staff member was told nothing.

The announcement now carries the keys the client already knows how to render:

- `linkUrl` = `navigator/goto/<roomId>` and `linkTitle`, which become the button
  that walks the user to the room. The link is written **without** the `event:`
  prefix the official AIR client uses - the client's link trackers register bare
  prefixes such as `navigator/`, and a prefixed link matches none of them.
- `timeout` = `120`, the delay after which the client closes the box on its own.
  Rendering that value is the client-side half of this change.
- `TIME` formatted as `HH:mm` instead of `Date.toString()`, which printed
  `Thu Aug 30 17:25:11 CEST 2026` into the announcement.

`:event off` (or `stop`) announces the end of the event under a second key,
`hotel.event.ended`, with no room button. Every branch now answers the sender:
an alert when the command is used outside a room, since a whisper only reaches a
user standing in one, and a whisper otherwise.

## Texts

The migration adds the four texts the feedback needs with `INSERT IGNORE`, so a
hotel that has already reworded or translated them keeps its own copy when the
migration is replayed. It also updates `commands.description.cmd_event`, guarded
by a `WHERE` on the stock value so a customised usage line survives.

The client-side texts (`notification.hotel.event.*`, English and Italian) belong
to the UI repository and are not part of this PR.

## Verification

- `./mvnw -B -Dtest=EventCommandNotificationTest test` - 7/7. The parsing, the
  closing argument and the notification keys are covered by pure helpers, the way
  `CommandsCommandFormatTest` covers the command listing.
- `./mvnw -B -Dtest='EventCommandNotificationTest,CommandsCommandFormatTest,CommandTargetGuardContractTest' test` - 15/15.
- `./mvnw -B spotless:check` clean, `./mvnw -B clean package -DskipTests` builds.
- **Not verified locally:** the migration. `MigrationRunnerIT` runs on
  Testcontainers and skips all 10 tests without Docker on this machine, staying
  green. CI is the first real run of this SQL.

## Risk

The notification keys are additive; a client that ignores `linkUrl` and
`timeout` renders the announcement exactly as before, only with texts that
resolve. The command's return value changes from `false` to `true` on the error
branches, which is what stops the handler from swallowing the feedback.
