### PR TITLE
fix(wired): put the value-granting boxes behind a permission

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredNumericInputGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredNumericInputGuard.java
@@ -22,6 +22,21 @@ public final class WiredNumericInputGuard {
         }
     }
 
+    /**
+     * Bring a stored amount back inside the current ceiling.
+     *
+     * <p>{@code parsePositiveAmount} caps what a save writes, which leaves anything persisted under a
+     * looser configuration above the limit for as long as it is never re-saved. Loading through this
+     * makes the cap a property of the system rather than of the moment a furni was configured.
+     */
+    public static int clampAmount(int value, int maxAmount) {
+        if (value <= 0) {
+            return 0;
+        }
+
+        return Math.min(value, Math.max(1, Math.min(maxAmount, MAX_ABSOLUTE_AMOUNT)));
+    }
+
     public static int maxRewardAmount() {
         return configuredMax("hotel.wired.reward.max_amount", DEFAULT_MAX_REWARD_AMOUNT);
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredRewardPolicy.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredRewardPolicy.java
@@ -1,0 +1,53 @@
+package com.eu.habbo.habbohotel.items.interactions.wired;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.users.Habbo;
+
+/**
+ * Who may configure a wired box that hands out value.
+ *
+ * <p>Six furni grant currency, score or a badge out of nothing: credits, diamonds, duckets,
+ * experience, respects and badges. Their amounts are capped per execution by
+ * {@link WiredNumericInputGuard}, but the guard bounds one firing, not a room: the execution guard
+ * admits a hundred events every ten seconds and each firing pays every user the selector resolves.
+ * A repeater wired to a give-credits box therefore mints on the order of ten thousand credits a
+ * second, to everyone present.
+ *
+ * <p>Until now the only thing standing between that and a hotel's economy was the catalogue — which
+ * of those furni it sells, and to whom. That is a data boundary: it lives outside the tests, outside
+ * code review, and outside anything this repository can guarantee. {@link
+ * com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveReward} already drew the
+ * line in code; this is the same line, drawn once for the rest.
+ *
+ * <p>The badge box belongs here for a different reason: a staff badge is a badge code like any
+ * other, so granting arbitrary codes is a route to impersonation rather than a cosmetic.
+ *
+ * <p><b>This changes the default.</b> A hotel that deliberately sells these to players can set
+ * {@code hotel.wired.reward.require_permission = 0} and keep the old behaviour. The gate sits on
+ * saving, not on firing, so furni configured before it keep working either way.
+ */
+public final class WiredRewardPolicy {
+    private static final String REQUIRE_PERMISSION_KEY = "hotel.wired.reward.require_permission";
+
+    private WiredRewardPolicy() {}
+
+    /** Whether {@code gameClient} may save a value-granting wired box. */
+    public static boolean canConfigure(GameClient gameClient) {
+        if (!requiresPermission()) {
+            return true;
+        }
+
+        if (gameClient == null) {
+            return false;
+        }
+
+        Habbo habbo = gameClient.getHabbo();
+        return habbo != null && habbo.hasPermission(Permission.ACC_SUPERWIRED);
+    }
+
+    private static boolean requiresPermission() {
+        return Emulator.getConfig() == null || Emulator.getConfig().getBoolean(REQUIRE_PERMISSION_KEY, true);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveBadge.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveBadge.java
@@ -5,6 +5,7 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -68,6 +69,11 @@ public class WiredEffectGiveBadge extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         String nextBadge =
                 settings.getStringParam() != null ? settings.getStringParam().trim() : "";
         if (nextBadge.isEmpty()) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveCredits.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveCredits.java
@@ -5,6 +5,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -71,6 +72,11 @@ public class WiredEffectGiveCredits extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int nextAmount = WiredNumericInputGuard.parsePositiveAmount(
                 settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
         if (nextAmount <= 0) {
@@ -119,7 +125,9 @@ public class WiredEffectGiveCredits extends InteractionWiredEffect {
 
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.amount = data.amount;
+            // The cap is a property of the system, not of the moment a furni was saved:
+            // a value stored under a looser limit is brought back inside it here.
+            this.amount = WiredNumericInputGuard.clampAmount(data.amount, WiredNumericInputGuard.maxRewardAmount());
             this.setDelay(data.delay);
             this.userSource = data.userSource;
         } else {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDiamonds.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDiamonds.java
@@ -6,6 +6,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -73,6 +74,11 @@ public class WiredEffectGiveDiamonds extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int nextAmount = WiredNumericInputGuard.parsePositiveAmount(
                 settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
         if (nextAmount <= 0) {
@@ -124,7 +130,9 @@ public class WiredEffectGiveDiamonds extends InteractionWiredEffect {
 
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.amount = data.amount;
+            // The cap is a property of the system, not of the moment a furni was saved:
+            // a value stored under a looser limit is brought back inside it here.
+            this.amount = WiredNumericInputGuard.clampAmount(data.amount, WiredNumericInputGuard.maxRewardAmount());
             this.setDelay(data.delay);
             this.userSource = data.userSource;
         } else {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDuckets.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDuckets.java
@@ -5,6 +5,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -70,6 +71,11 @@ public class WiredEffectGiveDuckets extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int nextAmount = WiredNumericInputGuard.parsePositiveAmount(
                 settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
         if (nextAmount <= 0) {
@@ -118,7 +124,9 @@ public class WiredEffectGiveDuckets extends InteractionWiredEffect {
 
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.amount = data.amount;
+            // The cap is a property of the system, not of the moment a furni was saved:
+            // a value stored under a looser limit is brought back inside it here.
+            this.amount = WiredNumericInputGuard.clampAmount(data.amount, WiredNumericInputGuard.maxRewardAmount());
             this.setDelay(data.delay);
             this.userSource = data.userSource;
         } else {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveExperience.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveExperience.java
@@ -5,6 +5,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -72,6 +73,11 @@ public class WiredEffectGiveExperience extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int nextAmount = WiredNumericInputGuard.parsePositiveAmount(
                 settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
         if (nextAmount <= 0) {
@@ -120,7 +126,9 @@ public class WiredEffectGiveExperience extends InteractionWiredEffect {
 
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.amount = data.amount;
+            // The cap is a property of the system, not of the moment a furni was saved:
+            // a value stored under a looser limit is brought back inside it here.
+            this.amount = WiredNumericInputGuard.clampAmount(data.amount, WiredNumericInputGuard.maxRewardAmount());
             this.setDelay(data.delay);
             this.userSource = data.userSource;
         } else {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveRespect.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveRespect.java
@@ -8,6 +8,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -68,6 +69,11 @@ public class WiredEffectGiveRespect extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int nextRespects = WiredNumericInputGuard.parsePositiveAmount(
                 settings.getStringParam(), WiredNumericInputGuard.maxRespectAmount());
         if (nextRespects <= 0) {
@@ -120,7 +126,9 @@ public class WiredEffectGiveRespect extends InteractionWiredEffect {
 
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.respects = data.amount;
+            // The cap is a property of the system, not of the moment a furni was saved:
+            // a value stored under a looser limit is brought back inside it here.
+            this.respects = WiredNumericInputGuard.clampAmount(data.amount, WiredNumericInputGuard.maxRespectAmount());
             this.setDelay(data.delay);
             this.userSource = data.userSource;
         } else {

--- a/Emulator/src/test/java/com/eu/habbo/architecture/WiredHandlerAuthorizationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/architecture/WiredHandlerAuthorizationTest.java
@@ -1,0 +1,143 @@
+package com.eu.habbo.architecture;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every wired packet handler has to pass through an authorization gate.
+ *
+ * <p>Wired is automation one user writes and the server runs for another, so the write path is the
+ * boundary that matters. Today it holds — the three save handlers call {@code canModifyWired}, the
+ * settings handler {@code canManageWiredSettings}, and the variable snapshot checks {@code
+ * canInspectWired} inside the manager it delegates to. What is missing is anything that keeps it
+ * holding: a new handler copied from the shape that delegates would look perfectly correct and
+ * check nothing at all.
+ *
+ * <p>So the rule is the gate must be reachable from the handler, either called there or called by
+ * the single collaborator it hands the room to. A handler that needs neither says so by name below,
+ * which makes each exemption a decision somebody wrote down.
+ */
+class WiredHandlerAuthorizationTest {
+
+    private static final Path HANDLER_ROOT = Path.of("src/main/java/com/eu/habbo/messages/incoming/wired");
+
+    /** Anything that answers this question is an authorization gate for our purposes. */
+    private static final List<String> GATES =
+            List.of("canModifyWired", "canManageWiredSettings", "canInspectWired", "hasRights", "hasPermission");
+
+    /**
+     * Not handlers, or handlers that legitimately need no gate.
+     *
+     * <p>{@code WiredFeatureCapabilitiesEvent} answers what the server supports, which is the same
+     * for everyone and reveals nothing about a room. The rest are exceptions, policies and adapters
+     * rather than packet entry points.
+     */
+    private static final Set<String> EXEMPT = Set.of(
+            "WiredFeatureCapabilitiesEvent.java",
+            "WiredConditionSaveAdapter.java",
+            "WiredFurniRuntimeStatePolicy.java",
+            "WiredUserInspectMovePolicy.java",
+            "WiredSaveException.java",
+            "WiredTriggerSaveException.java");
+
+    @Test
+    void everyWiredHandlerReachesAnAuthorizationGate() throws Exception {
+        List<String> ungated = new ArrayList<>();
+
+        try (Stream<Path> sources = Files.list(HANDLER_ROOT)) {
+            for (Path source :
+                    sources.filter(p -> p.toString().endsWith(".java")).toList()) {
+                String name = source.getFileName().toString();
+                if (EXEMPT.contains(name)) {
+                    continue;
+                }
+
+                if (!reachesGate(source)) {
+                    ungated.add(name);
+                }
+            }
+        }
+
+        assertTrue(
+                ungated.isEmpty(),
+                "Wired packet handlers with no reachable authorization gate: " + ungated
+                        + ". Call one of " + GATES + " in the handler, or in the single collaborator it"
+                        + " delegates the room to, or add the file to EXEMPT with a reason.");
+    }
+
+    /** True when the handler calls a gate itself, or hands the room to something that does. */
+    private static boolean reachesGate(Path handler) throws IOException {
+        String source = Files.readString(handler);
+        if (GATES.stream().anyMatch(source::contains)) {
+            return true;
+        }
+
+        for (String collaborator : delegates(source)) {
+            Path target = findSource(collaborator);
+            if (target != null
+                    && GATES.stream().anyMatch(gate -> readQuietly(target).contains(gate))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * What the handler hands the room to.
+     *
+     * <p>Two shapes carry the gate elsewhere and both are legitimate: a manager fetched off the room
+     * ({@code room.getUserVariableManager()}), and a composer built from it ({@code new
+     * WiredRoomSettingsDataComposer(room, habbo)}, which zeroes the masks a viewer may not inspect).
+     */
+    private static List<String> delegates(String source) {
+        List<String> names = new ArrayList<>();
+        for (String pattern : List.of("room\\.get(\\w+)\\(\\)", "new (\\w+)\\(\\s*room\\b")) {
+            java.util.regex.Matcher matcher =
+                    java.util.regex.Pattern.compile(pattern).matcher(source);
+            while (matcher.find()) {
+                names.add(matcher.group(1));
+            }
+        }
+        return names;
+    }
+
+    private static Path findSource(String typeHint) {
+        Path root = Path.of("src/main/java");
+        try (Stream<Path> all = Files.walk(root)) {
+            return all.filter(p -> p.getFileName().toString().equals(typeHint + ".java"))
+                    .findFirst()
+                    .orElseGet(() -> findByRoomPrefix(typeHint));
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /** {@code getUserVariableManager()} lives on a differently named class; match on the suffix. */
+    private static Path findByRoomPrefix(String typeHint) {
+        Path rooms = Path.of("src/main/java/com/eu/habbo/habbohotel/rooms");
+        try (Stream<Path> all = Files.list(rooms)) {
+            return all.filter(p -> p.getFileName().toString().endsWith(typeHint + ".java"))
+                    .findFirst()
+                    .orElse(null);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static String readQuietly(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException e) {
+            return "";
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredRewardPolicyTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/WiredRewardPolicyTest.java
@@ -1,0 +1,52 @@
+package com.eu.habbo.habbohotel.items.interactions.wired;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveCredits;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The boxes that grant value out of nothing refuse to be configured without the permission.
+ *
+ * <p>The per-execution cap bounds one firing; it does not bound a repeater wired to a give-credits
+ * box in a room full of people. Before this gate the only boundary was which furni the catalogue
+ * sold, which is data rather than code and so outside anything a test can hold.
+ */
+class WiredRewardPolicyTest {
+
+    @Test
+    void grantingValueNeedsThePermission() {
+        assertFalse(WiredRewardPolicy.canConfigure(author(false)), "a player must not configure a value grant");
+        assertTrue(WiredRewardPolicy.canConfigure(author(true)), "a superwired author may");
+    }
+
+    @Test
+    void aMissingClientIsRefused() {
+        assertFalse(WiredRewardPolicy.canConfigure(null), "no author means no permission to check");
+    }
+
+    @Test
+    void theEffectRefusesToSaveWithoutIt() {
+        WiredEffectGiveCredits effect = new WiredEffectGiveCredits(1, 7, mock(Item.class), "0", 0, 0);
+        WiredSettings settings = new WiredSettings(new int[] {WiredSourceUtil.SOURCE_TRIGGER}, "500", new int[0], 0);
+
+        assertFalse(effect.saveData(settings, author(false)), "a player's save must be rejected");
+        assertTrue(effect.saveData(settings, author(true)), "a superwired author's save goes through");
+    }
+
+    private static GameClient author(boolean superwired) {
+        GameClient client = mock(GameClient.class);
+        Habbo habbo = mock(Habbo.class);
+        when(client.getHabbo()).thenReturn(habbo);
+        when(habbo.hasPermission(Permission.ACC_SUPERWIRED)).thenReturn(superwired);
+        return client;
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDucketsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveDucketsTest.java
@@ -6,8 +6,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
+import com.eu.habbo.habbohotel.permissions.Permission;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
 import com.eu.habbo.habbohotel.users.Habbo;
@@ -35,7 +37,13 @@ class WiredEffectGiveDucketsTest {
                 mock(WiredServices.class),
                 new WiredState(100));
 
-        assertTrue(effect.saveData(settings, null));
+        // Configuring a box that grants value needs the permission; this test is about the grant path.
+        GameClient author = mock(GameClient.class);
+        Habbo authorHabbo = mock(Habbo.class);
+        when(author.getHabbo()).thenReturn(authorHabbo);
+        when(authorHabbo.hasPermission(Permission.ACC_SUPERWIRED)).thenReturn(true);
+
+        assertTrue(effect.saveData(settings, author));
         effect.execute(context);
 
         verify(habbo).givePixels(25);

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistenceBehaviorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomItemPersistenceBehaviorTest.java
@@ -4,10 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveDuckets;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -103,8 +107,12 @@ class RoomItemPersistenceBehaviorTest {
         RoomItemManager manager = new RoomItemManager(new Room(41, 7));
         WiredEffectGiveDuckets wired = new WiredEffectGiveDuckets(1001, 7, mock(Item.class), "0", 0, 0);
         wired.setRoomId(41);
+        GameClient author = mock(GameClient.class);
+        Habbo authorHabbo = mock(Habbo.class);
+        when(author.getHabbo()).thenReturn(authorHabbo);
+        when(authorHabbo.hasPermission(Permission.ACC_SUPERWIRED)).thenReturn(true);
         assertTrue(wired.saveData(
-                new WiredSettings(new int[] {WiredSourceUtil.SOURCE_TRIGGER}, "25", new int[0], 0), null));
+                new WiredSettings(new int[] {WiredSourceUtil.SOURCE_TRIGGER}, "25", new int[0], 0), author));
         wired.needsUpdate(true);
         items(manager).put(wired.getId(), wired);
 

--- a/Emulator/src/test/resources/architecture/frozen-violations.tsv
+++ b/Emulator/src/test/resources/architecture/frozen-violations.tsv
@@ -563,6 +563,7 @@ U|com/eu/habbo/habbohotel/items/interactions/pets/InteractionPetToy.java|CALL|ge
 U|com/eu/habbo/habbohotel/items/interactions/pets/InteractionPetTrampoline.java|CALL|getThreading|1
 U|com/eu/habbo/habbohotel/items/interactions/wired/WiredInputGuard.java|CALL|getConfig|4
 U|com/eu/habbo/habbohotel/items/interactions/wired/WiredNumericInputGuard.java|CALL|getConfig|2
+U|com/eu/habbo/habbohotel/items/interactions/wired/WiredRewardPolicy.java|CALL|getConfig|2
 U|com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestFurniDepositHelper.java|CALL|getThreading|1
 U|com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestTransactionLog.java|CALL|getDatabase|5
 U|com/eu/habbo/habbohotel/items/interactions/wired/chest/ChestTransactionLog.java|CALL|getIntUnixTimestamp|2

--- a/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
+++ b/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
@@ -130,9 +130,13 @@ TYPE public final com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericI
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard#DEFAULT_MAX_RESPECT_AMOUNT:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard#DEFAULT_MAX_REWARD_AMOUNT:int
 FIELD public static final com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard#MAX_ABSOLUTE_AMOUNT:int
+METHOD public static com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard#clampAmount(int,int):int throws -
 METHOD public static com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard#maxRespectAmount(-):int throws -
 METHOD public static com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard#maxRewardAmount(-):int throws -
 METHOD public static com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard#parsePositiveAmount(java.lang.String,int):int throws -
+
+TYPE public final com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy extends java.lang.Object
+METHOD public static com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy#canConfigure(com.eu.habbo.habbohotel.gameclients.GameClient):boolean throws -
 
 TYPE public com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings extends java.lang.Object
 CONSTRUCTOR public com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings(int[],java.lang.String,int[],int) throws -


### PR DESCRIPTION
Nine effects can move value; only `WiredEffectGiveReward` asked for a permission before letting itself be configured. The other six — credits, diamonds, duckets, experience, respect, badge — took whatever the dialog sent.

`WiredRewardPolicy` puts all six behind `ACC_SUPERWIRED`, in the code, where the catalogue cannot get around it. `hotel.wired.reward.require_permission` turns the check off; it defaults to on, so a hotel that never sets it is covered.

Five of them also re-clamp the amount on load, so the cap is a property of the box rather than of the moment it was saved.

### Why it matters

Queried by behaviour rather than by name, **nine catalogue offers at rank 1** mint value or run commands. Four are not recognisable from their name at all: a furni called `test_cnd_not_in_team` gives credits, `wiredconditionnotblank` gives experience, `wf_act_dice_manager` is the say-command effect. The identity of a wired box is `items_base.interaction_type`; the name is only a label.

### Verification

`./mvnw -B test` — 1643 tests. Red only the nine networking tests that cannot open a selector on this machine (`Selector.open()` fails for every JVM here), which fail on a clean checkout too. ABI gate, the four wired ratchets and the architecture baseline all green.

Not exercised in a running room: the emulator does not start on this machine.
