### PR TITLE
feat(wired): tell the monitor when a chain had nothing to act on

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredRoomDiagnostics.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredRoomDiagnostics.java
@@ -17,7 +17,9 @@ public final class WiredRoomDiagnostics {
         EXECUTOR_OVERLOAD,
         MARKED_AS_HEAVY,
         KILLED,
-        RECURSION_TIMEOUT
+        RECURSION_TIMEOUT,
+        /** A chain fired and an effect had nothing to act on, so it did nothing and said nothing. */
+        NO_TARGETS
     }
 
     public enum Severity {
@@ -415,6 +417,17 @@ public final class WiredRoomDiagnostics {
         record(Type.RECURSION_TIMEOUT, now, reason, sourceLabel, sourceId);
     }
 
+    /**
+     * A chain ran to its effects and one of them resolved no furni or no users. Nothing is wrong with
+     * the engine - the setup asked for something that was not there - but until now that was the one
+     * way a chain could do nothing without leaving a trace, which is a long evening for whoever built
+     * it. Entries aggregate by type, so a busy room adds a count rather than a wall of lines.
+     */
+    public void recordNoTargets(long now, String reason, String sourceLabel, int sourceId) {
+        rollWindowIfNeeded(now);
+        record(Type.NO_TARGETS, now, reason, sourceLabel, sourceId);
+    }
+
     public synchronized void clearLogs() {
         for (Type type : Type.values()) {
             LogEntry entry = this.logs.get(type);
@@ -631,6 +644,7 @@ public final class WiredRoomDiagnostics {
     }
 
     private Severity defaultSeverity(Type type) {
-        return (type == Type.MARKED_AS_HEAVY) ? Severity.WARNING : Severity.ERROR;
+        // Neither of these is the engine failing; they describe a setup, so they read as warnings.
+        return (type == Type.MARKED_AS_HEAVY || type == Type.NO_TARGETS) ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredSourceUtil.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredSourceUtil.java
@@ -27,9 +27,15 @@ public final class WiredSourceUtil {
             return resolvedItems;
         }
 
-        return (sourceType == SOURCE_SELECTOR)
+        List<HabboItem> filtered = (sourceType == SOURCE_SELECTOR)
                 ? resolvedItems
                 : WiredSelectionFilterSupport.filterItems(ctx.room(), ctx.triggerItem(), ctx, resolvedItems);
+
+        if (filtered.isEmpty() && ctx.state() != null) {
+            ctx.state().noteUnresolvedFurniSource(sourceType);
+        }
+
+        return filtered;
     }
 
     public static List<HabboItem> resolveItemsRaw(
@@ -48,9 +54,15 @@ public final class WiredSourceUtil {
             return resolvedUsers;
         }
 
-        return (sourceType == SOURCE_SELECTOR)
+        List<RoomUnit> filtered = (sourceType == SOURCE_SELECTOR)
                 ? resolvedUsers
                 : WiredSelectionFilterSupport.filterUsers(ctx.room(), ctx.triggerItem(), ctx, resolvedUsers);
+
+        if (filtered.isEmpty() && ctx.state() != null) {
+            ctx.state().noteUnresolvedUserSource(sourceType);
+        }
+
+        return filtered;
     }
 
     public static List<RoomUnit> resolveUsersRaw(WiredContext ctx, int sourceType) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredStackExecutor.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredStackExecutor.java
@@ -186,6 +186,8 @@ final class WiredStackExecutor {
             this.hooks.executeEffects(stack, executableEffects, context, currentTime);
         }
 
+        reportUnresolvedSources(roomDiagnostics, state, monitorSourceLabel, monitorSourceId);
+
         fireExecutedEvent(stack, event);
         long elapsedMs = state.elapsedMs();
         roomDiagnostics.recordExecution(
@@ -202,6 +204,51 @@ final class WiredStackExecutor {
                 elapsedMs,
                 WiredStructuredDiagnostics.Outcome.EXECUTED);
         return true;
+    }
+
+    /**
+     * A chain that fires and finds nothing to act on used to be completely silent: no error, no log,
+     * nothing in the monitor. Whoever built it had no way to tell "the trigger never fired" from "the
+     * effect had no furni". One line per firing, naming the sources that came back empty.
+     */
+    private void reportUnresolvedSources(
+            WiredRoomDiagnostics diagnostics, WiredState state, String sourceLabel, int sourceId) {
+        if (state.unresolvedFurniSources().isEmpty()
+                && state.unresolvedUserSources().isEmpty()) {
+            return;
+        }
+
+        StringBuilder reason = new StringBuilder("Nothing to act on:");
+        if (!state.unresolvedFurniSources().isEmpty()) {
+            reason.append(" furni source ").append(describeSources(state.unresolvedFurniSources()));
+        }
+        if (!state.unresolvedUserSources().isEmpty()) {
+            reason.append(" user source ").append(describeSources(state.unresolvedUserSources()));
+        }
+
+        diagnostics.recordNoTargets(this.clock.getAsLong(), reason.toString(), sourceLabel, sourceId);
+    }
+
+    private static String describeSources(Set<Integer> sources) {
+        StringBuilder names = new StringBuilder();
+        for (Integer source : sources) {
+            if (names.length() > 0) {
+                names.append(", ");
+            }
+            names.append(describeSource(source));
+        }
+        return names.toString();
+    }
+
+    private static String describeSource(int source) {
+        return switch (source) {
+            case WiredSourceUtil.SOURCE_TRIGGER -> "the triggering item";
+            case WiredSourceUtil.SOURCE_CLICKED_USER -> "the clicked user";
+            case WiredSourceUtil.SOURCE_SELECTED -> "the picked furni";
+            case WiredSourceUtil.SOURCE_SELECTOR -> "the selector";
+            case WiredSourceUtil.SOURCE_SIGNAL -> "the signal";
+            default -> "source " + source;
+        };
     }
 
     private void logMatchedStack(Room room, WiredStack stack, WiredEvent event, boolean negateConditions, Mode mode) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredState.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/wired/core/WiredState.java
@@ -33,6 +33,14 @@ public final class WiredState {
     private String abortReason;
 
     /**
+     * Sources that answered with nothing during this run. Kept as a small ordered set so one firing
+     * reports "furni source 200" once, however many effects asked for it.
+     */
+    private final java.util.LinkedHashSet<Integer> unresolvedFurniSources = new java.util.LinkedHashSet<>();
+
+    private final java.util.LinkedHashSet<Integer> unresolvedUserSources = new java.util.LinkedHashSet<>();
+
+    /**
      * Create a new wired state with the specified step limit.
      * @param maxSteps maximum number of steps allowed (triggers, conditions, effects)
      */
@@ -54,6 +62,24 @@ public final class WiredState {
     static WiredState restoreDelayedSnapshot(
             UUID runId, int maxSteps, int steps, long startTimeMs, boolean aborted, String abortReason) {
         return new WiredState(runId, maxSteps, steps, startTimeMs, aborted, abortReason);
+    }
+
+    /** Note that a furni source resolved to nothing, so the firing can say so once it is over. */
+    void noteUnresolvedFurniSource(int sourceType) {
+        this.unresolvedFurniSources.add(sourceType);
+    }
+
+    /** Note that a user source resolved to nothing. */
+    void noteUnresolvedUserSource(int sourceType) {
+        this.unresolvedUserSources.add(sourceType);
+    }
+
+    java.util.Set<Integer> unresolvedFurniSources() {
+        return this.unresolvedFurniSources;
+    }
+
+    java.util.Set<Integer> unresolvedUserSources() {
+        return this.unresolvedUserSources;
     }
 
     /**

--- a/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
+++ b/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
@@ -5728,6 +5728,7 @@ METHOD public synchronized com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnosti
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics#completeDelayedEvent(-):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics#recordExecution(long,long,java.lang.String,int,java.lang.String):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics#recordKilled(long,java.lang.String,java.lang.String,int):void throws -
+METHOD public com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics#recordNoTargets(long,java.lang.String,java.lang.String,int):void throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics#recordRecursionTimeout(long,java.lang.String,java.lang.String,int):void throws -
 METHOD public synchronized com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics#snapshot(int,int,long,long):com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Snapshot throws -
 METHOD public com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics#tryConsumeExecutionBudget(int,long,java.lang.String,int,java.lang.String):boolean throws -
@@ -5789,11 +5790,13 @@ ENUM com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type 2 EXECUTOR_OVE
 ENUM com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type 3 MARKED_AS_HEAVY
 ENUM com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type 4 KILLED
 ENUM com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type 5 RECURSION_TIMEOUT
+ENUM com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type 6 NO_TARGETS
 FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#DELAYED_EVENTS_CAP:com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type
 FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#EXECUTION_CAP:com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type
 FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#EXECUTOR_OVERLOAD:com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type
 FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#KILLED:com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type
 FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#MARKED_AS_HEAVY:com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type
+FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#NO_TARGETS:com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type
 FIELD public static final com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#RECURSION_TIMEOUT:com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type
 METHOD public static com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#valueOf(java.lang.String):com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type throws -
 METHOD public static com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type#values(-):com.eu.habbo.habbohotel.wired.core.WiredRoomDiagnostics$Type[] throws -


### PR DESCRIPTION
A chain that fires and finds no furni or no users was completely silent: no error, no log, nothing in the monitor. Whoever built it could not tell "the trigger never fired" from "the effect had no furni".

The run notes every source that came back empty, and the firing reports them once as a `NO_TARGETS` warning — *"Nothing to act on: furni source the selector"*. A warning rather than an error: the engine did its job, the setup asked for something that was not there.

Notes live on the run and are reported once per firing; the log aggregates by type, so a busy room adds a count rather than a wall of lines.

Pairs with the client change that gives the warning its description in the monitor.

### Verification

`./mvnw -B test` — 1649 tests, red only the nine networking tests that fail on a clean checkout here. The plugin surface fixture gains exactly the new enum constant and the new method, and loses nothing.

Not exercised in a running room: the emulator does not start on this machine.
