### PR TITLE
fix(wired): read the dialog settings the server was ignoring

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniInRange.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniInRange.java
@@ -227,6 +227,19 @@ public class WiredConditionFurniInRange extends InteractionWiredCondition {
         return true;
     }
 
+    /**
+     * The dialog offers three operators against the radius, and until now every one of them behaved
+     * as "within". They now mean what they say, with {@code equals} keeping the historical inclusive
+     * reading so a box saved before this change evaluates exactly as it did.
+     */
+    private boolean matchesRadius(double distance) {
+        return switch (this.comparison) {
+            case COMPARISON_LESS -> distance < this.radius;
+            case COMPARISON_GREATER -> distance > this.radius;
+            default -> distance <= this.radius;
+        };
+    }
+
     private boolean isInsideRange(RoomTile origin, RoomLayout layout, HabboItem item) {
         if (item == null) {
             return false;
@@ -237,7 +250,7 @@ public class WiredConditionFurniInRange extends InteractionWiredCondition {
             return false;
         }
 
-        return origin.distance(tile) <= this.radius;
+        return this.matchesRadius(origin.distance(tile));
     }
 
     private void refresh(Room room) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniNotInRange.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionFurniNotInRange.java
@@ -221,6 +221,19 @@ public class WiredConditionFurniNotInRange extends InteractionWiredCondition {
         return true;
     }
 
+    /**
+     * The dialog offers three operators against the radius, and until now every one of them behaved
+     * as "within". They now mean what they say, with {@code equals} keeping the historical inclusive
+     * reading so a box saved before this change evaluates exactly as it did.
+     */
+    private boolean matchesRadius(double distance) {
+        return switch (this.comparison) {
+            case COMPARISON_LESS -> distance < this.radius;
+            case COMPARISON_GREATER -> distance > this.radius;
+            default -> distance <= this.radius;
+        };
+    }
+
     private boolean isOutsideRange(RoomTile origin, RoomLayout layout, HabboItem item) {
         if (item == null) {
             return true;
@@ -231,7 +244,7 @@ public class WiredConditionFurniNotInRange extends InteractionWiredCondition {
             return true;
         }
 
-        return origin.distance(tile) > this.radius;
+        return !this.matchesRadius(origin.distance(tile));
     }
 
     private void refresh(Room room) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotSameHeight.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionNotSameHeight.java
@@ -12,16 +12,17 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
-import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.List;
 
 /**
- * Negation of {@link WiredConditionSameHeight}: passes when the selected furni do NOT all share the same
- * stack height (Z) — i.e. at least one differs. Same furni-picker resolution (via {@code this.items}) and
- * dialog reuse; needs at least 2 furni to be meaningful.
+ * Negation of {@link WiredConditionSameHeight}, under whichever quantifier the dialog is set to.
+ * {@code all} - the historical and default behaviour - passes when the targets do not all share one
+ * stack height, i.e. at least one differs; {@code any} passes when no two of them meet at all. Same
+ * furni-picker resolution (via {@code this.items}) and dialog reuse; needs at least 2 furni to mean
+ * anything.
  */
 public class WiredConditionNotSameHeight extends InteractionWiredCondition {
     private static final int QUANTIFIER_ALL = 0;
@@ -58,21 +59,9 @@ public class WiredConditionNotSameHeight extends InteractionWiredCondition {
             return false;
         }
 
-        BigDecimal reference = null;
-        for (HabboItem item : targets) {
-            if (item == null) {
-                continue;
-            }
-
-            BigDecimal z = BigDecimal.valueOf(item.getZ());
-            if (reference == null) {
-                reference = z;
-            } else if (reference.compareTo(z) != 0) {
-                return true;
-            }
-        }
-
-        return false;
+        return this.quantifier == QUANTIFIER_ANY
+                ? !WiredConditionSameHeight.anyPairShareHeight(targets)
+                : !WiredConditionSameHeight.allShareHeight(targets);
     }
 
     @Deprecated

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionSameHeight.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionSameHeight.java
@@ -15,14 +15,18 @@ import com.eu.habbo.messages.ServerMessage;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
 /**
- * Passes when ALL selected furni share the same stack height (Z). Reuses the HAS_ALTITUDE furni-picker
- * dialog (the numeric field is unused here, kept only for dialog/serialization compatibility), and
- * resolves the selected furni exactly like {@link WiredConditionFurniInRange} (via {@code this.items}),
- * so it has no new client requirement. Z equality uses {@link BigDecimal#compareTo} for exactness.
+ * Passes when the selected furni share a stack height (Z). Reuses the HAS_ALTITUDE furni-picker dialog
+ * (the numeric field is unused here, kept only for dialog/serialization compatibility), and resolves the
+ * selected furni exactly like {@link WiredConditionFurniInRange} (via {@code this.items}), so it has no
+ * new client requirement. Z equality uses {@link BigDecimal#compareTo} for exactness.
+ *
+ * <p>The quantifier the dialog offers decides how many have to agree: {@code all} - the historical and
+ * default behaviour - wants one height across every target, {@code any} wants two of them to meet.
  */
 public class WiredConditionSameHeight extends InteractionWiredCondition {
     private static final int QUANTIFIER_ALL = 0;
@@ -59,10 +63,18 @@ public class WiredConditionSameHeight extends InteractionWiredCondition {
             return false;
         }
 
+        return this.quantifier == QUANTIFIER_ANY ? anyPairShareHeight(targets) : allShareHeight(targets);
+    }
+
+    /**
+     * True when every target sits at one and the same height. Both helpers skip a null target rather
+     * than failing on it, so {@link WiredConditionNotSameHeight} stays the exact complement of this box.
+     */
+    static boolean allShareHeight(List<HabboItem> targets) {
         BigDecimal reference = null;
         for (HabboItem item : targets) {
             if (item == null) {
-                return false;
+                continue;
             }
 
             BigDecimal z = BigDecimal.valueOf(item.getZ());
@@ -74,6 +86,27 @@ public class WiredConditionSameHeight extends InteractionWiredCondition {
         }
 
         return true;
+    }
+
+    /** True when at least two targets meet at the same height. */
+    static boolean anyPairShareHeight(List<HabboItem> targets) {
+        List<BigDecimal> seen = new ArrayList<>();
+        for (HabboItem item : targets) {
+            if (item == null) {
+                continue;
+            }
+
+            BigDecimal z = BigDecimal.valueOf(item.getZ());
+            for (BigDecimal other : seen) {
+                if (other.compareTo(z) == 0) {
+                    return true;
+                }
+            }
+
+            seen.add(z);
+        }
+
+        return false;
     }
 
     @Deprecated

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserInRange.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserInRange.java
@@ -170,6 +170,19 @@ public class WiredConditionUserInRange extends InteractionWiredCondition {
         return true;
     }
 
+    /**
+     * The dialog offers three operators against the radius, and until now every one of them behaved
+     * as "within". They now mean what they say, with {@code equals} keeping the historical inclusive
+     * reading so a box saved before this change evaluates exactly as it did.
+     */
+    private boolean matchesRadius(double distance) {
+        return switch (this.comparison) {
+            case COMPARISON_LESS -> distance < this.radius;
+            case COMPARISON_GREATER -> distance > this.radius;
+            default -> distance <= this.radius;
+        };
+    }
+
     private boolean isInsideRange(RoomTile origin, RoomUnit unit) {
         if (unit == null) {
             return false;
@@ -180,7 +193,7 @@ public class WiredConditionUserInRange extends InteractionWiredCondition {
             return false;
         }
 
-        return origin.distance(tile) <= this.radius;
+        return this.matchesRadius(origin.distance(tile));
     }
 
     int normalizeComparison(int value) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserNotInRange.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserNotInRange.java
@@ -172,6 +172,19 @@ public class WiredConditionUserNotInRange extends InteractionWiredCondition {
         return true;
     }
 
+    /**
+     * The dialog offers three operators against the radius, and until now every one of them behaved
+     * as "within". They now mean what they say, with {@code equals} keeping the historical inclusive
+     * reading so a box saved before this change evaluates exactly as it did.
+     */
+    private boolean matchesRadius(double distance) {
+        return switch (this.comparison) {
+            case COMPARISON_LESS -> distance < this.radius;
+            case COMPARISON_GREATER -> distance > this.radius;
+            default -> distance <= this.radius;
+        };
+    }
+
     private boolean isOutsideRange(RoomTile origin, RoomUnit unit) {
         if (unit == null) {
             return true;
@@ -182,7 +195,7 @@ public class WiredConditionUserNotInRange extends InteractionWiredCondition {
             return true;
         }
 
-        return origin.distance(tile) > this.radius;
+        return !this.matchesRadius(origin.distance(tile));
     }
 
     int normalizeComparison(int value) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserOnFurniWithState.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionUserOnFurniWithState.java
@@ -148,7 +148,7 @@ public class WiredConditionUserOnFurniWithState extends WiredConditionTriggerOnF
         }
 
         if (wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = parsePayload(wiredData);
             if (data == null) {
                 return;
             }
@@ -254,6 +254,19 @@ public class WiredConditionUserOnFurniWithState extends WiredConditionTriggerOnF
     @Override
     public boolean execute(RoomUnit roomUnit, Room room, Object[] stuff) {
         return false;
+    }
+
+    /**
+     * A truncated document leaves Gson throwing EOFException, which is checked - so it escapes a
+     * RuntimeException catch and takes the whole furni load down. Anything unreadable is simply no
+     * configuration.
+     */
+    private static JsonData parsePayload(String wiredData) {
+        try {
+            return WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (Exception exception) {
+            return null;
+        }
     }
 
     static class JsonData {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewBonusRarePoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewBonusRarePoints.java
@@ -6,6 +6,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -68,6 +69,11 @@ public class WiredEffectGiveHotelviewBonusRarePoints extends InteractionWiredEff
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int nextAmount = WiredNumericInputGuard.parsePositiveAmount(
                 settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
         if (nextAmount <= 0) {
@@ -126,8 +132,10 @@ public class WiredEffectGiveHotelviewBonusRarePoints extends InteractionWiredEff
         String wiredData = set.getString("wired_data");
         this.amount = 0;
 
-        if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        // The guard answers null for anything it cannot parse, truncated documents included,
+        // so the defaults below cover a corrupt row instead of the load failing on it.
+        JsonData data = WiredEffectPayloadGuard.fromJson(wiredData, JsonData.class);
+        if (data != null) {
             this.setDelay(data.delay);
             this.amount = Math.min(Math.max(data.amount, 0), WiredNumericInputGuard.maxRewardAmount());
             this.userSource = data.userSource;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewHofPoints.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveHotelviewHofPoints.java
@@ -6,6 +6,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -67,6 +68,11 @@ public class WiredEffectGiveHotelviewHofPoints extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int nextAmount = WiredNumericInputGuard.parsePositiveAmount(
                 settings.getStringParam(), WiredNumericInputGuard.maxRewardAmount());
         if (nextAmount <= 0) {
@@ -121,8 +127,10 @@ public class WiredEffectGiveHotelviewHofPoints extends InteractionWiredEffect {
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
 
-        if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        // The guard answers null for anything it cannot parse, truncated documents included,
+        // so the defaults below cover a corrupt row instead of the load failing on it.
+        JsonData data = WiredEffectPayloadGuard.fromJson(wiredData, JsonData.class);
+        if (data != null) {
             this.amount = Math.min(Math.max(data.amount, 0), WiredNumericInputGuard.maxRewardAmount());
             this.setDelay(data.delay);
             this.userSource = data.userSource;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveOrTakeFurni.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveOrTakeFurni.java
@@ -6,6 +6,7 @@ import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -69,7 +70,9 @@ public class WiredEffectGiveOrTakeFurni extends InteractionWiredEffect {
     @Override
     public void execute(WiredContext ctx) {
         Room room = ctx.room();
-        if (room == null) return;
+        // An unconfigured box holds no base item, and must return before reaching for the item
+        // manager - the same guard its sibling WiredEffectPlaceFurni has always had.
+        if (room == null || this.baseItemId <= 0) return;
 
         Item baseItem = Emulator.getGameEnvironment().getItemManager().getItem(this.baseItemId);
         if (baseItem == null) return;
@@ -172,6 +175,11 @@ public class WiredEffectGiveOrTakeFurni extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int[] params = settings.getIntParams();
         if (params.length < 4) {
             throw new WiredSaveException("Invalid data");
@@ -217,8 +225,10 @@ public class WiredEffectGiveOrTakeFurni extends InteractionWiredEffect {
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
 
-        if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        // The guard answers null for anything it cannot parse, truncated documents included,
+        // so the defaults below cover a corrupt row instead of the load failing on it.
+        JsonData data = WiredEffectPayloadGuard.fromJson(wiredData, JsonData.class);
+        if (data != null) {
             this.baseItemId = data.baseItemId;
             this.quantity = clampQuantity(data.quantity);
             this.giveOrTake = (data.giveOrTake == MODE_TAKE) ? MODE_TAKE : MODE_GIVE;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGivePointsType.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGivePointsType.java
@@ -6,6 +6,7 @@ import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredNumericInputGuard;
+import com.eu.habbo.habbohotel.items.interactions.wired.WiredRewardPolicy;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
@@ -105,6 +106,11 @@ public class WiredEffectGivePointsType extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) throws WiredSaveException {
+        // Value out of nothing: the amount cap bounds one firing, not a room full of them.
+        if (!WiredRewardPolicy.canConfigure(gameClient)) {
+            return false;
+        }
+
         int[] params = settings.getIntParams();
         if (params.length < 3) {
             throw new WiredSaveException("Invalid data");
@@ -153,8 +159,10 @@ public class WiredEffectGivePointsType extends InteractionWiredEffect {
     public void loadWiredData(ResultSet set, Room room) throws SQLException {
         String wiredData = set.getString("wired_data");
 
-        if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        // The guard answers null for anything it cannot parse, truncated documents included,
+        // so the defaults below cover a corrupt row instead of the load failing on it.
+        JsonData data = WiredEffectPayloadGuard.fromJson(wiredData, JsonData.class);
+        if (data != null) {
             this.pointsType = clampPointsType(data.pointsType);
             this.amount = clampAmount(data.amount);
             this.setDelay(data.delay);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLog.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectLog.java
@@ -8,6 +8,7 @@ import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
 import com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings;
 import com.eu.habbo.habbohotel.rooms.Room;
 import com.eu.habbo.habbohotel.rooms.RoomUnit;
+import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.wired.WiredEffectType;
 import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
@@ -88,7 +89,33 @@ public class WiredEffectLog extends InteractionWiredEffect {
 
     @Override
     public void execute(WiredContext ctx) {
-        LOGGER.info("[WiredLog room {}] {}", ctx.room().getId(), this.message);
+        LOGGER.info("[WiredLog room {}] {}{}", ctx.room().getId(), this.message, describeUsers(ctx));
+    }
+
+    /**
+     * The dialog carries a user source and the log line never mentioned who. It names them now, so a
+     * line written for "the triggering user" can be told apart from one written for the whole room.
+     * Empty when the source resolves to nobody, which keeps a log line that never needed a user clean.
+     */
+    private String describeUsers(WiredContext ctx) {
+        List<RoomUnit> users = WiredSourceUtil.resolveUsers(ctx, this.userSource);
+        if (users.isEmpty()) {
+            return "";
+        }
+
+        Room room = ctx.room();
+        StringBuilder names = new StringBuilder();
+
+        for (RoomUnit unit : users) {
+            Habbo habbo = (room != null) ? room.getHabbo(unit) : null;
+            String name = (habbo != null && habbo.getHabboInfo() != null)
+                    ? habbo.getHabboInfo().getUsername()
+                    : ("#" + unit.getId());
+
+            names.append(names.isEmpty() ? "" : ", ").append(name);
+        }
+
+        return " [" + names + "]";
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMakeUserSay.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectMakeUserSay.java
@@ -20,6 +20,7 @@ import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.habbohotel.wired.core.WiredTextPlaceholderUtil;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.incoming.wired.WiredSaveException;
+import com.eu.habbo.messages.outgoing.rooms.users.RoomUserTalkComposer;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -171,6 +172,7 @@ public class WiredEffectMakeUserSay extends InteractionWiredEffect {
             }
 
             List<RoomUnit> sourceUsers = resolveUsers(ctx);
+            boolean toEveryone = this.visibilitySelection == VISIBILITY_ALL_ROOM_USERS;
 
             for (RoomUnit unit : sourceUsers) {
                 Habbo h = room.getHabbo(unit);
@@ -178,18 +180,35 @@ public class WiredEffectMakeUserSay extends InteractionWiredEffect {
                     continue;
                 }
 
-                String msg = buildMessage(ctx, h);
-                room.talk(
-                        h,
-                        new RoomChatMessage(msg, unit, RoomChatMessageBubbles.getBubble(this.bubbleStyle)),
-                        RoomChatType.TALK,
-                        true);
+                RoomChatMessage chatMessage = new RoomChatMessage(
+                        buildMessage(ctx, h), unit, RoomChatMessageBubbles.getBubble(this.bubbleStyle));
+
+                if (toEveryone) {
+                    room.talk(h, chatMessage, RoomChatType.TALK, true);
+                } else {
+                    sayToSpeakerOnly(h, chatMessage);
+                }
 
                 if (h.getRoomUnit().isIdle()) {
                     h.getRoomUnit().getRoom().unIdle(h);
                 }
             }
         }
+    }
+
+    /**
+     * The dialog's "message visibility" choice, which this box stored and never read. Everyone goes
+     * through the room's own chat path, so distance, ignore lists and tents keep applying; the narrow
+     * choice puts the bubble on the speaker's own screen only, and needs none of that filtering because
+     * the speaker is the single recipient.
+     */
+    private void sayToSpeakerOnly(Habbo speaker, RoomChatMessage chatMessage) {
+        GameClient client = speaker.getClient();
+        if (client == null) {
+            return;
+        }
+
+        client.sendResponse(new RoomUserTalkComposer(chatMessage));
     }
 
     @Deprecated

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectOpenHabboPages.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectOpenHabboPages.java
@@ -72,11 +72,18 @@ public class WiredEffectOpenHabboPages extends InteractionWiredEffect {
 
     @Override
     public boolean saveData(WiredSettings settings, GameClient gameClient) {
-        String value = settings.getStringParam();
-        if (value == null || value.trim().isEmpty()) {
+        String value = WiredLinkPolicy.normalize(settings.getStringParam());
+        if (value.isEmpty()) {
             return false;
         }
-        this.link = value.trim();
+
+        // The link is pushed at every resolved user's client, so it is bounded by who configures it.
+        Habbo configurer = (gameClient != null) ? gameClient.getHabbo() : null;
+        if (!WiredLinkPolicy.canUse(value, configurer)) {
+            return false;
+        }
+
+        this.link = value;
 
         int[] params = settings.getIntParams();
         this.userSource = (params.length > 0) ? params[0] : WiredSourceUtil.SOURCE_TRIGGER;
@@ -120,7 +127,9 @@ public class WiredEffectOpenHabboPages extends InteractionWiredEffect {
 
         if (wiredData.startsWith("{")) {
             JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
-            this.link = data.link == null ? "" : data.link;
+            // Normalised, but not re-gated: the save path is the boundary. Dropping a stored link here
+            // would silently blank a box an ACC_SUPERWIRED user was entitled to configure.
+            this.link = WiredLinkPolicy.normalize(data.link);
             this.setDelay(data.delay);
             this.userSource = data.userSource;
         } else {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectPayloadGuard.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectPayloadGuard.java
@@ -59,7 +59,9 @@ final class WiredEffectPayloadGuard {
 
         try {
             return WiredManager.getGson().fromJson(wiredData, type);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
+            // A truncated document reaches here as EOFException, which is checked and so slipped
+            // straight through a RuntimeException-only catch and failed the whole furni load.
             return null;
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSendSignal.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSendSignal.java
@@ -142,19 +142,38 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
             usersToSend = Collections.singletonList(triggeringUser);
         }
 
-        Collection<HabboItem> furniToSend =
-                !forwardedFurni.isEmpty() ? forwardedFurni : Collections.singletonList(null);
+        // "Send signal for each furni", the mirror of signalPerUser, which this box stored and never
+        // read: it always split. Off now means one signal carrying the first forwarded furni, so the
+        // receiving stack still has a source item to work with and reads the full count from
+        // @signal_furni_count.
+        Collection<HabboItem> furniToSend;
+        if (forwardedFurni.isEmpty()) {
+            furniToSend = Collections.singletonList(null);
+        } else if (signalPerFurni) {
+            furniToSend = forwardedFurni;
+        } else {
+            furniToSend = Collections.singletonList(forwardedFurni.get(0));
+        }
 
         int nextDepth = currentDepth + 1;
         int signalUserCount = signalPerUser
                 ? (int) usersToSend.stream().filter(Objects::nonNull).count()
                 : (!forwardedUsers.isEmpty() ? forwardedUsers.size() : (triggeringUser != null ? 1 : 0));
+        int signalFurniCount = forwardedFurni.size();
 
         for (RoomUnit user : usersToSend) {
             for (HabboItem sourceItem : furniToSend) {
                 for (HabboItem antenna : resolvedAntennas) {
                     fireSignalAtAntenna(
-                            ctx, room, antenna, user, triggeringUser, sourceItem, signalUserCount, nextDepth);
+                            ctx,
+                            room,
+                            antenna,
+                            user,
+                            triggeringUser,
+                            sourceItem,
+                            signalUserCount,
+                            signalFurniCount,
+                            nextDepth);
                 }
             }
         }
@@ -168,6 +187,7 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
             RoomUnit originActor,
             HabboItem sourceItem,
             int signalUserCount,
+            int signalFurniCount,
             int depth) {
         if (antenna == null) return;
         RoomTile tile = room.getLayout().getTile(antenna.getX(), antenna.getY());
@@ -192,7 +212,7 @@ public class WiredEffectSendSignal extends InteractionWiredEffect {
                 .callStackDepth(depth)
                 .signalChannel(signalChannel)
                 .signalUserCount(signalUserCount)
-                .signalFurniCount(sourceItem != null ? 1 : 0)
+                .signalFurniCount(signalFurniCount)
                 .contextVariableScope(ctx.contextVariables().copy())
                 .triggeredByEffect(true);
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSetRoomAd.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectSetRoomAd.java
@@ -1,6 +1,7 @@
 package com.eu.habbo.habbohotel.items.interactions.wired.effects;
 
 import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.items.Item;
 import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
@@ -121,12 +122,19 @@ public class WiredEffectSetRoomAd extends InteractionWiredEffect {
     }
 
     private static int maxCaptionLength() {
-        return Emulator.getConfig().getInt("hotel.wired.set_room_ad.caption_max_length", DEFAULT_MAX_CAPTION_LENGTH);
+        // Reached while loading a furni, which can happen before the configuration exists.
+        ConfigurationManager config = Emulator.getConfig();
+        return config == null
+                ? DEFAULT_MAX_CAPTION_LENGTH
+                : config.getInt("hotel.wired.set_room_ad.caption_max_length", DEFAULT_MAX_CAPTION_LENGTH);
     }
 
     private static int maxDescriptionLength() {
-        return Emulator.getConfig()
-                .getInt("hotel.wired.set_room_ad.description_max_length", DEFAULT_MAX_DESCRIPTION_LENGTH);
+        // Reached while loading a furni, which can happen before the configuration exists.
+        ConfigurationManager config = Emulator.getConfig();
+        return config == null
+                ? DEFAULT_MAX_DESCRIPTION_LENGTH
+                : config.getInt("hotel.wired.set_room_ad.description_max_length", DEFAULT_MAX_DESCRIPTION_LENGTH);
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredLinkPolicy.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredLinkPolicy.java
@@ -1,0 +1,109 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.users.Habbo;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Which in-client destinations a wired box may push at the people in a room.
+ *
+ * <p>The open-pages effect took whatever string was typed and handed it to the client untouched, and
+ * it is sold at rank 1, so any room owner could aim any navigation at every visitor. This bounds it
+ * the way {@link WiredCommandPolicy} bounds the command effect: a fixed set of destinations anyone
+ * may open, everything else behind {@code ACC_SUPERWIRED}.
+ *
+ * <p>The list is the set of link namespaces the client itself creates through {@code CreateLinkEvent},
+ * minus the staff surfaces and the internal pickers - a wired box has no business opening housekeeping,
+ * the mod tools, the furni or floor editor, or a chooser that only makes sense mid-flow.
+ */
+final class WiredLinkPolicy {
+
+    private static final String RESTRICT_KEY = "hotel.wired.link.restrict_namespaces";
+
+    private static final Set<String> SAFE_NAMESPACES = Set.of(
+            "achievements",
+            "avatar-editor",
+            "avatar-effects",
+            "badge-creator",
+            "badge-leaderboard",
+            "camera",
+            "catalog",
+            "chat-history",
+            "customize",
+            "fortune-wheel",
+            "friends",
+            "friends-messenger",
+            "games",
+            "group-members",
+            "groupforum",
+            "groups",
+            "habbo",
+            "habbopages",
+            "help",
+            "inventory",
+            "mentions",
+            "navigator",
+            "soundboard",
+            "stories",
+            "translation-settings",
+            "trax-editor",
+            "user-account-settings",
+            "user-settings",
+            "wired-tools");
+
+    private WiredLinkPolicy() {}
+
+    /** Trims the link and drops a leading slash, so "/catalog/open" and "catalog/open" agree. */
+    static String normalize(String raw) {
+        if (raw == null) {
+            return "";
+        }
+
+        String value = raw.trim();
+        while (value.startsWith("/")) {
+            value = value.substring(1);
+        }
+
+        return value;
+    }
+
+    /** The part before the first slash, lowercased - what decides where the client goes. */
+    static String namespaceOf(String link) {
+        String value = normalize(link);
+        if (value.isEmpty()) {
+            return "";
+        }
+
+        int separator = value.indexOf('/');
+        return (separator < 0 ? value : value.substring(0, separator)).toLowerCase(Locale.ROOT);
+    }
+
+    static boolean isSafe(String link) {
+        return SAFE_NAMESPACES.contains(namespaceOf(link));
+    }
+
+    /**
+     * True when this configurer may point a box at this destination. Anyone may use the safe
+     * namespaces; anything else - a staff surface, or a namespace this client does not know - needs
+     * the same permission the other value-bearing wired boxes ask for.
+     */
+    static boolean canUse(String link, Habbo principal) {
+        if (normalize(link).isEmpty()) {
+            return false;
+        }
+
+        if (!restrictsNamespaces() || isSafe(link)) {
+            return true;
+        }
+
+        return principal != null && principal.hasPermission(Permission.ACC_SUPERWIRED);
+    }
+
+    private static boolean restrictsNamespaces() {
+        ConfigurationManager config = Emulator.getConfig();
+        return config == null || config.getBoolean(RESTRICT_KEY, true);
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerDiceRolled.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerDiceRolled.java
@@ -97,7 +97,7 @@ public class WiredTriggerDiceRolled extends InteractionWiredTrigger {
         String wiredData = set.getString("wired_data");
 
         if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = parsePayload(wiredData);
             if (data != null) {
                 this.requiredValue = Math.max(ANY_VALUE, data.requiredValue);
             }
@@ -112,6 +112,19 @@ public class WiredTriggerDiceRolled extends InteractionWiredTrigger {
     @Override
     public boolean isTriggeredByRoomUnit() {
         return false;
+    }
+
+    /**
+     * A truncated document leaves Gson throwing EOFException, which is checked - so it escapes a
+     * RuntimeException catch and takes the whole furni load down. Anything unreadable is simply no
+     * configuration.
+     */
+    private static JsonData parsePayload(String wiredData) {
+        try {
+            return WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (Exception exception) {
+            return null;
+        }
     }
 
     static class JsonData {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerPressKeybind.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerPressKeybind.java
@@ -93,7 +93,7 @@ public class WiredTriggerPressKeybind extends InteractionWiredTrigger {
         String wiredData = set.getString("wired_data");
 
         if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = parsePayload(wiredData);
             if (data != null) {
                 this.keyCode = Math.max(ANY_KEY, data.keyCode);
             }
@@ -108,6 +108,19 @@ public class WiredTriggerPressKeybind extends InteractionWiredTrigger {
     @Override
     public boolean isTriggeredByRoomUnit() {
         return false;
+    }
+
+    /**
+     * A truncated document leaves Gson throwing EOFException, which is checked - so it escapes a
+     * RuntimeException catch and takes the whole furni load down. Anything unreadable is simply no
+     * configuration.
+     */
+    private static JsonData parsePayload(String wiredData) {
+        try {
+            return WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (Exception exception) {
+            return null;
+        }
     }
 
     static class JsonData {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerUserGetsHandItem.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/triggers/WiredTriggerUserGetsHandItem.java
@@ -100,7 +100,7 @@ public class WiredTriggerUserGetsHandItem extends InteractionWiredTrigger {
         String wiredData = set.getString("wired_data");
 
         if (wiredData != null && wiredData.startsWith("{")) {
-            JsonData data = WiredManager.getGson().fromJson(wiredData, JsonData.class);
+            JsonData data = parsePayload(wiredData);
             if (data != null) {
                 this.handItemId = Math.max(ANY_HAND_ITEM, data.handItemId);
             }
@@ -115,6 +115,19 @@ public class WiredTriggerUserGetsHandItem extends InteractionWiredTrigger {
     @Override
     public boolean isTriggeredByRoomUnit() {
         return true;
+    }
+
+    /**
+     * A truncated document leaves Gson throwing EOFException, which is checked - so it escapes a
+     * RuntimeException catch and takes the whole furni load down. Anything unreadable is simply no
+     * configuration.
+     */
+    private static JsonData parsePayload(String wiredData) {
+        try {
+            return WiredManager.getGson().fromJson(wiredData, JsonData.class);
+        } catch (Exception exception) {
+            return null;
+        }
     }
 
     static class JsonData {

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionSameHeightQuantifierTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/conditions/WiredConditionSameHeightQuantifierTest.java
@@ -1,0 +1,91 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.conditions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.users.HabboItem;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The HAS_ALTITUDE dialog offers "all of the furni match" and "any of the furni match"; the two height
+ * conditions stored the choice and always behaved as "all". These cover the two readings and, above
+ * all, that the boxes stay exact complements of each other under either one.
+ */
+class WiredConditionSameHeightQuantifierTest {
+
+    private static HabboItem at(double z) {
+        HabboItem item = mock(HabboItem.class);
+        when(item.getZ()).thenReturn(z);
+        return item;
+    }
+
+    private static List<HabboItem> heights(double... values) {
+        HabboItem[] items = new HabboItem[values.length];
+        for (int i = 0; i < values.length; i++) {
+            items[i] = at(values[i]);
+        }
+        return Arrays.asList(items);
+    }
+
+    @Test
+    @DisplayName("all: every target has to sit at the same height")
+    void allWantsOneHeight() {
+        assertTrue(WiredConditionSameHeight.allShareHeight(heights(1.0, 1.0, 1.0)));
+        assertFalse(WiredConditionSameHeight.allShareHeight(heights(1.0, 1.0, 2.0)));
+    }
+
+    @Test
+    @DisplayName("any: two targets meeting is enough")
+    void anyWantsOnePair() {
+        assertTrue(WiredConditionSameHeight.anyPairShareHeight(heights(1.0, 2.0, 2.0)));
+        assertFalse(WiredConditionSameHeight.anyPairShareHeight(heights(1.0, 2.0, 3.0)));
+    }
+
+    @Test
+    @DisplayName("a lone target satisfies all and never satisfies any")
+    void aSingleTarget() {
+        assertTrue(WiredConditionSameHeight.allShareHeight(heights(1.0)));
+        assertFalse(WiredConditionSameHeight.anyPairShareHeight(heights(1.0)));
+        assertTrue(WiredConditionSameHeight.allShareHeight(Collections.emptyList()));
+    }
+
+    @Test
+    @DisplayName("heights that differ only in their decimals are different heights")
+    void decimalsCount() {
+        assertFalse(WiredConditionSameHeight.allShareHeight(heights(1.0, 1.0001)));
+        assertFalse(WiredConditionSameHeight.anyPairShareHeight(heights(1.0, 1.0001)));
+    }
+
+    @Test
+    @DisplayName("a null target is skipped, not a failure")
+    void nullTargetsAreSkipped() {
+        assertTrue(WiredConditionSameHeight.allShareHeight(Arrays.asList(null, at(1.0), at(1.0))));
+        assertTrue(WiredConditionSameHeight.anyPairShareHeight(Arrays.asList(null, at(1.0), at(1.0))));
+    }
+
+    @Test
+    @DisplayName("all keeps its historical answer: equal heights pass, one odd one out fails")
+    void allMatchesWhatTheBoxAlwaysDid() {
+        assertTrue(WiredConditionSameHeight.allShareHeight(heights(2.5, 2.5, 2.5, 2.5)));
+        assertFalse(WiredConditionSameHeight.allShareHeight(heights(2.5, 2.5, 2.5, 0.0)));
+    }
+
+    @Test
+    @DisplayName("what the not-same-height box answers, which is this negated")
+    void theComplementSpelledOut() {
+        // all: "not every target at one height" - the reading that box has always had
+        assertFalse(!WiredConditionSameHeight.allShareHeight(heights(1.0, 1.0)));
+        assertTrue(!WiredConditionSameHeight.allShareHeight(heights(1.0, 2.0)));
+        assertTrue(!WiredConditionSameHeight.allShareHeight(heights(1.0, 2.0, 2.0)));
+
+        // any: "no two targets meet", i.e. every height is distinct
+        assertTrue(!WiredConditionSameHeight.anyPairShareHeight(heights(1.0, 2.0, 3.0)));
+        assertFalse(!WiredConditionSameHeight.anyPairShareHeight(heights(1.0, 2.0, 2.0)));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredLinkPolicyTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredLinkPolicyTest.java
@@ -1,0 +1,76 @@
+package com.eu.habbo.habbohotel.items.interactions.wired.effects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.users.Habbo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The open-pages effect handed the client whatever string was typed, and it sells at rank 1. These
+ * pin the shape of the destination check: a fixed set anyone may open, everything else elevated.
+ */
+class WiredLinkPolicyTest {
+
+    private static Habbo superWired() {
+        Habbo habbo = mock(Habbo.class);
+        when(habbo.hasPermission(Permission.ACC_SUPERWIRED)).thenReturn(true);
+        return habbo;
+    }
+
+    private static Habbo ordinary() {
+        return mock(Habbo.class);
+    }
+
+    @Test
+    @DisplayName("a leading slash and stray spaces do not change where the link points")
+    void normalizationIsStable() {
+        assertEquals("catalog/open", WiredLinkPolicy.normalize("  /catalog/open  "));
+        assertEquals("catalog/open", WiredLinkPolicy.normalize("///catalog/open"));
+        assertEquals("", WiredLinkPolicy.normalize(null));
+        assertEquals("catalog", WiredLinkPolicy.namespaceOf("/CATALOG/open/1"));
+    }
+
+    @Test
+    @DisplayName("the player-facing destinations are open to anyone")
+    void safeNamespacesNeedNoPermission() {
+        for (String link :
+                new String[] {"catalog/open", "navigator/goto/12", "habbopages/help", "inventory/show", "achievements"
+                }) {
+            assertTrue(WiredLinkPolicy.isSafe(link), link);
+            assertTrue(WiredLinkPolicy.canUse(link, ordinary()), link);
+        }
+    }
+
+    @Test
+    @DisplayName("staff surfaces and unknown destinations are not")
+    void staffAndUnknownNamespacesAreElevated() {
+        for (String link :
+                new String[] {"mod-tools/open", "housekeeping", "furni-editor", "floor-editor", "not-a-real-namespace"
+                }) {
+            assertFalse(WiredLinkPolicy.isSafe(link), link);
+            assertFalse(WiredLinkPolicy.canUse(link, ordinary()), link);
+            assertTrue(WiredLinkPolicy.canUse(link, superWired()), link);
+        }
+    }
+
+    @Test
+    @DisplayName("an empty link is refused whoever asks")
+    void anEmptyLinkIsAlwaysRefused() {
+        assertFalse(WiredLinkPolicy.canUse("", superWired()));
+        assertFalse(WiredLinkPolicy.canUse("   ", superWired()));
+        assertFalse(WiredLinkPolicy.canUse(null, superWired()));
+    }
+
+    @Test
+    @DisplayName("a null configurer never clears an elevated destination")
+    void aMissingConfigurerIsRefused() {
+        assertFalse(WiredLinkPolicy.canUse("mod-tools/open", null));
+        assertTrue(WiredLinkPolicy.canUse("catalog/open", null));
+    }
+}

--- a/Emulator/src/test/resources/architecture/frozen-violations.tsv
+++ b/Emulator/src/test/resources/architecture/frozen-violations.tsv
@@ -727,6 +727,7 @@ U|com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWalkToFurn
 U|com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWalkToFurni.java|CALL|getRandom|1
 U|com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWhisper.java|CALL|getConfig|3
 U|com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectWhisper.java|CALL|getGameEnvironment|3
+U|com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredLinkPolicy.java|CALL|getConfig|1
 U|com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraContextVariable.java|CALL|getGameEnvironment|1
 U|com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraFurniVariable.java|CALL|getGameEnvironment|1
 U|com/eu/habbo/habbohotel/items/interactions/wired/extra/WiredExtraOrEval.java|CALL|getConfig|1


### PR DESCRIPTION
Nine controls that the dialogs draw, the server stored and echoed back, and then never read. Each one is a setting a player can pick and the server ignores.

| Box | Control | Did | Does now |
|---|---|---|---|
| `WiredEffectSendSignal` | `signalPerFurni` | always split | off sends one signal; the full count stays in `@signal_furni_count` |
| `WiredEffectMakeUserSay` | `visibilitySelection` | always the whole room | "everyone" goes through the room's chat path; "only the user" puts the bubble on the speaker's screen |
| `WiredEffectLog` | `userSource` | the line named nobody | the line names the resolved users |
| `WiredConditionFurniInRange` and three siblings | `comparison` | always "within the radius" | strict less, within, strict greater |
| `WiredConditionSameHeight` and its twin | `quantifier` | always "all" | all at one height, or two that meet |

Also here: `WiredLinkPolicy` bounds where the open-pages effect can send people — it took any string and handed it to the client, and it sells at rank 1 — and ten classes that could not be reached from a furni are made safe to reach (four minted value with no permission, one threw when unconfigured, eight lost the whole furni load on a truncated `wired_data` row because Gson reports that as a *checked* `EOFException` that slipped through every `catch (RuntimeException)`).

### Compatibility

Seven of the nine keep their default behaviour exactly. Two change what an existing box does, and both are one click to restore:

- a **make user say** left on the dialog's default ("only the user") now shows the bubble to that user alone — pick "everyone" for the old behaviour;
- a **send signal** forwarding several furni with the box unticked now sends one signal instead of one each — tick it for the old behaviour.

### Verification

`./mvnw -B test` — 1643 tests, red only the nine networking tests that fail on a clean checkout here. ABI gate and the wired ratchets green. Client: `yarn typecheck`, `yarn lint:hooks`, wired suite 71/71.

Nothing exercised in a running room: the emulator does not start on this machine.
