### PR TITLE
feat(achievements): align AIR rewards and progress

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/Achievement.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/Achievement.java
@@ -9,15 +9,14 @@ public class Achievement {
 
     public final int id;
 
-
     public final String name;
 
-
     public final AchievementCategories category;
-
+    public volatile short state = 1;
+    public volatile int displayMethod;
+    public volatile String subcategory = "";
 
     public final Map<Integer, AchievementLevel> levels;
-
 
     public Achievement(ResultSet set) throws SQLException {
         this.levels = new HashMap<>();
@@ -26,16 +25,27 @@ public class Achievement {
         this.name = set.getString("name");
         this.category = AchievementCategories.valueOf(set.getString("category").toUpperCase());
 
+        this.loadMetadata(set);
+
         this.addLevel(new AchievementLevel(set));
     }
 
+    void loadMetadata(ResultSet set) throws SQLException {
+        try {
+            set.findColumn("state");
+        } catch (SQLException missingMetadata) {
+            return; // Legacy plugins may construct achievements from their original column projection.
+        }
+        this.state = set.getShort("state");
+        this.displayMethod = set.getInt("display_method");
+        this.subcategory = set.getString("subcategory");
+    }
 
     public void addLevel(AchievementLevel level) {
         synchronized (this.levels) {
             this.levels.put(level.level, level);
         }
     }
-
 
     public AchievementLevel getLevelForProgress(int progress) {
         AchievementLevel l = null;
@@ -55,12 +65,10 @@ public class Achievement {
         return l;
     }
 
-
     public AchievementLevel getNextLevel(int currentLevel) {
 
         for (AchievementLevel level : this.levels.values()) {
-            if (level.level == (currentLevel + 1))
-                return level;
+            if (level.level == (currentLevel + 1)) return level;
         }
 
         return null;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementCategories.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementCategories.java
@@ -1,39 +1,33 @@
 package com.eu.habbo.habbohotel.achievements;
 
 public enum AchievementCategories {
-
     IDENTITY,
-
 
     EXPLORE,
 
-
     MUSIC,
-
 
     SOCIAL,
 
-
     GAMES,
-
 
     ROOM_BUILDER,
 
-
     PETS,
-
 
     TOOLS,
 
-
     OTHER,
-
 
     TEST,
 
-
     INVISIBLE,
 
+    EVENTS,
 
-    EVENTS
+    MISC,
+
+    ARCHIVE,
+
+    WIRED_GAMES
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementManager.java
@@ -1,11 +1,15 @@
 package com.eu.habbo.habbohotel.achievements;
 
 import com.eu.habbo.Emulator;
-import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.catalog.CatalogPurchaseMath;
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboBadge;
 import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.habbohotel.users.inventory.BadgesComponent;
+import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
 import com.eu.habbo.messages.outgoing.achievements.AchievementProgressComposer;
 import com.eu.habbo.messages.outgoing.achievements.AchievementUnlockedComposer;
 import com.eu.habbo.messages.outgoing.achievements.talenttrack.TalentLevelUpdateComposer;
@@ -13,10 +17,18 @@ import com.eu.habbo.messages.outgoing.inventory.AddHabboItemComposer;
 import com.eu.habbo.messages.outgoing.inventory.InventoryRefreshComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDataComposer;
 import com.eu.habbo.messages.outgoing.users.AddUserBadgeComposer;
+import com.eu.habbo.messages.outgoing.users.UserAchievementScoreComposer;
 import com.eu.habbo.messages.outgoing.users.UserBadgesComposer;
+import com.eu.habbo.messages.outgoing.users.UserCreditsComposer;
+import com.eu.habbo.messages.outgoing.users.UserCurrencyComposer;
+import com.eu.habbo.messages.outgoing.users.UserPointsComposer;
 import com.eu.habbo.plugin.Event;
+import com.eu.habbo.plugin.events.users.UserCreditsEvent;
+import com.eu.habbo.plugin.events.users.UserPointsEvent;
 import com.eu.habbo.plugin.events.users.achievements.UserAchievementLeveledEvent;
 import com.eu.habbo.plugin.events.users.achievements.UserAchievementProgressEvent;
+import com.eu.habbo.plugin.events.users.subscriptions.UserSubscriptionCreatedEvent;
+import com.eu.habbo.plugin.events.users.subscriptions.UserSubscriptionExtendedEvent;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -24,6 +36,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,17 +59,16 @@ public class AchievementManager {
     }
 
     public static void progressAchievement(int habboId, Achievement achievement, int amount) {
-        if (achievement != null) {
+        if (achievement != null && amount > 0 && habboId > 0) {
             Habbo habbo = Emulator.getGameEnvironment().getHabboManager().getHabbo(habboId);
 
             if (habbo != null) {
                 progressAchievement(habbo, achievement, amount);
             } else {
-                try (Connection connection =
-                                Emulator.getDatabase().getDataSource().getConnection();
+                try (Connection connection = openConnection();
                         PreparedStatement statement = connection.prepareStatement(""
                                 + "INSERT INTO users_achievements_queue (user_id, achievement_id, amount) VALUES (?, ?, ?) "
-                                + "ON DUPLICATE KEY UPDATE amount = amount + ?")) {
+                                + "ON DUPLICATE KEY UPDATE amount = LEAST(2147483647, CAST(amount AS SIGNED) + ?)")) {
                     statement.setInt(1, habboId);
                     statement.setInt(2, achievement.id);
                     statement.setInt(3, amount);
@@ -74,146 +86,212 @@ public class AchievementManager {
     }
 
     public static void progressAchievement(Habbo habbo, Achievement achievement, int amount) {
-        if (achievement == null) return;
+        if (achievement == null || habbo == null || !habbo.isOnline() || amount <= 0) return;
 
-        if (habbo == null) return;
+        try {
+            LedgerWalletMutation.coordinated(habbo, () -> {
+                progressWhileCoordinated(habbo, achievement, amount, 0);
+                return null;
+            });
+        } catch (SQLException | RuntimeException exception) {
+            LOGGER.error(
+                    "Unable to progress achievement {} for user {}",
+                    achievement.name,
+                    habbo.getHabboInfo().getId(),
+                    exception);
+        }
+    }
 
-        if (!habbo.isOnline()) return;
+    private static void progressWhileCoordinated(Habbo habbo, Achievement achievement, int amount, int queuedAmount)
+            throws SQLException {
+        int currentProgress = Math.max(0, habbo.getHabboStats().getAchievementProgress(achievement));
+        int newProgress = (int) Math.min(Integer.MAX_VALUE, (long) currentProgress + amount);
+        AchievementLevel oldLevel = achievement.getLevelForProgress(currentProgress);
 
-        if (habbo.getHabboStats().initAchievementProgressIfAbsent(achievement)) {
-            createUserEntry(habbo, achievement);
+        if (achievement.state == 0 || achievement.state == 2 || achievement.state == 3) return;
+        if (hasAchieved(habbo, achievement) || currentProgress == newProgress) {
+            if (queuedAmount > 0) {
+                try (Connection connection = openConnection()) {
+                    AchievementRewards.persist(
+                            connection,
+                            habbo.getHabboInfo().getId(),
+                            achievement,
+                            currentProgress,
+                            currentProgress,
+                            List.of(),
+                            List.of(),
+                            queuedAmount,
+                            habbo.getHabboStats().getAchievementScore());
+                }
+            }
+            return;
         }
 
-        int currentProgress = habbo.getHabboStats().getAchievementProgress(achievement);
+        var plugins = Emulator.getPluginManager();
+        if (plugins.isRegistered(UserAchievementProgressEvent.class, true)
+                && plugins.fireEvent(new UserAchievementProgressEvent(habbo, achievement, amount))
+                        .isCancelled()) return;
 
-        if (Emulator.getPluginManager().isRegistered(UserAchievementProgressEvent.class, true)) {
-            Event userAchievementProgressedEvent = new UserAchievementProgressEvent(habbo, achievement, amount);
-            Emulator.getPluginManager().fireEvent(userAchievementProgressedEvent);
-
-            if (userAchievementProgressedEvent.isCancelled()) return;
-        }
-
-        AchievementLevel currentLevel = achievement.getLevelForProgress(currentProgress);
-
-        if (currentLevel != null
-                && (currentLevel.level == achievement.levels.size()
-                        && currentProgress >= currentLevel.progress)) // Maximum achievement gotten.
-        return;
-
-        int newProgress = habbo.getHabboStats().incrementProgress(achievement, amount);
-
-        AchievementLevel oldLevel = achievement.getLevelForProgress(newProgress - amount);
         AchievementLevel newLevel = achievement.getLevelForProgress(newProgress);
+        List<AchievementLevel> earnedLevels = achievement.levels.values().stream()
+                .filter(level -> (oldLevel == null || level.level > oldLevel.level)
+                        && newLevel != null
+                        && level.level <= newLevel.level)
+                .sorted(java.util.Comparator.comparingInt(level -> level.level))
+                .toList();
 
-        if (AchievementManager.TALENTTRACK_ENABLED) {
-            for (TalentTrackType type : TalentTrackType.values()) {
-                if (Emulator.getGameEnvironment()
-                        .getAchievementManager()
-                        .talentTrackLevels
-                        .containsKey(type)) {
-                    for (Map.Entry<Integer, TalentTrackLevel> entry : Emulator.getGameEnvironment()
-                            .getAchievementManager()
-                            .talentTrackLevels
-                            .get(type)
-                            .entrySet()) {
-                        if (entry.getValue().achievements.containsKey(achievement)) {
-                            Emulator.getGameEnvironment()
-                                    .getAchievementManager()
-                                    .handleTalentTrackAchievement(habbo, type, achievement);
-                            break;
-                        }
-                    }
-                }
+        if (!earnedLevels.isEmpty()
+                && plugins.isRegistered(UserAchievementLeveledEvent.class, true)
+                && plugins.fireEvent(new UserAchievementLeveledEvent(habbo, achievement, oldLevel, newLevel))
+                        .isCancelled()) return;
+
+        int userId = habbo.getHabboInfo().getId();
+        List<EconomyOperation> rewards = new java.util.ArrayList<>();
+        for (AchievementLevel level : earnedLevels) {
+            if (level.rewardAmount <= 0) continue;
+
+            int currency = level.rewardType;
+            int reward;
+            if (currency == EconomyLedger.CREDITS) {
+                UserCreditsEvent event = new UserCreditsEvent(habbo, level.rewardAmount);
+                if (plugins.fireEvent(event).isCancelled()) continue;
+                reward = event.credits;
+            } else {
+                UserPointsEvent event = new UserPointsEvent(habbo, level.rewardAmount, currency);
+                if (plugins.fireEvent(event).isCancelled()) continue;
+                reward = event.points;
+                currency = event.type;
             }
+            if (reward == 0) continue;
+
+            rewards.add(new EconomyOperation(
+                    "achievement:" + userId + ":" + achievement.id + ":" + level.level,
+                    userId,
+                    userId,
+                    "achievement_reward",
+                    "achievement.level",
+                    currency,
+                    reward,
+                    null,
+                    achievement.name));
         }
 
-        if (newLevel == null
-                || (oldLevel != null
-                        && (oldLevel.level == newLevel.level && newLevel.level < achievement.levels.size()))) {
-            habbo.getClient().sendResponse(new AchievementProgressComposer(habbo, achievement));
-        } else {
-            if (Emulator.getPluginManager().isRegistered(UserAchievementLeveledEvent.class, true)) {
-                Event userAchievementLeveledEvent =
-                        new UserAchievementLeveledEvent(habbo, achievement, oldLevel, newLevel);
-                Emulator.getPluginManager().fireEvent(userAchievementLeveledEvent);
-
-                if (userAchievementLeveledEvent.isCancelled()) return;
+        AchievementRewards.Result result;
+        synchronized (habbo.getHabboStats()) {
+            try (Connection connection = openConnection()) {
+                result = AchievementRewards.persist(
+                        connection,
+                        userId,
+                        achievement,
+                        currentProgress,
+                        newProgress,
+                        earnedLevels,
+                        rewards,
+                        queuedAmount,
+                        habbo.getHabboStats().getAchievementScore());
             }
+            if (result.badge() != null) habbo.getHabboStats().achievementScore = result.score();
+        }
 
-            habbo.getClient().sendResponse(new AchievementProgressComposer(habbo, achievement));
-            habbo.getClient().sendResponse(new AchievementUnlockedComposer(habbo, achievement));
+        habbo.getHabboStats().setProgress(achievement, newProgress);
+        for (int index = 0; index < rewards.size(); index++) {
+            LedgerWalletMutation.applyCommitted(
+                    habbo,
+                    rewards.get(index).currencyType(),
+                    result.balances().get(index).balanceAfter());
+        }
+        for (EconomyOperation reward : rewards) {
+            if (reward.currencyType() == EconomyLedger.CREDITS)
+                habbo.getClient().sendResponse(new UserCreditsComposer(habbo));
+            else if (reward.currencyType() == 0) habbo.getClient().sendResponse(new UserCurrencyComposer(habbo));
+            else
+                habbo.getClient()
+                        .sendResponse(new UserPointsComposer(
+                                habbo.getHabboInfo().getCurrencyAmount(reward.currencyType()),
+                                reward.delta(),
+                                reward.currencyType()));
+        }
 
-            String newBadgeCode = "ACH_" + achievement.name + newLevel.level;
-
+        if (result.badge() != null) {
+            BadgesComponent badges = habbo.getInventory().getBadgesComponent();
             HabboBadge badge = null;
-
-            try {
-                BadgesComponent badgesComponent = habbo.getInventory().getBadgesComponent();
-
-                for (HabboBadge owned : badgesComponent.getBadgesSnapshot()) {
-                    if (!isAchievementBadge(owned.getCode(), achievement.name)) continue;
-
-                    if (badge == null) {
-                        badge = owned;
-                        continue;
-                    }
-
-                    if (badge.getSlot() == 0 && owned.getSlot() > 0) {
-                        badge.setSlot(owned.getSlot());
-                    }
-
-                    badgesComponent.removeBadge(owned);
-
-                    if (!owned.getCode().equalsIgnoreCase(badge.getCode())) {
-                        BadgesComponent.deleteBadge(habbo.getHabboInfo().getId(), owned.getCode());
-                    }
-                }
-            } catch (Exception e) {
-                LOGGER.error("Caught exception", e);
-                return;
+            for (HabboBadge owned : badges.getBadgesSnapshot()) {
+                if (!isAchievementBadge(owned.getCode(), achievement.name)) continue;
+                if (owned.getId() == result.badge().id()) badge = owned;
+                else badges.removeBadge(owned);
             }
-
-            if (badge != null) {
-                badge.setCode(newBadgeCode);
-                badge.needsInsert(false);
-                badge.needsUpdate(true);
-            } else {
-                badge = new HabboBadge(0, newBadgeCode, 0, habbo);
-                habbo.getClient().sendResponse(new AddUserBadgeComposer(badge));
-                badge.needsInsert(true);
-                badge.needsUpdate(true);
-                habbo.getInventory().getBadgesComponent().addBadge(badge);
+            if (badge == null) {
+                badge = new HabboBadge(
+                        result.badge().id(),
+                        result.badge().code(),
+                        result.badge().slot(),
+                        habbo);
+                badges.addBadge(badge);
             }
-
-            badge.run();
-
-            if (badge.getSlot() > 0) {
-                if (habbo.getHabboInfo().getCurrentRoom() != null) {
-                    habbo.getHabboInfo()
-                            .getCurrentRoom()
-                            .sendComposer(new UserBadgesComposer(
-                                            habbo.getInventory()
-                                                    .getBadgesComponent()
-                                                    .getWearingBadges(),
-                                            habbo.getHabboInfo().getId())
-                                    .compose());
-                }
-            }
-
+            badge.setCode(result.badge().code());
+            badge.setSlot(result.badge().slot());
+            badge.needsInsert(false);
+            badge.needsUpdate(false);
+            habbo.getClient().sendResponse(new AddUserBadgeComposer(badge));
             habbo.getClient()
                     .sendResponse(
                             new AddHabboItemComposer(badge.getId(), AddHabboItemComposer.AddHabboItemCategory.BADGE));
-
-            habbo.getHabboStats().addAchievementScore(newLevel.points);
-
-            if (newLevel.rewardAmount > 0) {
-                habbo.givePoints(newLevel.rewardType, newLevel.rewardAmount);
+            habbo.getClient().sendResponse(new UserAchievementScoreComposer(habbo));
+            for (AchievementLevel level : earnedLevels) {
+                habbo.getClient()
+                        .sendResponse(new AchievementUnlockedComposer(habbo, achievement, level, badge.getId()));
             }
 
             if (habbo.getHabboInfo().getCurrentRoom() != null) {
+                if (badge.getSlot() > 0) {
+                    habbo.getHabboInfo()
+                            .getCurrentRoom()
+                            .sendComposer(new UserBadgesComposer(badges.getWearingBadges(), userId).compose());
+                }
                 habbo.getHabboInfo().getCurrentRoom().sendComposer(new RoomUserDataComposer(habbo).compose());
             }
         }
+
+        habbo.getClient().sendResponse(new AchievementProgressComposer(habbo, achievement));
+        if (TALENTTRACK_ENABLED) {
+            AchievementManager manager = Emulator.getGameEnvironment().getAchievementManager();
+            for (TalentTrackType type : TalentTrackType.values()) {
+                if (manager.talentTrackLevels.containsKey(type))
+                    manager.handleTalentTrackAchievement(habbo, type, achievement);
+            }
+        }
+    }
+
+    public static void processQueuedAchievements(Habbo habbo) {
+        try {
+            LedgerWalletMutation.coordinated(habbo, () -> {
+                Map<Integer, Integer> queued = new LinkedHashMap<>();
+                try (Connection connection = openConnection();
+                        PreparedStatement statement = connection.prepareStatement(
+                                "SELECT achievement_id, amount FROM users_achievements_queue WHERE user_id = ? AND amount > 0")) {
+                    statement.setInt(1, habbo.getHabboInfo().getId());
+                    try (ResultSet result = statement.executeQuery()) {
+                        while (result.next()) queued.put(result.getInt("achievement_id"), result.getInt("amount"));
+                    }
+                }
+                AchievementManager manager = Emulator.getGameEnvironment().getAchievementManager();
+                for (Map.Entry<Integer, Integer> entry : queued.entrySet()) {
+                    Achievement achievement = manager.getAchievement(entry.getKey());
+                    if (achievement != null)
+                        progressWhileCoordinated(habbo, achievement, entry.getValue(), entry.getValue());
+                }
+                return null;
+            });
+        } catch (SQLException | RuntimeException exception) {
+            LOGGER.error(
+                    "Unable to apply queued achievements for user {}",
+                    habbo.getHabboInfo().getId(),
+                    exception);
+        }
+    }
+
+    private static Connection openConnection() throws SQLException {
+        return Emulator.getDatabase().getDataSource().getConnection();
     }
 
     /**
@@ -255,12 +333,12 @@ public class AchievementManager {
     }
 
     public static void createUserEntry(Habbo habbo, Achievement achievement) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+        try (Connection connection = openConnection();
                 PreparedStatement statement = connection.prepareStatement(
                         "INSERT INTO users_achievements (user_id, achievement_name, progress) VALUES (?, ?, ?)")) {
             statement.setInt(1, habbo.getHabboInfo().getId());
             statement.setString(2, achievement.name);
-            statement.setInt(3, 1);
+            statement.setInt(3, 0);
             statement.execute();
         } catch (SQLException e) {
             LOGGER.error("Caught SQL exception", e);
@@ -268,9 +346,9 @@ public class AchievementManager {
     }
 
     public static void saveAchievements(Habbo habbo) {
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+        try (Connection connection = openConnection();
                 PreparedStatement statement = connection.prepareStatement(
-                        "UPDATE users_achievements SET progress = ? WHERE achievement_name = ? AND user_id = ? LIMIT 1")) {
+                        "UPDATE users_achievements SET progress = GREATEST(progress, ?) WHERE achievement_name = ? AND user_id = ? LIMIT 1")) {
             statement.setInt(3, habbo.getHabboInfo().getId());
             for (Map.Entry<Achievement, Integer> map :
                     habbo.getHabboStats().getAchievementProgress().entrySet()) {
@@ -289,7 +367,7 @@ public class AchievementManager {
             return 0;
         }
 
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection();
+        try (Connection connection = openConnection();
                 PreparedStatement statement = connection.prepareStatement(
                         "SELECT progress FROM users_achievements WHERE user_id = ? AND achievement_name = ? LIMIT 1")) {
             statement.setInt(1, userId);
@@ -313,14 +391,15 @@ public class AchievementManager {
                 achievement.clearLevels();
             }
 
-            try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
+            try (Connection connection = openConnection()) {
                 try (Statement statement = connection.createStatement();
-                        ResultSet set = statement.executeQuery("SELECT * FROM achievements")) {
+                        ResultSet set = statement.executeQuery("SELECT * FROM achievements ORDER BY name, level")) {
                     while (set.next()) {
                         if (!this.achievements.containsKey(set.getString("name"))) {
                             this.achievements.put(set.getString("name"), new Achievement(set));
                         } else {
                             this.achievements.get(set.getString("name")).addLevel(new AchievementLevel(set));
+                            this.achievements.get(set.getString("name")).loadMetadata(set);
                         }
                     }
                 } catch (SQLException e) {
@@ -388,8 +467,11 @@ public class AchievementManager {
             final boolean[] allCompleted = {true};
             for (Map.Entry<Achievement, Integer> achievementEntry :
                     entry.getValue().achievements.entrySet()) {
-                if (habbo.getHabboStats().getAchievementProgress(achievementEntry.getKey())
-                        < achievementEntry.getValue()) {
+                AchievementLevel requiredLevel =
+                        achievementEntry.getKey().levels.get(achievementEntry.getValue());
+                if (requiredLevel == null
+                        || habbo.getHabboStats().getAchievementProgress(achievementEntry.getKey())
+                                < requiredLevel.progress) {
                     allCompleted[0] = false;
                     break;
                 }
@@ -408,55 +490,79 @@ public class AchievementManager {
     }
 
     public void handleTalentTrackAchievement(Habbo habbo, TalentTrackType type, Achievement achievement) {
-        TalentTrackLevel currentLevel = this.calculateTalenTrackLevel(habbo, type);
+        try {
+            LedgerWalletMutation.coordinated(habbo, () -> {
+                synchronized (habbo.getHabboStats()) {
+                    TalentTrackLevel currentLevel = this.calculateTalenTrackLevel(habbo, type);
+                    int previousLevel = habbo.getHabboStats().talentTrackLevel(type);
+                    if (currentLevel == null || currentLevel.level <= previousLevel) return null;
 
-        if (currentLevel != null) {
-            if (currentLevel.level > habbo.getHabboStats().talentTrackLevel(type)) {
-                for (int i = habbo.getHabboStats().talentTrackLevel(type); i <= currentLevel.level; i++) {
-                    TalentTrackLevel level = this.getTalentTrackLevel(type, i);
-
-                    if (level != null) {
-                        if (level.items != null && !level.items.isEmpty()) {
-                            for (Item item : level.items) {
-                                HabboItem rewardItem = Emulator.getGameEnvironment()
-                                        .getItemManager()
-                                        .createItem(habbo.getHabboInfo().getId(), item, 0, 0, "");
-                                habbo.getInventory().getItemsComponent().addItem(rewardItem);
-                                habbo.getClient().sendResponse(new AddHabboItemComposer(rewardItem));
-                                habbo.getClient().sendResponse(new InventoryRefreshComposer());
-                            }
-                        }
-
-                        if (level.badges != null && level.badges.length > 0) {
-                            for (String badge : level.badges) {
-                                if (!badge.isEmpty()) {
-                                    if (!habbo.getInventory()
-                                            .getBadgesComponent()
-                                            .hasBadge(badge)) {
-                                        HabboBadge b = new HabboBadge(0, badge, 0, habbo);
-                                        Emulator.getThreading().run(b);
-                                        habbo.getInventory()
-                                                .getBadgesComponent()
-                                                .addBadge(b);
-                                        habbo.getClient().sendResponse(new AddUserBadgeComposer(b));
-                                    }
-                                }
-                            }
-                        }
-
-                        if (level.perks != null && level.perks.length > 0) {
-                            for (String perk : level.perks) {
-                                if (perk.equalsIgnoreCase("TRADE")) {
-                                    habbo.getHabboStats().perkTrade = true;
-                                }
-                            }
-                        }
-                        habbo.getClient().sendResponse(new TalentLevelUpdateComposer(type, level));
+                    List<TalentTrackLevel> earnedLevels = this.talentTrackLevels.get(type).values().stream()
+                            .filter(level -> level.level > previousLevel && level.level <= currentLevel.level)
+                            .sorted(java.util.Comparator.comparingInt(level -> level.level))
+                            .toList();
+                    int clubSeconds = CatalogPurchaseMath.checkedSubscriptionSeconds(earnedLevels.stream()
+                            .mapToInt(level -> level.hcDays)
+                            .reduce(0, Math::addExact));
+                    if (clubSeconds > 0) {
+                        Subscription subscription = habbo.getHabboStats().getSubscription(Subscription.HABBO_CLUB);
+                        Event event = subscription == null
+                                ? new UserSubscriptionCreatedEvent(
+                                        habbo.getHabboInfo().getId(), Subscription.HABBO_CLUB, clubSeconds)
+                                : new UserSubscriptionExtendedEvent(
+                                        habbo.getHabboInfo().getId(), subscription, clubSeconds);
+                        if (Emulator.getPluginManager().fireEvent(event).isCancelled()) return null;
                     }
+                    var environment = Emulator.getGameEnvironment();
+                    TalentTrackRewards.Result result;
+                    try (Connection connection = openConnection()) {
+                        result = TalentTrackRewards.persist(
+                                connection,
+                                habbo,
+                                environment.getItemManager(),
+                                environment.getSubscriptionManager(),
+                                type,
+                                previousLevel,
+                                currentLevel.level,
+                                earnedLevels,
+                                Math.toIntExact(java.time.Instant.now().getEpochSecond()));
+                    }
+                    habbo.getHabboStats().setTalentLevel(type, currentLevel.level);
+                    if (result.trade()) habbo.getHabboStats().perkTrade = true;
+                    if (result.subscription() != null) {
+                        Subscription subscription = habbo.getHabboStats().subscriptions.stream()
+                                .filter(owned -> owned.getSubscriptionId()
+                                        == result.subscription().getSubscriptionId())
+                                .findFirst()
+                                .orElse(null);
+                        if (subscription != null) {
+                            subscription.applyPersistedDuration(
+                                    result.subscription().getDuration());
+                            subscription.onExtended(result.clubSeconds());
+                        } else {
+                            habbo.getHabboStats().subscriptions.add(result.subscription());
+                            result.subscription().onCreated();
+                        }
+                    }
+                    for (HabboItem item : result.items()) {
+                        habbo.getInventory().getItemsComponent().addItem(item);
+                        habbo.getClient().sendResponse(new AddHabboItemComposer(item));
+                    }
+                    if (!result.items().isEmpty()) habbo.getClient().sendResponse(new InventoryRefreshComposer());
+                    for (HabboBadge badge : result.badges()) {
+                        habbo.getInventory().getBadgesComponent().addBadge(badge);
+                        habbo.getClient().sendResponse(new AddUserBadgeComposer(badge));
+                    }
+                    for (TalentTrackLevel level : earnedLevels)
+                        habbo.getClient().sendResponse(new TalentLevelUpdateComposer(type, level));
                 }
-            }
-
-            habbo.getHabboStats().setTalentLevel(type, currentLevel.level);
+                return null;
+            });
+        } catch (SQLException | RuntimeException exception) {
+            LOGGER.error(
+                    "Unable to grant talent rewards for user {}",
+                    habbo.getHabboInfo().getId(),
+                    exception);
         }
     }
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementRewards.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/AchievementRewards.java
@@ -1,0 +1,167 @@
+package com.eu.habbo.habbohotel.achievements;
+
+import com.eu.habbo.habbohotel.economy.EconomyLedger;
+import com.eu.habbo.habbohotel.economy.EconomyMutationResult;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Persists one achievement transition together with its badge, score and wallet rewards. */
+final class AchievementRewards {
+    private AchievementRewards() {}
+
+    static Result persist(
+            Connection connection,
+            int userId,
+            Achievement achievement,
+            int previousProgress,
+            int progress,
+            List<AchievementLevel> earnedLevels,
+            List<EconomyOperation> rewards,
+            int queuedAmount,
+            int currentScore)
+            throws SQLException {
+        connection.setAutoCommit(false);
+
+        try {
+            // Use the same lock order as the wallet ledger, including transitions without currency.
+            try (PreparedStatement statement =
+                    connection.prepareStatement("SELECT id FROM users WHERE id = ? FOR UPDATE")) {
+                statement.setInt(1, userId);
+                try (ResultSet result = statement.executeQuery()) {
+                    if (!result.next()) throw new SQLException("Unknown achievement user " + userId);
+                }
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT IGNORE INTO users_achievements (user_id, achievement_name, progress) VALUES (?, ?, 0)")) {
+                statement.setInt(1, userId);
+                statement.setString(2, achievement.name);
+                statement.executeUpdate();
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "UPDATE users_achievements SET progress = ? WHERE user_id = ? AND achievement_name = ? AND progress = ?")) {
+                statement.setInt(1, progress);
+                statement.setInt(2, userId);
+                statement.setString(3, achievement.name);
+                statement.setInt(4, previousProgress);
+                if (statement.executeUpdate() != 1) throw new SQLException("Achievement progress changed concurrently");
+            }
+
+            List<EconomyMutationResult> balances =
+                    rewards.isEmpty() ? List.of() : EconomyLedger.applyBatch(connection, rewards);
+            int score = 0;
+            Badge badge = null;
+
+            if (!earnedLevels.isEmpty()) {
+                int points =
+                        earnedLevels.stream().mapToInt(level -> level.points).reduce(0, Math::addExact);
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE users_settings SET achievement_score = GREATEST(achievement_score, ?) + ? WHERE user_id = ?")) {
+                    statement.setInt(1, currentScore);
+                    statement.setInt(2, points);
+                    statement.setInt(3, userId);
+                    if (statement.executeUpdate() != 1) throw new SQLException("Missing achievement user settings");
+                }
+
+                try (PreparedStatement statement =
+                        connection.prepareStatement("SELECT achievement_score FROM users_settings WHERE user_id = ?")) {
+                    statement.setInt(1, userId);
+                    try (ResultSet result = statement.executeQuery()) {
+                        result.next();
+                        score = result.getInt(1);
+                    }
+                }
+
+                badge = replaceBadge(connection, userId, achievement, earnedLevels.getLast().level);
+            }
+
+            if (queuedAmount > 0) {
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "UPDATE users_achievements_queue SET amount = GREATEST(0, amount - ?) WHERE user_id = ? AND achievement_id = ?")) {
+                    statement.setInt(1, queuedAmount);
+                    statement.setInt(2, userId);
+                    statement.setInt(3, achievement.id);
+                    statement.executeUpdate();
+                }
+            }
+
+            connection.commit();
+            return new Result(score, badge, balances);
+        } catch (SQLException | RuntimeException exception) {
+            try {
+                connection.rollback();
+            } catch (SQLException rollbackException) {
+                exception.addSuppressed(rollbackException);
+            }
+            throw exception;
+        }
+    }
+
+    private static Badge replaceBadge(Connection connection, int userId, Achievement achievement, int level)
+            throws SQLException {
+        int badgeId = 0;
+        int slot = 0;
+        List<Integer> obsoleteBadges = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT id, badge_code, slot_id FROM users_badges WHERE user_id = ? ORDER BY id FOR UPDATE")) {
+            statement.setInt(1, userId);
+            try (ResultSet result = statement.executeQuery()) {
+                while (result.next()) {
+                    if (!AchievementManager.isAchievementBadge(result.getString("badge_code"), achievement.name))
+                        continue;
+                    if (badgeId == 0) badgeId = result.getInt("id");
+                    else obsoleteBadges.add(result.getInt("id"));
+                    if (slot == 0) slot = result.getInt("slot_id");
+                }
+            }
+        }
+
+        String badgeCode = "ACH_" + achievement.name + level;
+        try (PreparedStatement statement =
+                connection.prepareStatement("DELETE FROM users_badges WHERE id = ? AND user_id = ?")) {
+            statement.setInt(2, userId);
+            for (int obsoleteBadge : obsoleteBadges) {
+                statement.setInt(1, obsoleteBadge);
+                statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+
+        if (badgeId > 0) {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "UPDATE users_badges SET badge_code = ?, slot_id = ? WHERE id = ? AND user_id = ?")) {
+                statement.setString(1, badgeCode);
+                statement.setInt(2, slot);
+                statement.setInt(3, badgeId);
+                statement.setInt(4, userId);
+                statement.executeUpdate();
+            }
+        } else {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO users_badges (user_id, badge_code, slot_id) VALUES (?, ?, ?)",
+                    Statement.RETURN_GENERATED_KEYS)) {
+                statement.setInt(1, userId);
+                statement.setString(2, badgeCode);
+                statement.setInt(3, slot);
+                statement.executeUpdate();
+                try (ResultSet result = statement.getGeneratedKeys()) {
+                    if (!result.next()) throw new SQLException("Missing achievement badge ID");
+                    badgeId = result.getInt(1);
+                }
+            }
+        }
+
+        return new Badge(badgeId, badgeCode, slot);
+    }
+
+    record Badge(int id, String code, int slot) {}
+
+    record Result(int score, Badge badge, List<EconomyMutationResult> balances) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/TalentTrackLevel.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/TalentTrackLevel.java
@@ -2,15 +2,14 @@ package com.eu.habbo.habbohotel.achievements;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.items.Item;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TalentTrackLevel {
     private static final Logger LOGGER = LoggerFactory.getLogger(TalentTrackLevel.class);
@@ -21,10 +20,16 @@ public class TalentTrackLevel {
     public Set<Item> items;
     public String[] perks;
     public String[] badges;
+    public int hcDays;
 
     public TalentTrackLevel(ResultSet set) throws SQLException {
         this.type = TalentTrackType.valueOf(set.getString("type").toUpperCase());
         this.level = set.getInt("level");
+        try {
+            this.hcDays = set.getInt("reward_hc_days");
+        } catch (SQLException missingMetadata) {
+            this.hcDays = 0;
+        }
         this.achievements = new HashMap<>();
         this.items = new HashSet<>();
 
@@ -32,21 +37,27 @@ public class TalentTrackLevel {
         String[] achievementLevels = set.getString("achievement_levels").split(",");
         if (achievementLevels.length == achievements.length) {
             for (int i = 0; i < achievements.length; i++) {
-                if (achievements[i].isEmpty() || achievementLevels[i].isEmpty())
-                    continue;
+                if (achievements[i].isEmpty() || achievementLevels[i].isEmpty()) continue;
 
-                Achievement achievement = Emulator.getGameEnvironment().getAchievementManager().getAchievement(Integer.parseInt(achievements[i]));
+                Achievement achievement = Emulator.getGameEnvironment()
+                        .getAchievementManager()
+                        .getAchievement(Integer.parseInt(achievements[i]));
 
                 if (achievement != null) {
                     this.achievements.put(achievement, Integer.parseInt(achievementLevels[i]));
                 } else {
-                    LOGGER.error("Could not find achievement with ID {} for talenttrack level {} of type {}", achievements[i], this.level, this.type);
+                    LOGGER.error(
+                            "Could not find achievement with ID {} for talenttrack level {} of type {}",
+                            achievements[i],
+                            this.level,
+                            this.type);
                 }
             }
         }
 
         for (String s : set.getString("reward_furni").split(",")) {
-            Item item = Emulator.getGameEnvironment().getItemManager().getItem(Integer.parseInt(s));
+            if (s.isBlank()) continue;
+            Item item = Emulator.getGameEnvironment().getItemManager().getItem(Integer.parseInt(s.trim()));
 
             if (item != null) {
                 this.items.add(item);

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/TalentTrackRewards.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/achievements/TalentTrackRewards.java
@@ -1,0 +1,147 @@
+package com.eu.habbo.habbohotel.achievements;
+
+import com.eu.habbo.habbohotel.catalog.CatalogPurchaseMath;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.items.ItemManager;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboBadge;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionManager;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+final class TalentTrackRewards {
+    private TalentTrackRewards() {}
+
+    static Result persist(
+            Connection connection,
+            Habbo habbo,
+            ItemManager itemManager,
+            SubscriptionManager subscriptionManager,
+            TalentTrackType type,
+            int previousLevel,
+            int nextLevel,
+            List<TalentTrackLevel> levels,
+            int timestamp)
+            throws SQLException {
+        int userId = habbo.getHabboInfo().getId();
+        String levelColumn =
+                type == TalentTrackType.CITIZENSHIP ? "talent_track_citizenship_level" : "talent_track_helpers_level";
+        List<HabboItem> items = new ArrayList<>();
+        List<HabboBadge> badges = new ArrayList<>();
+        boolean trade = levels.stream()
+                .anyMatch(level -> level.perks != null
+                        && java.util.Arrays.stream(level.perks).anyMatch("TRADE"::equalsIgnoreCase));
+        int clubSeconds = CatalogPurchaseMath.checkedSubscriptionSeconds(
+                levels.stream().mapToInt(level -> level.hcDays).reduce(0, Math::addExact));
+        connection.setAutoCommit(false);
+        try {
+            try (PreparedStatement statement = connection.prepareStatement("UPDATE users_settings SET " + levelColumn
+                    + " = ?, perk_trade = IF(?, '1', perk_trade) WHERE user_id = ? AND " + levelColumn + " = ?")) {
+                statement.setInt(1, nextLevel);
+                statement.setBoolean(2, trade);
+                statement.setInt(3, userId);
+                statement.setInt(4, previousLevel);
+                if (statement.executeUpdate() != 1) throw new SQLException("Talent milestone changed concurrently");
+            }
+            Subscription subscription =
+                    clubSeconds > 0 ? grantClub(connection, subscriptionManager, userId, clubSeconds, timestamp) : null;
+            for (TalentTrackLevel level : levels) {
+                for (Item item : level.items) {
+                    HabboItem reward = itemManager.createItem(connection, userId, item, 0, 0, "");
+                    if (reward == null) throw new SQLException("Unable to create talent reward " + item.getName());
+                    items.add(reward);
+                }
+                if (level.badges == null) continue;
+                for (String code : level.badges) {
+                    if (code.isBlank()) continue;
+                    try (PreparedStatement statement = connection.prepareStatement(
+                            "SELECT id FROM users_badges WHERE user_id = ? AND badge_code = ?")) {
+                        statement.setInt(1, userId);
+                        statement.setString(2, code);
+                        try (ResultSet result = statement.executeQuery()) {
+                            if (result.next()) continue;
+                        }
+                    }
+                    HabboBadge badge = new HabboBadge(0, code, 0, habbo);
+                    badge.insert(connection);
+                    badges.add(badge);
+                }
+            }
+            connection.commit();
+            return new Result(items, badges, trade, subscription, clubSeconds);
+        } catch (SQLException | RuntimeException exception) {
+            try {
+                connection.rollback();
+            } catch (SQLException rollbackException) {
+                exception.addSuppressed(rollbackException);
+            }
+            throw exception;
+        }
+    }
+
+    private static Subscription grantClub(
+            Connection connection, SubscriptionManager manager, int userId, int seconds, int timestamp)
+            throws SQLException {
+        int id = 0;
+        int start = timestamp;
+        int duration = seconds;
+        try (PreparedStatement statement = connection.prepareStatement(
+                "SELECT id, timestamp_start, duration FROM users_subscriptions WHERE user_id = ? AND subscription_type = ? AND active = 1 AND timestamp_start + duration > ? ORDER BY id DESC LIMIT 1 FOR UPDATE")) {
+            statement.setInt(1, userId);
+            statement.setString(2, Subscription.HABBO_CLUB);
+            statement.setInt(3, timestamp);
+            try (ResultSet result = statement.executeQuery()) {
+                if (result.next()) {
+                    id = result.getInt("id");
+                    start = result.getInt("timestamp_start");
+                    duration = CatalogPurchaseMath.checkedAdd(result.getInt("duration"), seconds);
+                }
+            }
+        }
+        Math.addExact(start, duration);
+        if (id > 0) {
+            try (PreparedStatement statement =
+                    connection.prepareStatement("UPDATE users_subscriptions SET duration = ? WHERE id = ?")) {
+                statement.setInt(1, duration);
+                statement.setInt(2, id);
+                statement.executeUpdate();
+            }
+        } else {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "INSERT INTO users_subscriptions (user_id,subscription_type,timestamp_start,duration,active) VALUES (?,?,?,?,1)",
+                    Statement.RETURN_GENERATED_KEYS)) {
+                statement.setInt(1, userId);
+                statement.setString(2, Subscription.HABBO_CLUB);
+                statement.setInt(3, start);
+                statement.setInt(4, duration);
+                statement.executeUpdate();
+                try (ResultSet result = statement.getGeneratedKeys()) {
+                    if (!result.next()) throw new SQLException("Missing talent subscription ID");
+                    id = result.getInt(1);
+                }
+            }
+        }
+        try {
+            return manager.getSubscriptionClass(Subscription.HABBO_CLUB)
+                    .getConstructor(
+                            Integer.class, Integer.class, String.class, Integer.class, Integer.class, Boolean.class)
+                    .newInstance(id, userId, Subscription.HABBO_CLUB, start, duration, true);
+        } catch (ReflectiveOperationException exception) {
+            throw new SQLException("Unable to construct talent subscription", exception);
+        }
+    }
+
+    record Result(
+            List<HabboItem> items,
+            List<HabboBadge> badges,
+            boolean trade,
+            Subscription subscription,
+            int clubSeconds) {}
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/SubscriptionCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/SubscriptionCommand.java
@@ -3,6 +3,7 @@ package com.eu.habbo.habbohotel.commands;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
+import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboInfo;
 import com.eu.habbo.habbohotel.users.HabboManager;
 import com.eu.habbo.habbohotel.users.HabboStats;
@@ -13,7 +14,9 @@ import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
  */
 public class SubscriptionCommand extends Command {
     public SubscriptionCommand() {
-        super("cmd_subscription", Emulator.getTexts().getValue("commands.keys.cmd_subscription").split(";"));
+        super(
+                "cmd_subscription",
+                Emulator.getTexts().getValue("commands.keys.cmd_subscription").split(";"));
     }
 
     /**
@@ -39,7 +42,9 @@ public class SubscriptionCommand extends Command {
     @Override
     public boolean handle(GameClient gameClient, String[] params) throws Exception {
         if (params.length >= 4) {
-            HabboInfo info = HabboManager.getOfflineHabboInfo(params[1]);
+            var environment = Emulator.getGameEnvironment();
+            Habbo online = environment.getHabboManager().getHabbo(params[1]);
+            HabboInfo info = online != null ? online.getHabboInfo() : HabboManager.getOfflineHabboInfo(params[1]);
 
             if (info != null) {
                 HabboStats stats = info.getHabboStats();
@@ -52,56 +57,132 @@ public class SubscriptionCommand extends Command {
                         message.append(params[i]).append(" ");
                     }
                 }
-                
-                if(!Emulator.getGameEnvironment().getSubscriptionManager().types.containsKey(subscription)) {
-                    gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.type_not_found", "%subscription% is not a valid subscription type").replace("%subscription%", subscription), RoomChatMessageBubbles.ALERT);
+
+                if (!environment.getSubscriptionManager().types.containsKey(subscription)) {
+                    gameClient
+                            .getHabbo()
+                            .whisper(
+                                    Emulator.getTexts()
+                                            .getValue(
+                                                    "commands.error.cmd_subscription.type_not_found",
+                                                    "%subscription% is not a valid subscription type")
+                                            .replace("%subscription%", subscription),
+                                    RoomChatMessageBubbles.ALERT);
                     return true;
                 }
 
-                if(action.equalsIgnoreCase("add") || action.equalsIgnoreCase("+") || action.equalsIgnoreCase("a")) {
+                if (action.equalsIgnoreCase("add") || action.equalsIgnoreCase("+") || action.equalsIgnoreCase("a")) {
                     int timeToAdd = Emulator.timeStringToSeconds(message.toString());
 
-                    if(timeToAdd < 1) {
-                        gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.invalid_params_time", "Invalid time span, try: x minutes/days/weeks/months"), RoomChatMessageBubbles.ALERT);
+                    if (timeToAdd < 1) {
+                        gameClient
+                                .getHabbo()
+                                .whisper(
+                                        Emulator.getTexts()
+                                                .getValue(
+                                                        "commands.error.cmd_subscription.invalid_params_time",
+                                                        "Invalid time span, try: x minutes/days/weeks/months"),
+                                        RoomChatMessageBubbles.ALERT);
                         return true;
                     }
 
                     stats.createSubscription(subscription, timeToAdd);
-                    gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.success_add_time", "Successfully added %time% seconds to %subscription% on %user%").replace("%time%", timeToAdd + "").replace("%user%", params[1]).replace("%subscription%", subscription), RoomChatMessageBubbles.ALERT);
-                }
-                else if(action.equalsIgnoreCase("remove") || action.equalsIgnoreCase("-") || action.equalsIgnoreCase("r")) {
-                    Subscription s = stats.getSubscription(subscription);
+                    gameClient
+                            .getHabbo()
+                            .whisper(
+                                    Emulator.getTexts()
+                                            .getValue(
+                                                    "commands.error.cmd_subscription.success_add_time",
+                                                    "Successfully added %time% seconds to %subscription% on %user%")
+                                            .replace("%time%", timeToAdd + "")
+                                            .replace("%user%", params[1])
+                                            .replace("%subscription%", subscription),
+                                    RoomChatMessageBubbles.ALERT);
+                } else if (action.equalsIgnoreCase("remove")
+                        || action.equalsIgnoreCase("-")
+                        || action.equalsIgnoreCase("r")) {
+                    int timeToRemove = message.isEmpty() ? -1 : Emulator.timeStringToSeconds(message.toString());
+                    if (!message.isEmpty() && timeToRemove < 1) {
+                        gameClient
+                                .getHabbo()
+                                .whisper(
+                                        Emulator.getTexts()
+                                                .getValue(
+                                                        "commands.error.cmd_subscription.invalid_params_time",
+                                                        "Invalid time span, try: x minutes/days/weeks/months"),
+                                        RoomChatMessageBubbles.ALERT);
+                        return true;
+                    }
+                    Subscription s = stats.removeSubscription(subscription, timeToRemove);
 
                     if (s == null) {
-                        gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.user_not_have", "%user% does not have the %subscription% subscription").replace("%user%", params[1]).replace("%subscription%", subscription), RoomChatMessageBubbles.ALERT);
+                        gameClient
+                                .getHabbo()
+                                .whisper(
+                                        Emulator.getTexts()
+                                                .getValue(
+                                                        "commands.error.cmd_subscription.user_not_have",
+                                                        "%user% does not have the %subscription% subscription")
+                                                .replace("%user%", params[1])
+                                                .replace("%subscription%", subscription),
+                                        RoomChatMessageBubbles.ALERT);
                         return true;
                     }
 
-                    if(message.length() != 0) {
-                        int timeToRemove = Emulator.timeStringToSeconds(message.toString());
-
-                        if (timeToRemove < 1) {
-                            gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.invalid_params_time", "Invalid time span, try: x minutes/days/weeks/months"), RoomChatMessageBubbles.ALERT);
-                            return true;
-                        }
-
-                        s.addDuration(-timeToRemove);
-                        gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.success_remove_time", "Successfully removed %time% seconds from %subscription% on %user%").replace("%time%", timeToRemove + "").replace("%user%", params[1]).replace("%subscription%", subscription), RoomChatMessageBubbles.ALERT);
+                    if (message.length() != 0) {
+                        gameClient
+                                .getHabbo()
+                                .whisper(
+                                        Emulator.getTexts()
+                                                .getValue(
+                                                        "commands.error.cmd_subscription.success_remove_time",
+                                                        "Successfully removed %time% seconds from %subscription% on %user%")
+                                                .replace("%time%", timeToRemove + "")
+                                                .replace("%user%", params[1])
+                                                .replace("%subscription%", subscription),
+                                        RoomChatMessageBubbles.ALERT);
+                    } else {
+                        gameClient
+                                .getHabbo()
+                                .whisper(
+                                        Emulator.getTexts()
+                                                .getValue(
+                                                        "commands.error.cmd_subscription.success_remove_sub",
+                                                        "Successfully removed %subscription% sub from %user%")
+                                                .replace("%user%", params[1])
+                                                .replace("%subscription%", subscription),
+                                        RoomChatMessageBubbles.ALERT);
                     }
-                    else {
-                        s.addDuration(-s.getRemaining());
-                        gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.success_remove_sub", "Successfully removed %subscription% sub from %user%").replace("%user%", params[1]).replace("%subscription%", subscription), RoomChatMessageBubbles.ALERT);
-                    }
-                }
-                else {
-                    gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.invalid_action", "Invalid action specified. Must be add, +, remove or -"), RoomChatMessageBubbles.ALERT);
+                } else {
+                    gameClient
+                            .getHabbo()
+                            .whisper(
+                                    Emulator.getTexts()
+                                            .getValue(
+                                                    "commands.error.cmd_subscription.invalid_action",
+                                                    "Invalid action specified. Must be add, +, remove or -"),
+                                    RoomChatMessageBubbles.ALERT);
                 }
 
             } else {
-                gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.user_not_found", "%user% was not found").replace("%user%", params[1]), RoomChatMessageBubbles.ALERT);
+                gameClient
+                        .getHabbo()
+                        .whisper(
+                                Emulator.getTexts()
+                                        .getValue(
+                                                "commands.error.cmd_subscription.user_not_found",
+                                                "%user% was not found")
+                                        .replace("%user%", params[1]),
+                                RoomChatMessageBubbles.ALERT);
             }
         } else {
-            gameClient.getHabbo().whisper(Emulator.getTexts().getValue("commands.error.cmd_subscription.invalid_params", "Invalid command format"), RoomChatMessageBubbles.ALERT);
+            gameClient
+                    .getHabbo()
+                    .whisper(
+                            Emulator.getTexts()
+                                    .getValue(
+                                            "commands.error.cmd_subscription.invalid_params", "Invalid command format"),
+                            RoomChatMessageBubbles.ALERT);
         }
         return true;
     }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveAchievement.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/items/interactions/wired/effects/WiredEffectGiveAchievement.java
@@ -14,6 +14,7 @@ import com.eu.habbo.habbohotel.wired.core.WiredContext;
 import com.eu.habbo.habbohotel.wired.core.WiredManager;
 import com.eu.habbo.habbohotel.wired.core.WiredSourceUtil;
 import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.wired.WiredEnvironmentComposer;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -80,7 +81,25 @@ public class WiredEffectGiveAchievement extends InteractionWiredEffect {
 
         this.setDelay(settings.getDelay());
 
+        Room room = gameClient.getHabbo().getHabboInfo().getCurrentRoom();
+        if (room != null) room.sendComposer(new WiredEnvironmentComposer(room).compose());
         return true;
+    }
+
+    public String getAchievementCode() {
+        return this.achievement;
+    }
+
+    @Override
+    public void onPlace(Room room) {
+        super.onPlace(room);
+        room.sendComposer(new WiredEnvironmentComposer(room).compose());
+    }
+
+    @Override
+    public void onPickUp(Room room) {
+        super.onPickUp(room);
+        room.sendComposer(new WiredEnvironmentComposer(room).compose());
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -785,6 +785,7 @@ public class RoomManager {
         room.refreshRightsForHabbo(habbo);
 
         habbo.getClient().sendResponse(new RoomScoreComposer(room.getScore(), !this.hasVotedForRoom(habbo, room)));
+        habbo.getClient().sendResponse(new com.eu.habbo.messages.outgoing.wired.WiredEnvironmentComposer(room));
 
         habbo.getRoomUnit()
                 .setFastWalk(

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/HabboStats.java
@@ -48,6 +48,8 @@ public class HabboStats implements Runnable {
     public final ArrayList<CalendarRewardClaimed> calendarRewardsClaimed;
     public final Int2ObjectMap<HabboOfferPurchase> offerCache = new Int2ObjectOpenHashMap<>();
     private final AtomicInteger lastOnlineTime = new AtomicInteger(Emulator.getIntUnixTimestamp());
+    private final int sessionStartedAt = this.lastOnlineTime.get();
+    private final int previousOnlineTime;
     private final Map<Achievement, Integer> achievementProgress;
     private final Map<Achievement, Integer> achievementCache;
     private static final int RECENT_PURCHASES_LIMIT = 50; // Here you can set the limit of recent items bought
@@ -142,6 +144,7 @@ public class HabboStats implements Runnable {
 
         this.habboInfo = habboInfo;
 
+        this.previousOnlineTime = set.getInt("online_time");
         this.achievementScore = set.getInt("achievement_score");
         this.respectPointsReceived = set.getInt("respects_received");
         this.respectPointsGiven = set.getInt("respects_given");
@@ -416,14 +419,13 @@ public class HabboStats implements Runnable {
     }
 
     @Override
-    public void run() {
-        // Find difference between last sync and update with a new timestamp.
-        int onlineTimeLast = this.lastOnlineTime.getAndUpdate(operand -> Emulator.getIntUnixTimestamp());
-        int onlineTime = Emulator.getIntUnixTimestamp() - onlineTimeLast;
+    public synchronized void run() {
+        int timestamp = Emulator.getIntUnixTimestamp();
+        int onlineTime = Math.max(0, timestamp - this.lastOnlineTime.get());
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(
-                    "UPDATE users_settings SET achievement_score = ?, respects_received = ?, respects_given = ?, daily_respect_points = ?, block_following = ?, block_friendrequests = ?, online_time = online_time + ?, guild_id = ?, daily_pet_respect_points = ?, club_expire_timestamp = ?, login_streak = ?, rent_space_id = ?, rent_space_endtime = ?, volume_system = ?, volume_furni = ?, volume_trax = ?, block_roominvites = ?, old_chat = ?, block_camera_follow = ?, chat_color = ?, hof_points = ?, block_alerts = ?, talent_track_citizenship_level = ?, talent_track_helpers_level = ?, ignore_bots = ?, ignore_pets = ?, nux = ?, mute_end_timestamp = ?, allow_name_change = ?, perk_trade = ?, can_trade = ?, `forums_post_count` = ?, ui_flags = ?, has_gotten_default_saved_searches = ?, max_friends = ?, max_rooms = ?, last_hc_payday = ?, hc_gifts_claimed = ?, builders_club_bonus_furni = ?, hide_online = ?, volume_soundboard = ? WHERE user_id = ? LIMIT 1")) {
+                    "UPDATE users_settings SET achievement_score = GREATEST(achievement_score, ?), respects_received = ?, respects_given = ?, daily_respect_points = ?, block_following = ?, block_friendrequests = ?, online_time = online_time + ?, guild_id = ?, daily_pet_respect_points = ?, club_expire_timestamp = ?, login_streak = ?, rent_space_id = ?, rent_space_endtime = ?, volume_system = ?, volume_furni = ?, volume_trax = ?, block_roominvites = ?, old_chat = ?, block_camera_follow = ?, chat_color = ?, hof_points = ?, block_alerts = ?, talent_track_citizenship_level = GREATEST(talent_track_citizenship_level, ?), talent_track_helpers_level = GREATEST(talent_track_helpers_level, ?), ignore_bots = ?, ignore_pets = ?, nux = ?, mute_end_timestamp = ?, allow_name_change = ?, perk_trade = ?, can_trade = ?, `forums_post_count` = ?, ui_flags = ?, has_gotten_default_saved_searches = ?, max_friends = ?, max_rooms = ?, last_hc_payday = ?, hc_gifts_claimed = ?, builders_club_bonus_furni = ?, hide_online = ?, volume_soundboard = ? WHERE user_id = ? LIMIT 1")) {
                 statement.setInt(1, this.achievementScore);
                 statement.setInt(2, this.respectPointsReceived);
                 statement.setInt(3, this.respectPointsGiven);
@@ -468,6 +470,7 @@ public class HabboStats implements Runnable {
                 statement.setInt(42, this.habboInfo.getId());
 
                 statement.executeUpdate();
+                this.lastOnlineTime.set(timestamp);
             }
 
             try (PreparedStatement statement = connection.prepareStatement(
@@ -527,11 +530,17 @@ public class HabboStats implements Runnable {
         return false;
     }
 
-    public int getAchievementScore() {
+    public int getOnlineMinutes(int timestamp) {
+        return (int) Math.min(
+                Integer.MAX_VALUE,
+                ((long) this.previousOnlineTime + Math.max(0, timestamp - this.sessionStartedAt)) / 60);
+    }
+
+    public synchronized int getAchievementScore() {
         return this.achievementScore;
     }
 
-    public void addAchievementScore(int achievementScore) {
+    public synchronized void addAchievementScore(int achievementScore) {
         this.achievementScore += achievementScore;
     }
 
@@ -616,6 +625,28 @@ public class HabboStats implements Runnable {
     }
 
     public Subscription createSubscription(String subscriptionType, int duration) {
+        synchronized (this.habboInfo.ledgerMutationLock()) {
+            synchronized (this) {
+                return createSubscriptionWhileCoordinated(subscriptionType, duration);
+            }
+        }
+    }
+
+    public Subscription removeSubscription(String subscriptionType, int duration) {
+        if (duration != -1 && duration <= 0) throw new IllegalArgumentException("Duration must be positive or -1");
+        synchronized (this.habboInfo.ledgerMutationLock()) {
+            synchronized (this) {
+                Subscription subscription = getSubscription(subscriptionType);
+                if (subscription != null) {
+                    int remaining = Math.max(0, subscription.getRemaining());
+                    subscription.addDuration(-(duration == -1 ? remaining : Math.min(duration, remaining)));
+                }
+                return subscription;
+            }
+        }
+    }
+
+    private Subscription createSubscriptionWhileCoordinated(String subscriptionType, int duration) {
         Subscription subscription = getSubscription(subscriptionType);
 
         if (subscription != null) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/Subscription.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/Subscription.java
@@ -1,7 +1,6 @@
 package com.eu.habbo.habbohotel.users.subscriptions;
 
 import com.eu.habbo.Emulator;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -29,7 +28,13 @@ public class Subscription {
      * @param duration Length of subscription in seconds
      * @param active Boolean indicating if subscription is active
      */
-    public Subscription(Integer id, Integer userId, String subscriptionType, Integer timestampStart, Integer duration, Boolean active) {
+    public Subscription(
+            Integer id,
+            Integer userId,
+            String subscriptionType,
+            Integer timestampStart,
+            Integer duration,
+            Boolean active) {
         this.id = id;
         this.userId = userId;
         this.subscriptionType = subscriptionType;
@@ -66,15 +71,21 @@ public class Subscription {
         return duration;
     }
 
+    /** Publishes a duration already committed by a reward transaction. */
+    public void applyPersistedDuration(int duration) {
+        this.duration = duration;
+    }
+
     /**
-     * Updates the Subscription record with new duration
+     * Updates the Subscription record with new duration.
      * @param amount Length of time to add in seconds
      */
     public void addDuration(int amount) {
         this.duration += amount;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-            try (PreparedStatement statement = connection.prepareStatement("UPDATE `users_subscriptions` SET `duration` = ? WHERE `id` = ? LIMIT 1")) {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "UPDATE `users_subscriptions` SET `duration` = ? WHERE `id` = ? LIMIT 1")) {
                 statement.setInt(1, this.duration);
                 statement.setInt(2, this.id);
                 statement.executeUpdate();
@@ -92,7 +103,8 @@ public class Subscription {
         this.active = active;
 
         try (Connection connection = Emulator.getDatabase().getDataSource().getConnection()) {
-            try (PreparedStatement statement = connection.prepareStatement("UPDATE `users_subscriptions` SET `active` = ? WHERE `id` = ? LIMIT 1")) {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "UPDATE `users_subscriptions` SET `active` = ? WHERE `id` = ? LIMIT 1")) {
                 statement.setInt(1, this.active ? 1 : 0);
                 statement.setInt(2, this.id);
                 statement.executeUpdate();
@@ -133,16 +145,16 @@ public class Subscription {
     /**
      * Called when the subscription is first created
      */
-    public void onCreated() { }
+    public void onCreated() {}
 
     /**
      * Called when the subscription is extended or bought again when already exists
      * @param duration Extended duration time in seconds
      */
-    public void onExtended(int duration) { }
+    public void onExtended(int duration) {}
 
     /**
      * Called by SubscriptionScheduler when isActive() && getRemaining() < 0
      */
-    public void onExpired() { }
+    public void onExpired() {}
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionScheduler.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/users/subscriptions/SubscriptionScheduler.java
@@ -3,11 +3,11 @@ package com.eu.habbo.habbohotel.users.subscriptions;
 import com.eu.habbo.Emulator;
 import com.eu.habbo.core.Scheduler;
 import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.LedgerWalletMutation;
 import com.eu.habbo.plugin.events.users.subscriptions.UserSubscriptionExpiredEvent;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 /**
  * @author Beny
@@ -39,27 +39,39 @@ public class SubscriptionScheduler extends Scheduler {
     public void run() {
         super.run();
 
-        Habbo habbo;
-        for (Map.Entry<Integer, Habbo> map : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().entrySet()) {
-            habbo = map.getValue();
+        for (Map.Entry<Integer, Habbo> map : Emulator.getGameEnvironment()
+                .getHabboManager()
+                .getOnlineHabbos()
+                .entrySet()) {
+            Habbo habbo = map.getValue();
 
             try {
                 if (habbo != null) {
-                    for(Subscription subscription : habbo.getHabboStats().subscriptions) {
-                        if(subscription.isActive() && subscription.getRemaining() < 0) {
-                            if (!Emulator.getPluginManager().fireEvent(new UserSubscriptionExpiredEvent(habbo.getHabboInfo().getId(), subscription)).isCancelled()) {
-                                subscription.onExpired();
-                                subscription.setActive(false);
+                    LedgerWalletMutation.coordinated(habbo, () -> {
+                        synchronized (habbo.getHabboStats()) {
+                            for (Subscription subscription : habbo.getHabboStats().subscriptions) {
+                                if (subscription.isActive() && subscription.getRemaining() < 0) {
+                                    if (!Emulator.getPluginManager()
+                                            .fireEvent(new UserSubscriptionExpiredEvent(
+                                                    habbo.getHabboInfo().getId(), subscription))
+                                            .isCancelled()) {
+                                        subscription.onExpired();
+                                        subscription.setActive(false);
+                                    }
+                                }
                             }
                         }
-                    }
+                        return null;
+                    });
                 }
             } catch (Exception e) {
                 LOGGER.error("Caught exception", e);
             }
         }
 
-        if(SubscriptionHabboClub.HC_PAYDAY_ENABLED && !SubscriptionHabboClub.isExecuting && SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE < Emulator.getIntUnixTimestamp()) {
+        if (SubscriptionHabboClub.HC_PAYDAY_ENABLED
+                && !SubscriptionHabboClub.isExecuting
+                && SubscriptionHabboClub.HC_PAYDAY_NEXT_DATE < Emulator.getIntUnixTimestamp()) {
             SubscriptionHabboClub.executePayDay();
         }
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/UsernameEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/UsernameEvent.java
@@ -1,5 +1,7 @@
 package com.eu.habbo.messages.incoming.handshake;
 
+import static java.time.temporal.ChronoUnit.DAYS;
+
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.campaign.calendar.CalendarCampaign;
@@ -9,15 +11,8 @@ import com.eu.habbo.messages.incoming.MessageHandler;
 import com.eu.habbo.messages.outgoing.catalog.TargetedOfferComposer;
 import com.eu.habbo.messages.outgoing.events.calendar.AdventCalendarDataComposer;
 import com.eu.habbo.messages.outgoing.habboway.nux.NuxAlertComposer;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.Timestamp;
-import java.util.Calendar;
 import java.util.Date;
-
-import static java.time.temporal.ChronoUnit.DAYS;
 
 public class UsernameEvent extends MessageHandler {
     public static void completeLogin(GameClient client) throws Exception {
@@ -28,80 +23,68 @@ public class UsernameEvent extends MessageHandler {
 
     @Override
     public void handle() throws Exception {
-        if (!this.client.getHabbo().getHabboStats().getAchievementProgress().containsKey(Emulator.getGameEnvironment().getAchievementManager().getAchievement("Login"))) {
-            AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("Login"));
-        } else {
+        var habbo = this.client.getHabbo();
+        var stats = habbo.getHabboStats();
+        var achievements = Emulator.getGameEnvironment().getAchievementManager();
+        int timestamp = Emulator.getIntUnixTimestamp();
+        stats.loginStreak = loginStreak(stats.loginStreak, habbo.getHabboInfo().getLastOnline(), timestamp);
 
-            long daysBetween = DAYS.between(new Date((long) this.client.getHabbo().getHabboInfo().getLastOnline() * 1000L).toInstant(), new Date().toInstant());
+        var loginAchievement = achievements.getAchievement("Login");
+        int loginProgress = Math.max(0, stats.getAchievementProgress(loginAchievement));
+        if (stats.loginStreak > loginProgress) {
+            AchievementManager.progressAchievement(habbo, loginAchievement, stats.loginStreak - loginProgress);
+        }
 
+        var registrationAchievement = achievements.getAchievement("RegistrationDuration");
+        int daysRegistered = Math.max(0, (timestamp - habbo.getHabboInfo().getAccountCreated()) / 86400);
+        int registrationProgress = Math.max(0, stats.getAchievementProgress(registrationAchievement));
+        if (daysRegistered > registrationProgress) {
+            AchievementManager.progressAchievement(
+                    habbo, registrationAchievement, daysRegistered - registrationProgress);
+        }
 
-            Date lastLogin = new Date(this.client.getHabbo().getHabboInfo().getLastOnline());
-            Calendar c1 = Calendar.getInstance();
-            c1.add(Calendar.DAY_OF_YEAR, -1);
+        var tradingAchievement = achievements.getAchievement("TraderPass");
+        if (stats.getAchievementProgress(tradingAchievement) < 0)
+            AchievementManager.progressAchievement(habbo, tradingAchievement);
+        AchievementManager.processQueuedAchievements(habbo);
+        var onlineTimeAchievement = achievements.getAchievement("AllTimeHotelPresence");
+        int onlineProgress = Math.max(0, stats.getAchievementProgress(onlineTimeAchievement));
+        int onlineMinutes = stats.getOnlineMinutes(timestamp);
+        if (onlineMinutes > onlineProgress)
+            AchievementManager.progressAchievement(habbo, onlineTimeAchievement, onlineMinutes - onlineProgress);
 
-            Calendar c2 = Calendar.getInstance();
-            c2.setTime(lastLogin);
-
-            if (daysBetween == 1) {
-                if (this.client.getHabbo().getHabboStats().getAchievementProgress().get(Emulator.getGameEnvironment().getAchievementManager().getAchievement("Login")) == this.client.getHabbo().getHabboStats().loginStreak) {
-                    AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("Login"));
-                }
-                this.client.getHabbo().getHabboStats().loginStreak++;
-            } else if (daysBetween >= 1) {
-                // Calendar would be shown
-            } else {
-                if (((lastLogin.getTime() / 1000) - Emulator.getIntUnixTimestamp()) > 86400) {
-                    this.client.getHabbo().getHabboStats().loginStreak = 0;
-                }
+        if (AchievementManager.TALENTTRACK_ENABLED) {
+            for (var type : com.eu.habbo.habbohotel.achievements.TalentTrackType.values()) {
+                if (achievements.getTalenTrackLevels(type) != null)
+                    achievements.handleTalentTrackAchievement(habbo, type, null);
             }
         }
 
-        if (!this.client.getHabbo().getHabboStats().getAchievementProgress().containsKey(Emulator.getGameEnvironment().getAchievementManager().getAchievement("RegistrationDuration"))) {
-            AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("RegistrationDuration"), 0);
-        } else {
-            int daysRegistered = ((Emulator.getIntUnixTimestamp() - this.client.getHabbo().getHabboInfo().getAccountCreated()) / 86400);
-
-            int days = this.client.getHabbo().getHabboStats().getAchievementProgress(
-                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("RegistrationDuration")
-            );
-
-            if (daysRegistered - days > 0) {
-                AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("RegistrationDuration"), daysRegistered - days);
-            }
-        }
-
-        if (!this.client.getHabbo().getHabboStats().getAchievementProgress().containsKey(Emulator.getGameEnvironment().getAchievementManager().getAchievement("TraderPass"))) {
-            AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement("TraderPass"));
-        }
-
-
-        try (Connection connection = Emulator.getDatabase().getDataSource().getConnection(); PreparedStatement achievementQueueStatement = connection.prepareStatement("SELECT * FROM users_achievements_queue WHERE user_id = ?")) {
-            achievementQueueStatement.setInt(1, this.client.getHabbo().getHabboInfo().getId());
-
-            try (ResultSet achievementSet = achievementQueueStatement.executeQuery()) {
-                while (achievementSet.next()) {
-                    AchievementManager.progressAchievement(this.client.getHabbo(), Emulator.getGameEnvironment().getAchievementManager().getAchievement(achievementSet.getInt("achievement_id")), achievementSet.getInt("amount"));
-                }
-            }
-
-            try (PreparedStatement deleteStatement = connection.prepareStatement("DELETE FROM users_achievements_queue WHERE user_id = ?")) {
-                deleteStatement.setInt(1, this.client.getHabbo().getHabboInfo().getId());
-                deleteStatement.execute();
-            }
-        }
         if (Emulator.getConfig().getBoolean("hotel.calendar.enabled")) {
-            CalendarCampaign campaign = Emulator.getGameEnvironment().getCalendarManager().getCalendarCampaign(Emulator.getConfig().getValue("hotel.calendar.default"));
-            if(campaign != null){
-                long daysBetween = DAYS.between(new Timestamp(campaign.getStartTimestamp() * 1000L).toInstant(), new Date().toInstant());
-                if(daysBetween >= 0) {
-                    this.client.sendResponse(new AdventCalendarDataComposer(campaign.getName(), campaign.getImage(), campaign.getTotalDays(), (int) daysBetween, this.client.getHabbo().getHabboStats().calendarRewardsClaimed, campaign.getLockExpired()));
+            CalendarCampaign campaign = Emulator.getGameEnvironment()
+                    .getCalendarManager()
+                    .getCalendarCampaign(Emulator.getConfig().getValue("hotel.calendar.default"));
+            if (campaign != null) {
+                long daysBetween = DAYS.between(
+                        new Timestamp(campaign.getStartTimestamp() * 1000L).toInstant(), new Date().toInstant());
+                if (daysBetween >= 0) {
+                    this.client.sendResponse(new AdventCalendarDataComposer(
+                            campaign.getName(),
+                            campaign.getImage(),
+                            campaign.getTotalDays(),
+                            (int) daysBetween,
+                            this.client.getHabbo().getHabboStats().calendarRewardsClaimed,
+                            campaign.getLockExpired()));
                     this.client.sendResponse(new NuxAlertComposer("openView/calendar"));
                 }
-            };
+            }
+            ;
         }
 
         if (TargetOffer.ACTIVE_TARGET_OFFER_ID > 0) {
-            TargetOffer offer = Emulator.getGameEnvironment().getCatalogManager().getTargetOffer(TargetOffer.ACTIVE_TARGET_OFFER_ID);
+            TargetOffer offer = Emulator.getGameEnvironment()
+                    .getCatalogManager()
+                    .getTargetOffer(TargetOffer.ACTIVE_TARGET_OFFER_ID);
 
             if (offer != null) {
                 this.client.sendResponse(new TargetedOfferComposer(this.client.getHabbo(), offer));
@@ -109,5 +92,11 @@ public class UsernameEvent extends MessageHandler {
         }
 
         this.client.getHabbo().getHabboInfo().setLastOnline(Emulator.getIntUnixTimestamp());
+    }
+
+    static int loginStreak(int previousStreak, int previousLogin, int timestamp) {
+        int elapsedDays = Math.floorDiv(timestamp, 86400) - Math.floorDiv(previousLogin, 86400);
+        if (elapsedDays <= 0) return Math.max(1, previousStreak);
+        return elapsedDays == 1 ? Math.max(1, previousStreak) + 1 : 1;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -665,6 +665,8 @@ public class Outgoing {
     public static final int HousekeepingDashboardComposer = 9204;
     public static final int HousekeepingActionLogComposer = 9205;
 
+    public static final int WiredEnvironmentComposer = 5111;
+
     // Custom features — IDs 9400+ reserved
     public static final int RareValuesComposer = 9400;
     public static final int HotLooksComposer = 9360; // AIR 13 avatar editor hot looks tab

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/AchievementListComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/AchievementListComposer.java
@@ -2,17 +2,12 @@ package com.eu.habbo.messages.outgoing.achievements;
 
 import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.Achievement;
-import com.eu.habbo.habbohotel.achievements.AchievementLevel;
-import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class AchievementListComposer extends MessageComposer {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AchievementListComposer.class);
 
     private final Habbo habbo;
 
@@ -24,36 +19,20 @@ public class AchievementListComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.AchievementListComposer);
 
-        try {
-            this.response.appendInt(Emulator.getGameEnvironment().getAchievementManager().getAchievements().size());
+        var achievements = Emulator.getGameEnvironment().getAchievementManager().getAchievements().values().stream()
+                .sorted(java.util.Comparator.comparingInt(achievement -> achievement.id))
+                .toList();
+        this.response.appendInt(achievements.size());
+        for (Achievement achievement : achievements) {
+            AchievementProgressComposer.appendAchievement(this.response, this.habbo, achievement);
+        }
+        this.response.appendString("");
 
-            for (Achievement achievement : Emulator.getGameEnvironment().getAchievementManager().getAchievements().values()) {
-                int achievementProgress;
-                AchievementLevel currentLevel;
-                AchievementLevel nextLevel;
-
-                achievementProgress = this.habbo.getHabboStats().getAchievementProgress(achievement);
-                currentLevel = achievement.getLevelForProgress(achievementProgress);
-                nextLevel = achievement.getNextLevel(currentLevel != null ? currentLevel.level : 0);
-
-                this.response.appendInt(achievement.id); //ID
-                this.response.appendInt(nextLevel != null ? nextLevel.level : currentLevel != null ? currentLevel.level : 0); //
-                this.response.appendString("ACH_" + achievement.name + (nextLevel != null ? nextLevel.level : currentLevel != null ? currentLevel.level : 0)); //Target badge code
-                this.response.appendInt(currentLevel != null ? currentLevel.progress : 0); //Last level progress needed
-                this.response.appendInt(nextLevel != null ? nextLevel.progress : -1); //Progress needed
-                this.response.appendInt(nextLevel != null ? nextLevel.rewardAmount : -1); //Reward amount
-                this.response.appendInt(nextLevel != null ? nextLevel.rewardType : -1); //Reward currency ID
-                this.response.appendInt(Math.max(achievementProgress, 0)); //Current progress
-                this.response.appendBoolean(AchievementManager.hasAchieved(this.habbo, achievement)); //Achieved? (Current Progress == MaxLevel.Progress)
-                this.response.appendString(achievement.category.toString().toLowerCase()); //Category
-                this.response.appendString(""); //Empty, completly unused in client code
-                this.response.appendInt(achievement.levels.size()); //Count of total levels in this achievement
-                this.response.appendInt(AchievementManager.hasAchieved(this.habbo, achievement) ? 1 : 0); //1 = Progressbar visible if the achievement is completed
-            }
-
-            this.response.appendString("");
-        } catch (Exception e) {
-            LOGGER.error("Caught exception", e);
+        // Keep legacy repeated records intact; state metadata is a whole-packet extension.
+        this.response.appendInt(achievements.size());
+        for (Achievement achievement : achievements) {
+            this.response.appendInt(achievement.id);
+            this.response.appendShort(achievement.state);
         }
 
         return this.response;

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/AchievementProgressComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/AchievementProgressComposer.java
@@ -21,40 +21,32 @@ public class AchievementProgressComposer extends MessageComposer {
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.AchievementProgressComposer);
 
-        int achievementProgress;
-        AchievementLevel currentLevel;
-        AchievementLevel nextLevel;
-
-        achievementProgress = this.habbo.getHabboStats().getAchievementProgress(this.achievement);
-        currentLevel = this.achievement.getLevelForProgress(achievementProgress);
-        nextLevel = this.achievement.getNextLevel(currentLevel != null ? currentLevel.level : 0);
-
-        if (currentLevel != null && currentLevel.level == this.achievement.levels.size())
-            nextLevel = null;
-
-        int targetLevel = 1;
-
-        if (nextLevel != null)
-            targetLevel = nextLevel.level;
-
-        if (currentLevel != null && currentLevel.level == this.achievement.levels.size())
-            targetLevel = currentLevel.level;
-
-        this.response.appendInt(this.achievement.id); //ID
-        this.response.appendInt(targetLevel); //Target level
-        this.response.appendString("ACH_" + this.achievement.name + targetLevel); //Target badge code
-        this.response.appendInt(currentLevel != null ? currentLevel.progress : 0); //Last level progress needed
-        this.response.appendInt(nextLevel != null ? nextLevel.progress : 0); //Progress needed
-        this.response.appendInt(nextLevel != null ? nextLevel.rewardAmount : 0); //Reward amount
-        this.response.appendInt(nextLevel != null ? nextLevel.rewardType : 0); //Reward currency ID
-        this.response.appendInt(achievementProgress == -1 ? 0 : achievementProgress); //Current progress
-        this.response.appendBoolean(AchievementManager.hasAchieved(this.habbo, this.achievement)); //Achieved? (Current Progress == MaxLevel.Progress)
-        this.response.appendString(this.achievement.category.toString().toLowerCase()); //Category
-        this.response.appendString(""); //Empty, completly unused in client code
-        this.response.appendInt(this.achievement.levels.size()); //Count of total levels in this achievement
-        this.response.appendInt(0); //1 = Progressbar visible if the achievement is completed
+        appendAchievement(this.response, this.habbo, this.achievement);
+        this.response.appendShort(this.achievement.state);
 
         return this.response;
+    }
+
+    static void appendAchievement(ServerMessage response, Habbo habbo, Achievement achievement) {
+        int progress = Math.max(0, habbo.getHabboStats().getAchievementProgress(achievement));
+        AchievementLevel currentLevel = achievement.getLevelForProgress(progress);
+        AchievementLevel nextLevel = achievement.getNextLevel(currentLevel != null ? currentLevel.level : 0);
+        AchievementLevel targetLevel = nextLevel != null ? nextLevel : currentLevel;
+        int target = targetLevel != null ? targetLevel.level : 1;
+
+        response.appendInt(achievement.id);
+        response.appendInt(target);
+        response.appendString("ACH_" + achievement.name + target);
+        response.appendInt(currentLevel != null ? currentLevel.progress : 0);
+        response.appendInt(targetLevel != null ? targetLevel.progress : 0);
+        response.appendInt(nextLevel != null ? nextLevel.rewardAmount : 0);
+        response.appendInt(nextLevel != null ? nextLevel.rewardType : 0);
+        response.appendInt(progress);
+        response.appendBoolean(AchievementManager.hasAchieved(habbo, achievement));
+        response.appendString(achievement.category.name().toLowerCase(java.util.Locale.ROOT));
+        response.appendString(achievement.subcategory);
+        response.appendInt(achievement.levels.size());
+        response.appendInt(achievement.displayMethod);
     }
 
     public Habbo getHabbo() {

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/AchievementUnlockedComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/AchievementUnlockedComposer.java
@@ -10,28 +10,40 @@ import com.eu.habbo.messages.outgoing.Outgoing;
 public class AchievementUnlockedComposer extends MessageComposer {
     private final Achievement achievement;
     private final Habbo habbo;
+    private final AchievementLevel earnedLevel;
+    private final int badgeId;
 
     public AchievementUnlockedComposer(Habbo habbo, Achievement achievement) {
+        this(habbo, achievement, null, 0);
+    }
+
+    public AchievementUnlockedComposer(
+            Habbo habbo, Achievement achievement, AchievementLevel earnedLevel, int badgeId) {
         this.achievement = achievement;
         this.habbo = habbo;
+        this.earnedLevel = earnedLevel;
+        this.badgeId = badgeId;
     }
 
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.AchievementUnlockedComposer);
 
-        AchievementLevel level = this.achievement.getLevelForProgress(this.habbo.getHabboStats().getAchievementProgress(this.achievement));
+        AchievementLevel level = this.earnedLevel != null
+                ? this.earnedLevel
+                : this.achievement.getLevelForProgress(
+                        this.habbo.getHabboStats().getAchievementProgress(this.achievement));
         this.response.appendInt(this.achievement.id);
         this.response.appendInt(level.level);
-        this.response.appendInt(144);
+        this.response.appendInt(this.badgeId);
         this.response.appendString("ACH_" + this.achievement.name + level.level);
+        this.response.appendInt(level.points);
         this.response.appendInt(level.rewardAmount);
         this.response.appendInt(level.rewardType);
         this.response.appendInt(0);
-        this.response.appendInt(10);
-        this.response.appendInt(21);
+        this.response.appendInt(this.achievement.id);
         this.response.appendString(level.level > 1 ? "ACH_" + this.achievement.name + (level.level - 1) : "");
-        this.response.appendString(this.achievement.category.name());
+        this.response.appendString(this.achievement.category.name().toLowerCase(java.util.Locale.ROOT));
         this.response.appendBoolean(true);
         return this.response;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/talenttrack/TalentLevelUpdateComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/talenttrack/TalentLevelUpdateComposer.java
@@ -19,7 +19,7 @@ public class TalentLevelUpdateComposer extends MessageComposer {
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.TalentLevelUpdateComposer);
-        this.response.appendString(this.talentTrackType.name());
+        this.response.appendString(this.talentTrackType.name().toLowerCase(java.util.Locale.ROOT));
         this.response.appendInt(this.talentTrackLevel.level);
 
         if (this.talentTrackLevel.perks != null) {
@@ -31,10 +31,14 @@ public class TalentLevelUpdateComposer extends MessageComposer {
             this.response.appendInt(0);
         }
 
-        this.response.appendInt(this.talentTrackLevel.items.size());
+        this.response.appendInt(this.talentTrackLevel.items.size() + (this.talentTrackLevel.hcDays > 0 ? 1 : 0));
         for (Item item : this.talentTrackLevel.items) {
             this.response.appendString(item.getName());
-            this.response.appendInt(item.getSpriteId());
+            this.response.appendInt(0);
+        }
+        if (this.talentTrackLevel.hcDays > 0) {
+            this.response.appendString("HABBO_CLUB");
+            this.response.appendInt(this.talentTrackLevel.hcDays);
         }
         return this.response;
     }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/talenttrack/TalentTrackComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/achievements/talenttrack/TalentTrackComposer.java
@@ -9,7 +9,6 @@ import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.MessageComposer;
 import com.eu.habbo.messages.outgoing.Outgoing;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -17,6 +16,7 @@ import java.util.NoSuchElementException;
 public class TalentTrackComposer extends MessageComposer {
     public final Habbo habbo;
     public final TalentTrackType type;
+
     public TalentTrackComposer(Habbo habbo, TalentTrackType type) {
         this.habbo = habbo;
         this.type = type;
@@ -27,9 +27,10 @@ public class TalentTrackComposer extends MessageComposer {
         this.response.init(Outgoing.TalentTrackComposer);
         this.response.appendString(this.type.name().toLowerCase());
 
-        LinkedHashMap<Integer, TalentTrackLevel> talentTrackLevels = Emulator.getGameEnvironment().getAchievementManager().getTalenTrackLevels(this.type);
+        LinkedHashMap<Integer, TalentTrackLevel> talentTrackLevels =
+                Emulator.getGameEnvironment().getAchievementManager().getTalenTrackLevels(this.type);
         if (talentTrackLevels != null) {
-            this.response.appendInt(talentTrackLevels.size()); //Count
+            this.response.appendInt(talentTrackLevels.size()); // Count
             for (Map.Entry<Integer, TalentTrackLevel> set : talentTrackLevels.entrySet()) {
                 try {
                     TalentTrackLevel level = set.getValue();
@@ -50,22 +51,20 @@ public class TalentTrackComposer extends MessageComposer {
                     this.response.appendInt(level.achievements.size());
 
                     final TalentTrackState finalState = state;
-                    for (Map.Entry<com.eu.habbo.habbohotel.achievements.Achievement, Integer> achievementEntry : level.achievements.entrySet()) {
+                    for (Map.Entry<com.eu.habbo.habbohotel.achievements.Achievement, Integer> achievementEntry :
+                            level.achievements.entrySet()) {
                         com.eu.habbo.habbohotel.achievements.Achievement achievement = achievementEntry.getKey();
                         int index = achievementEntry.getValue();
                         if (achievement != null) {
                             this.response.appendInt(achievement.id);
 
-                            //TODO Move this to TalenTrackLevel class
-                            this.response.appendInt(index); //idk
+                            // TODO Move this to TalenTrackLevel class
+                            this.response.appendInt(index); // idk
                             this.response.appendString("ACH_" + achievement.name + index);
 
-                            int progress = Math.max(0, this.habbo.getHabboStats().getAchievementProgress(achievement));
-                            AchievementLevel achievementLevel = achievement.getLevelForProgress(progress);
-
-                            if (achievementLevel == null) {
-                                achievementLevel = achievement.firstLevel();
-                            }
+                            int progress =
+                                    Math.max(0, this.habbo.getHabboStats().getAchievementProgress(achievement));
+                            AchievementLevel achievementLevel = achievement.levels.get(index);
                             if (finalState != TalentTrackState.LOCKED) {
                                 if (achievementLevel != null && achievementLevel.progress <= progress) {
                                     this.response.appendInt(2);
@@ -81,13 +80,11 @@ public class TalentTrackComposer extends MessageComposer {
                             this.response.appendInt(0);
                             this.response.appendInt(0);
                             this.response.appendString("");
-                            this.response.appendString("");
                             this.response.appendInt(0);
                             this.response.appendInt(0);
                             this.response.appendInt(0);
                         }
                     }
-
 
                     if (level.perks != null && level.perks.length > 0) {
                         this.response.appendInt(level.perks.length);
@@ -98,11 +95,15 @@ public class TalentTrackComposer extends MessageComposer {
                         this.response.appendInt(-1);
                     }
 
-                    if (!level.items.isEmpty()) {
-                        this.response.appendInt(level.items.size());
+                    if (!level.items.isEmpty() || level.hcDays > 0) {
+                        this.response.appendInt(level.items.size() + (level.hcDays > 0 ? 1 : 0));
                         for (Item item : level.items) {
                             this.response.appendString(item.getName());
                             this.response.appendInt(0);
+                        }
+                        if (level.hcDays > 0) {
+                            this.response.appendString("HABBO_CLUB");
+                            this.response.appendInt(level.hcDays);
                         }
                     } else {
                         this.response.appendInt(-1);

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/wired/WiredEnvironmentComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/wired/WiredEnvironmentComposer.java
@@ -1,0 +1,35 @@
+package com.eu.habbo.messages.outgoing.wired;
+
+import com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement;
+import com.eu.habbo.habbohotel.items.interactions.wired.triggers.WiredTriggerHabboClicksUser;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+public final class WiredEnvironmentComposer extends MessageComposer {
+    private final Room room;
+
+    public WiredEnvironmentComposer(Room room) {
+        this.room = room;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        var items = this.room.getFloorItems();
+        var achievements = items.stream()
+                .filter(WiredEffectGiveAchievement.class::isInstance)
+                .map(WiredEffectGiveAchievement.class::cast)
+                .map(WiredEffectGiveAchievement::getAchievementCode)
+                .map(code -> code.startsWith("WF_") ? code.substring(3) : code)
+                .filter(code -> !code.isBlank())
+                .distinct()
+                .sorted()
+                .toList();
+        this.response.init(Outgoing.WiredEnvironmentComposer);
+        this.response.appendBoolean(items.stream().anyMatch(WiredTriggerHabboClicksUser.class::isInstance));
+        this.response.appendInt(achievements.size());
+        for (String achievement : achievements) this.response.appendString(achievement);
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/rcon/ModifyUserSubscription.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/rcon/ModifyUserSubscription.java
@@ -23,7 +23,7 @@ public class ModifyUserSubscription extends RCONMessage<ModifyUserSubscription.J
     public void handle(Gson gson, JSON json) {
         try {
 
-            if(json.user_id <= 0) {
+            if (json.user_id <= 0) {
                 this.status = RCONMessage.HABBO_NOT_FOUND;
                 this.message = "User not found";
                 return;
@@ -43,8 +43,11 @@ public class ModifyUserSubscription extends RCONMessage<ModifyUserSubscription.J
                 return;
             }
 
-            int maxDuration = parseMaxDuration(Emulator.getConfig().getValue("rcon.subscription.max_duration_seconds", String.valueOf(DEFAULT_MAX_DURATION_SECONDS)));
-            if (json.action.equalsIgnoreCase("add") || json.action.equalsIgnoreCase("+") || json.action.equalsIgnoreCase("a")) {
+            int maxDuration = parseMaxDuration(Emulator.getConfig()
+                    .getValue("rcon.subscription.max_duration_seconds", String.valueOf(DEFAULT_MAX_DURATION_SECONDS)));
+            if (json.action.equalsIgnoreCase("add")
+                    || json.action.equalsIgnoreCase("+")
+                    || json.action.equalsIgnoreCase("a")) {
                 if (!isValidDuration(json.duration, maxDuration)) {
                     this.status = RCONMessage.STATUS_ERROR;
                     this.message = "duration must be between 1 and " + maxDuration + " seconds";
@@ -53,38 +56,46 @@ public class ModifyUserSubscription extends RCONMessage<ModifyUserSubscription.J
 
                 habbo.getHabboStats().createSubscription(json.type, json.duration);
                 this.status = RCONMessage.STATUS_OK;
-                this.message = "Successfully added %time% seconds to %subscription% on %user%".replace("%time%", json.duration + "").replace("%user%", habbo.getUsername()).replace("%subscription%", json.type);
-            } else if (json.action.equalsIgnoreCase("remove") || json.action.equalsIgnoreCase("-") || json.action.equalsIgnoreCase("r")) {
-                Subscription s = habbo.getHabboStats().getSubscription(json.type);
+                this.message = "Successfully added %time% seconds to %subscription% on %user%"
+                        .replace("%time%", json.duration + "")
+                        .replace("%user%", habbo.getUsername())
+                        .replace("%subscription%", json.type);
+            } else if (json.action.equalsIgnoreCase("remove")
+                    || json.action.equalsIgnoreCase("-")
+                    || json.action.equalsIgnoreCase("r")) {
+                if (json.duration != -1 && !isValidDuration(json.duration, maxDuration)) {
+                    this.status = RCONMessage.STATUS_ERROR;
+                    this.message =
+                            "duration must be between 1 and " + maxDuration + " seconds, or -1 to remove all time";
+                    return;
+                }
+                Subscription s = habbo.getHabboStats().removeSubscription(json.type, json.duration);
 
                 if (s == null) {
                     this.status = RCONMessage.STATUS_ERROR;
-                    this.message = "%user% does not have the %subscription% subscription".replace("%user%", habbo.getUsername()).replace("%subscription%", json.type);
+                    this.message = "%user% does not have the %subscription% subscription"
+                            .replace("%user%", habbo.getUsername())
+                            .replace("%subscription%", json.type);
                     return;
                 }
 
                 if (json.duration != -1) {
-                    if (!isValidDuration(json.duration, maxDuration)) {
-                        this.status = RCONMessage.STATUS_ERROR;
-                        this.message = "duration must be between 1 and " + maxDuration + " seconds, or -1 to remove all time";
-                        return;
-                    }
-
-                    s.addDuration(-Math.min(json.duration, s.getRemaining()));
                     this.status = RCONMessage.STATUS_OK;
-                    this.message = "Successfully removed %time% seconds from %subscription% on %user%".replace("%time%", json.duration + "").replace("%user%", habbo.getUsername()).replace("%subscription%", json.type);
+                    this.message = "Successfully removed %time% seconds from %subscription% on %user%"
+                            .replace("%time%", json.duration + "")
+                            .replace("%user%", habbo.getUsername())
+                            .replace("%subscription%", json.type);
                 } else {
-                    s.addDuration(-s.getRemaining());
                     this.status = RCONMessage.STATUS_OK;
-                    this.message = "Successfully removed %subscription% sub from %user%".replace("%user%", habbo.getUsername()).replace("%subscription%", json.type);
+                    this.message = "Successfully removed %subscription% sub from %user%"
+                            .replace("%user%", habbo.getUsername())
+                            .replace("%subscription%", json.type);
                 }
-            }
-            else {
+            } else {
                 this.status = RCONMessage.STATUS_ERROR;
                 this.message = "Invalid action specified. Must be add, +, remove or -";
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             this.status = RCONMessage.SYSTEM_ERROR;
             this.message = "Exception occurred";
             LOGGER.error("Exception occurred", e);
@@ -123,6 +134,5 @@ public class ModifyUserSubscription extends RCONMessage<ModifyUserSubscription.J
         public String action = ""; // Can be add or remove
 
         public int duration = -1; // Time to add/remove in seconds. -1 means remove subscription entirely
-
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/threading/runnables/AchievementUpdater.java
+++ b/Emulator/src/main/java/com/eu/habbo/threading/runnables/AchievementUpdater.java
@@ -4,7 +4,6 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.achievements.Achievement;
 import com.eu.habbo.habbohotel.achievements.AchievementManager;
 import com.eu.habbo.habbohotel.users.Habbo;
-
 import java.util.Map;
 
 public class AchievementUpdater implements Runnable {
@@ -18,16 +17,18 @@ public class AchievementUpdater implements Runnable {
         }
 
         if (Emulator.isReady) {
-            Achievement onlineTime = Emulator.getGameEnvironment().getAchievementManager().getAchievement("AllTimeHotelPresence");
+            Achievement onlineTime =
+                    Emulator.getGameEnvironment().getAchievementManager().getAchievement("AllTimeHotelPresence");
 
             int timestamp = Emulator.getIntUnixTimestamp();
-            for (Map.Entry<Integer, Habbo> set : Emulator.getGameEnvironment().getHabboManager().getOnlineHabbos().entrySet()) {
-                int timeOnlineSinceLastInterval = INTERVAL;
+            for (Map.Entry<Integer, Habbo> set : Emulator.getGameEnvironment()
+                    .getHabboManager()
+                    .getOnlineHabbos()
+                    .entrySet()) {
                 Habbo habbo = set.getValue();
-                if (habbo.getHabboInfo().getLastOnline() > this.lastExecutionTimestamp) {
-                    timeOnlineSinceLastInterval = timestamp - habbo.getHabboInfo().getLastOnline();
-                }
-                AchievementManager.progressAchievement(habbo, onlineTime, (int) Math.floor((timeOnlineSinceLastInterval) / 60));
+                int minutes = habbo.getHabboStats().getOnlineMinutes(timestamp);
+                int progress = Math.max(0, habbo.getHabboStats().getAchievementProgress(onlineTime));
+                if (minutes > progress) AchievementManager.progressAchievement(habbo, onlineTime, minutes - progress);
             }
 
             this.lastExecutionTimestamp = timestamp;

--- a/Emulator/src/main/resources/db/migration/V20260911160000__achievement_air_metadata.sql
+++ b/Emulator/src/main/resources/db/migration/V20260911160000__achievement_air_metadata.sql
@@ -1,0 +1,10 @@
+-- AIR achievement states: disabled, enabled, archived, off-season, wired-controlled.
+ALTER TABLE achievements
+    ADD COLUMN state SMALLINT NOT NULL DEFAULT 1,
+    ADD COLUMN display_method INT NOT NULL DEFAULT 0,
+    ADD COLUMN subcategory VARCHAR(64) NOT NULL DEFAULT '',
+    MODIFY COLUMN category ENUM('identity','explore','music','social','games','room_builder','pets','tools','events','other','test','invisible','misc','archive','wired_games') NOT NULL DEFAULT 'identity';
+
+-- Legacy seeds used MyISAM; progress and queued events must participate in reward transactions.
+ALTER TABLE users_achievements ENGINE = InnoDB, ROW_FORMAT = DYNAMIC;
+ALTER TABLE users_achievements_queue ENGINE = InnoDB, ROW_FORMAT = DYNAMIC;

--- a/Emulator/src/main/resources/db/migration/V20260911160100__talent_habbo_club_rewards.sql
+++ b/Emulator/src/main/resources/db/migration/V20260911160100__talent_habbo_club_rewards.sql
@@ -1,0 +1,1 @@
+ALTER TABLE achievements_talents ADD COLUMN reward_hc_days INT NOT NULL DEFAULT 0;

--- a/Emulator/src/main/resources/db/runtime-schema-contract.json
+++ b/Emulator/src/main/resources/db/runtime-schema-contract.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "source": "Flyway migrated schema",
   "tables": {
-    "achievements": ["category", "id", "level", "name", "points", "progress_needed", "reward_amount", "reward_type"],
-    "achievements_talents": ["achievement_ids", "achievement_levels", "id", "level", "reward_badges", "reward_furni", "reward_perks", "type"],
+    "achievements": ["category", "display_method", "id", "level", "name", "points", "progress_needed", "reward_amount", "reward_type", "state", "subcategory"],
+    "achievements_talents": ["achievement_ids", "achievement_levels", "id", "level", "reward_badges", "reward_furni", "reward_hc_days", "reward_perks", "type"],
     "bans": ["ban_expire", "ban_reason", "cfh_topic", "id", "ip", "machine_id", "timestamp", "type", "user_id", "user_staff_id"],
     "bot_chat_responses": ["bot_type", "id", "keys", "responses"],
     "bot_serves": ["id", "item", "keys"],

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/achievements/AchievementRewardsIT.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/achievements/AchievementRewardsIT.java
@@ -1,0 +1,435 @@
+package com.eu.habbo.habbohotel.achievements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.database.Database;
+import com.eu.habbo.database.TestDatabase;
+import com.eu.habbo.database.migration.MigrationRunner;
+import com.eu.habbo.habbohotel.economy.EconomyOperation;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboBadge;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboInventory;
+import com.eu.habbo.habbohotel.users.HabboStats;
+import com.eu.habbo.habbohotel.users.inventory.BadgesComponent;
+import com.eu.habbo.plugin.PluginManager;
+import com.eu.habbo.plugin.events.users.achievements.UserAchievementLeveledEvent;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AchievementRewardsIT {
+    private static HikariDataSource dataSource;
+    private Achievement achievement;
+
+    @BeforeAll
+    static void database() throws Exception {
+        assumeTrue(TestDatabase.dockerAvailable(), "Docker required for MariaDB integration tests");
+        dataSource = TestDatabase.freshDatabase("achievement_rewards");
+        MigrationRunner.migrate(dataSource);
+    }
+
+    @AfterAll
+    static void close() {
+        if (dataSource != null) dataSource.close();
+    }
+
+    @BeforeEach
+    void seed() throws Exception {
+        execute("DELETE FROM users_achievements_queue WHERE user_id = 910020");
+        execute("DELETE FROM users_achievements WHERE user_id = 910020");
+        execute("DELETE FROM users_badges WHERE user_id = 910020");
+        execute("DELETE FROM items WHERE user_id = 910020");
+        execute("DELETE FROM users_subscriptions WHERE user_id = 910020");
+        execute("TRUNCATE TABLE logs_economy");
+        execute("DELETE FROM users_currency WHERE user_id = 910020");
+        execute("DELETE FROM users_settings WHERE user_id = 910020");
+        execute("DELETE FROM users WHERE id = 910020");
+        execute("DELETE FROM achievements WHERE name = 'AtomicReward'");
+        execute(
+                "INSERT INTO users (id, username, password, ip_register, ip_current, credits) VALUES (910020, 'achievement_it', '!', '127.0.0.1', '127.0.0.1', 20)");
+        execute("INSERT INTO users_settings (user_id, achievement_score) VALUES (910020, 0)");
+        execute(
+                "INSERT INTO achievements (id,name,category,level,reward_amount,reward_type,points,progress_needed) VALUES (990001,'AtomicReward','identity',1,7,0,11,2), (990002,'AtomicReward','identity',2,13,5,17,4), (990003,'AtomicReward','identity',3,19,-1,23,6)");
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet result = statement.executeQuery(
+                        "SELECT * FROM achievements WHERE name = 'AtomicReward' ORDER BY level")) {
+            result.next();
+            achievement = new Achievement(result);
+            while (result.next()) achievement.addLevel(new AchievementLevel(result));
+        }
+    }
+
+    @Test
+    void crossingSeveralLevelsPaysEveryConfiguredRewardAndCannotReplay() throws Exception {
+        withOnlineUser(
+                habbo -> {
+                    AchievementManager.progressAchievement(habbo, achievement, 6);
+                    AchievementManager.progressAchievement(habbo, achievement, 6);
+                    assertEquals(6, habbo.getHabboStats().getAchievementProgress(achievement));
+                    assertEquals(51, habbo.getHabboStats().achievementScore);
+                    assertEquals(
+                            List.of("ACH_AtomicReward3"),
+                            habbo.getInventory().getBadgesComponent().getBadgesSnapshot().stream()
+                                    .map(HabboBadge::getCode)
+                                    .toList());
+                },
+                false);
+        assertEquals(6, value("SELECT progress FROM users_achievements WHERE user_id = 910020"));
+        assertEquals(51, value("SELECT achievement_score FROM users_settings WHERE user_id = 910020"));
+        assertEquals(7, value("SELECT amount FROM users_currency WHERE user_id = 910020 AND type = 0"));
+        assertEquals(13, value("SELECT amount FROM users_currency WHERE user_id = 910020 AND type = 5"));
+        assertEquals(39, value("SELECT credits FROM users WHERE id = 910020"));
+        assertEquals(3, value("SELECT COUNT(*) FROM logs_economy WHERE user_id = 910020"));
+        assertEquals(
+                1,
+                value("SELECT COUNT(*) FROM users_badges WHERE user_id = 910020 AND badge_code = 'ACH_AtomicReward3'"));
+    }
+
+    @Test
+    void normalAchievementPreservesUnsavedWiredAndPluginExperience() throws Exception {
+        execute("UPDATE users_settings SET achievement_score = 100 WHERE user_id = 910020");
+        withOnlineUser(
+                habbo -> {
+                    habbo.getHabboStats().achievementScore = 100;
+                    habbo.getHabboStats().addAchievementScore(50);
+                    AchievementManager.progressAchievement(habbo, achievement, 2);
+                    assertEquals(161, habbo.getHabboStats().getAchievementScore());
+                },
+                false);
+        assertEquals(161, value("SELECT achievement_score FROM users_settings WHERE user_id = 910020"));
+    }
+
+    @Test
+    void cancelledLevelUpLeavesProgressWalletAndBadgeUnchanged() throws Exception {
+        withOnlineUser(habbo -> AchievementManager.progressAchievement(habbo, achievement, 6), true);
+        assertEquals(0, value("SELECT COUNT(*) FROM users_achievements WHERE user_id = 910020"));
+        assertEquals(0, value("SELECT COUNT(*) FROM users_badges WHERE user_id = 910020"));
+        assertEquals(0, value("SELECT COUNT(*) FROM logs_economy WHERE user_id = 910020"));
+    }
+
+    @Test
+    void inactiveAndMalformedProgressCannotGrantRewards() throws Exception {
+        withOnlineUser(
+                habbo -> {
+                    AchievementManager.progressAchievement(habbo, achievement, -1);
+                    AchievementManager.progressAchievement(habbo, achievement, 0);
+                    for (short state : new short[] {0, 2, 3}) {
+                        achievement.state = state;
+                        AchievementManager.progressAchievement(habbo, achievement, 6);
+                    }
+                },
+                false);
+        assertEquals(0, value("SELECT COUNT(*) FROM users_achievements WHERE user_id = 910020"));
+        assertEquals(0, value("SELECT COUNT(*) FROM logs_economy WHERE user_id = 910020"));
+    }
+
+    @Test
+    void rewardFailureRollsBackProgressScoreAndOfflineQueue() throws Exception {
+        execute("INSERT INTO users_achievements_queue (user_id,achievement_id,amount) VALUES (910020,990001,6)");
+        try (Connection connection = dataSource.getConnection()) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> AchievementRewards.persist(
+                            connection,
+                            910020,
+                            achievement,
+                            0,
+                            6,
+                            levels(),
+                            List.of(operation(1, 0, 7), operation(2, -1, -100)),
+                            6,
+                            0));
+        }
+        assertEquals(0, value("SELECT COUNT(*) FROM users_achievements WHERE user_id = 910020"));
+        assertEquals(0, value("SELECT achievement_score FROM users_settings WHERE user_id = 910020"));
+        assertEquals(0, value("SELECT COUNT(*) FROM users_currency WHERE user_id = 910020"));
+        assertEquals(6, value("SELECT amount FROM users_achievements_queue WHERE user_id = 910020"));
+    }
+
+    @Test
+    void successfulQueueConsumptionPreservesNewlyQueuedProgressAndBadgeSlot() throws Exception {
+        execute("INSERT INTO users_achievements_queue (user_id,achievement_id,amount) VALUES (910020,990001,9)");
+        execute(
+                "INSERT INTO users_badges (user_id,badge_code,slot_id) VALUES (910020,'ACH_AtomicReward1',3), (910020,'ACH_AtomicRewardFriend5',2)");
+        try (Connection connection = dataSource.getConnection()) {
+            var result = AchievementRewards.persist(
+                    connection, 910020, achievement, 0, 6, levels(), List.of(operation(1, 0, 7)), 6, 0);
+            assertEquals(3, result.badge().slot());
+        }
+        assertEquals(3, value("SELECT amount FROM users_achievements_queue WHERE user_id = 910020"));
+        assertEquals(
+                1,
+                value(
+                        "SELECT COUNT(*) FROM users_badges WHERE user_id = 910020 AND badge_code = 'ACH_AtomicRewardFriend5'"));
+    }
+
+    @Test
+    void concurrentDuplicateTransitionCannotAwardTwice() throws Exception {
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<Boolean>> attempts = new ArrayList<>();
+            for (int index = 0; index < 2; index++) {
+                attempts.add(executor.submit(() -> {
+                    try (Connection connection = dataSource.getConnection()) {
+                        AchievementRewards.persist(
+                                connection, 910020, achievement, 0, 6, levels(), List.of(operation(1, 0, 7)), 0, 0);
+                        return true;
+                    } catch (SQLException staleProgress) {
+                        return false;
+                    }
+                }));
+            }
+            assertNotEquals(attempts.get(0).get(), attempts.get(1).get());
+        }
+        assertEquals(51, value("SELECT achievement_score FROM users_settings WHERE user_id = 910020"));
+        assertEquals(7, value("SELECT amount FROM users_currency WHERE user_id = 910020 AND type = 0"));
+    }
+
+    @Test
+    void talentMilestoneCommitsFurnitureBadgeAndPerkOnce() throws Exception {
+        var level = talentLevel();
+        Habbo habbo = mock(Habbo.class);
+        HabboInfo info = mock(HabboInfo.class);
+        when(info.getId()).thenReturn(910020);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        var itemManager = mock(com.eu.habbo.habbohotel.items.ItemManager.class, CALLS_REAL_METHODS);
+        int previous = value("SELECT talent_track_citizenship_level FROM users_settings WHERE user_id = 910020");
+        try (Connection connection = dataSource.getConnection()) {
+            var result = TalentTrackRewards.persist(
+                    connection,
+                    habbo,
+                    itemManager,
+                    new com.eu.habbo.habbohotel.users.subscriptions.SubscriptionManager(),
+                    TalentTrackType.CITIZENSHIP,
+                    previous,
+                    3,
+                    List.of(level),
+                    1000);
+            assertEquals(1, result.items().size());
+            assertEquals(1, result.badges().size());
+            assertTrue(result.trade());
+            assertEquals(172800, result.subscription().getDuration());
+        }
+        try (Connection connection = dataSource.getConnection()) {
+            assertThrows(
+                    SQLException.class,
+                    () -> TalentTrackRewards.persist(
+                            connection,
+                            habbo,
+                            itemManager,
+                            new com.eu.habbo.habbohotel.users.subscriptions.SubscriptionManager(),
+                            TalentTrackType.CITIZENSHIP,
+                            previous,
+                            3,
+                            List.of(level),
+                            1000));
+        }
+        assertEquals(1, value("SELECT COUNT(*) FROM items WHERE user_id = 910020"));
+        assertEquals(3, value("SELECT talent_track_citizenship_level FROM users_settings WHERE user_id = 910020"));
+        assertEquals(1, value("SELECT perk_trade FROM users_settings WHERE user_id = 910020"));
+        assertEquals(1, value("SELECT COUNT(*) FROM users_subscriptions WHERE user_id = 910020"));
+        assertEquals(172800, value("SELECT duration FROM users_subscriptions WHERE user_id = 910020"));
+    }
+
+    @Test
+    void failedTalentFurnitureRollsBackTheMilestone() throws Exception {
+        var level = talentLevel();
+        Habbo habbo = mock(Habbo.class);
+        HabboInfo info = mock(HabboInfo.class);
+        when(info.getId()).thenReturn(910020);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        var itemManager = mock(com.eu.habbo.habbohotel.items.ItemManager.class);
+        int previous = value("SELECT talent_track_citizenship_level FROM users_settings WHERE user_id = 910020");
+        try (Connection connection = dataSource.getConnection()) {
+            assertThrows(
+                    SQLException.class,
+                    () -> TalentTrackRewards.persist(
+                            connection,
+                            habbo,
+                            itemManager,
+                            new com.eu.habbo.habbohotel.users.subscriptions.SubscriptionManager(),
+                            TalentTrackType.CITIZENSHIP,
+                            previous,
+                            3,
+                            List.of(level),
+                            1000));
+        }
+        assertEquals(
+                previous, value("SELECT talent_track_citizenship_level FROM users_settings WHERE user_id = 910020"));
+        assertEquals(0, value("SELECT COUNT(*) FROM users_badges WHERE user_id = 910020"));
+        assertEquals(0, value("SELECT COUNT(*) FROM users_subscriptions WHERE user_id = 910020"));
+    }
+
+    @Test
+    void talentClubDaysExtendTheActiveSubscription() throws Exception {
+        execute(
+                "INSERT INTO users_subscriptions (user_id, subscription_type, timestamp_start, duration, active) VALUES (910020,'HABBO_CLUB',500,86400,1)");
+        var level = talentLevel();
+        level.items = Set.of();
+        Habbo habbo = mock(Habbo.class);
+        HabboInfo info = mock(HabboInfo.class);
+        when(info.getId()).thenReturn(910020);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        int previous = value("SELECT talent_track_citizenship_level FROM users_settings WHERE user_id = 910020");
+        try (Connection connection = dataSource.getConnection()) {
+            var result = TalentTrackRewards.persist(
+                    connection,
+                    habbo,
+                    null,
+                    new com.eu.habbo.habbohotel.users.subscriptions.SubscriptionManager(),
+                    TalentTrackType.CITIZENSHIP,
+                    previous,
+                    3,
+                    List.of(level),
+                    1000);
+            assertEquals(259200, result.subscription().getDuration());
+            assertEquals(500, result.subscription().getTimestampStart());
+        }
+        assertEquals(1, value("SELECT COUNT(*) FROM users_subscriptions WHERE user_id = 910020"));
+    }
+
+    @Test
+    void loadsClubOnlyMilestonesWithoutFurniture() throws Exception {
+        execute(
+                "INSERT INTO achievements_talents (id,type,level,achievement_ids,achievement_levels,reward_furni,reward_perks,reward_badges,reward_hc_days) VALUES (990001,'citizenship',20,'','',' , ','TRADE','',2)");
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet result = statement.executeQuery("SELECT * FROM achievements_talents WHERE id = 990001")) {
+            result.next();
+            var level = new TalentTrackLevel(result);
+            assertEquals(2, level.hcDays);
+            assertTrue(level.items.isEmpty());
+        }
+    }
+
+    private TalentTrackLevel talentLevel() {
+        var level = mock(TalentTrackLevel.class);
+        level.level = 3;
+        level.hcDays = 2;
+        level.perks = new String[] {"TRADE"};
+        level.badges = new String[] {"TALENT_TEST"};
+        var item = mock(com.eu.habbo.habbohotel.items.Item.class);
+        when(item.getId()).thenReturn(1);
+        when(item.getName()).thenReturn("talent_chair");
+        when(item.getInteractionType())
+                .thenReturn(new com.eu.habbo.habbohotel.items.ItemInteraction(
+                        "default", com.eu.habbo.habbohotel.items.interactions.InteractionDefault.class));
+        level.items = Set.of(item);
+        return level;
+    }
+
+    private void withOnlineUser(java.util.function.Consumer<Habbo> action, boolean cancelLevel) throws Exception {
+        Habbo habbo = mock(Habbo.class);
+        var constructor = HabboInfo.class.getDeclaredConstructor(int.class, int.class);
+        constructor.setAccessible(true);
+        HabboInfo info = constructor.newInstance(910020, 20);
+        HabboStats stats = mock(HabboStats.class);
+        HabboInventory inventory = mock(HabboInventory.class);
+        BadgesComponent badges = mock(BadgesComponent.class);
+        Set<HabboBadge> ownedBadges = new HashSet<>();
+        Map<Achievement, Integer> progress = new HashMap<>();
+        when(stats.getAchievementScore()).thenAnswer(call -> stats.achievementScore);
+        doCallRealMethod().when(stats).addAchievementScore(anyInt());
+        when(stats.getAchievementProgress(any())).thenAnswer(call -> progress.getOrDefault(call.getArgument(0), -1));
+        doAnswer(call -> {
+                    progress.put(call.getArgument(0), call.getArgument(1));
+                    return null;
+                })
+                .when(stats)
+                .setProgress(any(), anyInt());
+        when(badges.getBadgesSnapshot()).thenAnswer(call -> new ArrayList<>(ownedBadges));
+        doAnswer(call -> {
+                    ownedBadges.add(call.getArgument(0));
+                    return null;
+                })
+                .when(badges)
+                .addBadge(any());
+        when(inventory.getBadgesComponent()).thenReturn(badges);
+        when(habbo.getInventory()).thenReturn(inventory);
+        when(habbo.getHabboInfo()).thenReturn(info);
+        when(habbo.getHabboStats()).thenReturn(stats);
+        when(habbo.getClient()).thenReturn(mock(GameClient.class));
+        when(habbo.isOnline()).thenReturn(true);
+        Database database = mock(Database.class);
+        when(database.getDataSource()).thenReturn(dataSource);
+        PluginManager plugins = mock(PluginManager.class);
+        when(plugins.isRegistered(any(), anyBoolean())).thenReturn(true);
+        when(plugins.fireEvent(any())).thenAnswer(call -> {
+            com.eu.habbo.plugin.Event event = call.getArgument(0);
+            if (cancelLevel && event instanceof UserAchievementLeveledEvent) event.setCancelled(true);
+            return event;
+        });
+        try (var emulator = mockStatic(Emulator.class)) {
+            emulator.when(Emulator::getDatabase).thenReturn(database);
+            emulator.when(Emulator::getPluginManager).thenReturn(plugins);
+            action.accept(habbo);
+        }
+    }
+
+    private List<AchievementLevel> levels() {
+        return achievement.levels.values().stream()
+                .sorted(Comparator.comparingInt(level -> level.level))
+                .toList();
+    }
+
+    private EconomyOperation operation(int level, int currency, int amount) {
+        return new EconomyOperation(
+                "achievement:910020:990001:" + level,
+                910020,
+                910020,
+                "achievement_reward",
+                "achievement.level",
+                currency,
+                amount,
+                null,
+                "AtomicReward");
+    }
+
+    private static void execute(String sql) throws Exception {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate(sql);
+        }
+    }
+
+    private static int value(String sql) throws Exception {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet result = statement.executeQuery(sql)) {
+            result.next();
+            return result.getInt(1);
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/users/AchievementOnlineTimeTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/users/AchievementOnlineTimeTest.java
@@ -1,0 +1,65 @@
+package com.eu.habbo.habbohotel.users;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class AchievementOnlineTimeTest {
+    @Test
+    void combinesSavedPartialMinutesWithActualElapsedSessionTime() throws Exception {
+        HabboStats stats = mock(HabboStats.class, CALLS_REAL_METHODS);
+        var previous = HabboStats.class.getDeclaredField("previousOnlineTime");
+        previous.setAccessible(true);
+        previous.setInt(stats, 59);
+        var started = HabboStats.class.getDeclaredField("sessionStartedAt");
+        started.setAccessible(true);
+        started.setInt(stats, 1000);
+        assertEquals(1, stats.getOnlineMinutes(1001));
+        assertEquals(11, stats.getOnlineMinutes(1601));
+        assertEquals(0, stats.getOnlineMinutes(999));
+
+        previous.setInt(stats, 659);
+        started.setInt(stats, 2000);
+        assertEquals(11, stats.getOnlineMinutes(2001));
+    }
+
+    @Test
+    void retriesUnsavedSessionSecondsAfterDatabaseFailure() throws Exception {
+        HabboStats stats = mock(HabboStats.class, CALLS_REAL_METHODS);
+        var lastOnlineTime = new java.util.concurrent.atomic.AtomicInteger(1000);
+        set(stats, "lastOnlineTime", lastOnlineTime);
+        set(stats, "habboInfo", new HabboInfo(42, 0));
+        set(stats, "offerCache", new it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap<>());
+        stats.chatColor = com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles.getBubble(0);
+        set(stats, "navigatorWindowSettings", new HabboNavigatorWindowSettings(42));
+        var database = mock(com.eu.habbo.database.Database.class);
+        var dataSource = mock(com.zaxxer.hikari.HikariDataSource.class);
+        var connection = mock(java.sql.Connection.class);
+        var statement = mock(java.sql.PreparedStatement.class);
+        org.mockito.Mockito.when(database.getDataSource()).thenReturn(dataSource);
+        org.mockito.Mockito.when(dataSource.getConnection()).thenReturn(connection);
+        org.mockito.Mockito.when(connection.prepareStatement(org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(statement);
+        org.mockito.Mockito.when(statement.executeUpdate())
+                .thenThrow(new java.sql.SQLException("unavailable"))
+                .thenReturn(1);
+        try (var emulator = org.mockito.Mockito.mockStatic(com.eu.habbo.Emulator.class)) {
+            emulator.when(com.eu.habbo.Emulator::getDatabase).thenReturn(database);
+            emulator.when(com.eu.habbo.Emulator::getIntUnixTimestamp).thenReturn(1100, 1300);
+            stats.run();
+            assertEquals(1000, lastOnlineTime.get());
+            stats.run();
+            assertEquals(1300, lastOnlineTime.get());
+            org.mockito.Mockito.verify(statement).setInt(7, 100);
+            org.mockito.Mockito.verify(statement).setInt(7, 300);
+        }
+    }
+
+    private static void set(HabboStats stats, String name, Object value) throws Exception {
+        var field = HabboStats.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(stats, value);
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/AchievementPacketsTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/AchievementPacketsTest.java
@@ -1,0 +1,192 @@
+package com.eu.habbo.messages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.habbohotel.achievements.Achievement;
+import com.eu.habbo.habbohotel.achievements.AchievementManager;
+import com.eu.habbo.habbohotel.achievements.TalentTrackLevel;
+import com.eu.habbo.habbohotel.achievements.TalentTrackType;
+import com.eu.habbo.habbohotel.items.Item;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboStats;
+import com.eu.habbo.messages.outgoing.achievements.AchievementListComposer;
+import com.eu.habbo.messages.outgoing.achievements.AchievementProgressComposer;
+import com.eu.habbo.messages.outgoing.achievements.AchievementUnlockedComposer;
+import com.eu.habbo.messages.outgoing.achievements.talenttrack.TalentLevelUpdateComposer;
+import io.netty.buffer.ByteBuf;
+import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AchievementPacketsTest {
+    @Test
+    void listKeepsBothLegacyRecordsWholeBeforeAppendingKeyedStates() throws Exception {
+        Achievement first = achievement(11, "First", 1);
+        Achievement second = achievement(22, "Second", 2);
+        AchievementManager manager = new AchievementManager();
+        manager.getAchievements().put(first.name, first);
+        manager.getAchievements().put(second.name, second);
+        GameEnvironment environment = mock(GameEnvironment.class);
+        when(environment.getAchievementManager()).thenReturn(manager);
+        Habbo habbo = habbo();
+        try (var emulator = mockStatic(Emulator.class)) {
+            emulator.when(Emulator::getGameEnvironment).thenReturn(environment);
+            ByteBuf packet = new AchievementListComposer(habbo).compose().get();
+            try {
+                packet.skipBytes(6);
+                assertEquals(2, packet.readInt());
+                readRecord(packet, 11, "First");
+                readRecord(packet, 22, "Second");
+                assertEquals("", string(packet));
+                assertEquals(2, packet.readInt());
+                assertEquals(11, packet.readInt());
+                assertEquals(1, packet.readShort());
+                assertEquals(22, packet.readInt());
+                assertEquals(2, packet.readShort());
+                assertFalse(packet.isReadable());
+            } finally {
+                packet.release();
+            }
+        }
+    }
+
+    @Test
+    void progressAndUnlockUseActualRewardFieldsAndMetadata() throws Exception {
+        Achievement achievement = achievement(11, "First", 4);
+        Habbo habbo = habbo();
+        ByteBuf progress =
+                new AchievementProgressComposer(habbo, achievement).compose().get();
+        try {
+            progress.skipBytes(6);
+            readRecord(progress, 11, "First");
+            assertEquals(4, progress.readShort());
+            assertFalse(progress.isReadable());
+        } finally {
+            progress.release();
+        }
+        ByteBuf unlocked = new AchievementUnlockedComposer(habbo, achievement, achievement.firstLevel(), 77)
+                .compose()
+                .get();
+        try {
+            unlocked.skipBytes(6);
+            assertEquals(11, unlocked.readInt());
+            assertEquals(1, unlocked.readInt());
+            assertEquals(77, unlocked.readInt());
+            assertEquals("ACH_First1", string(unlocked));
+            assertEquals(19, unlocked.readInt());
+            assertEquals(7, unlocked.readInt());
+            assertEquals(5, unlocked.readInt());
+            assertEquals(0, unlocked.readInt());
+            assertEquals(11, unlocked.readInt());
+            assertEquals("", string(unlocked));
+            assertEquals("identity", string(unlocked));
+            assertTrue(unlocked.readBoolean());
+            assertFalse(unlocked.isReadable());
+        } finally {
+            unlocked.release();
+        }
+    }
+
+    @Test
+    void talentLevelUpSendsPerkStringsAndFurnitureWithoutFakeClubDays() {
+        TalentTrackLevel level = mock(TalentTrackLevel.class);
+        level.level = 3;
+        level.hcDays = 2;
+        level.perks = new String[] {"TRADE", "HELPER"};
+        Item item = mock(Item.class);
+        when(item.getName()).thenReturn("welcome_chair");
+        when(item.getSpriteId()).thenReturn(12345);
+        level.items = Set.of(item);
+        ByteBuf packet = new TalentLevelUpdateComposer(TalentTrackType.CITIZENSHIP, level)
+                .compose()
+                .get();
+        try {
+            packet.skipBytes(6);
+            assertEquals("citizenship", string(packet));
+            assertEquals(3, packet.readInt());
+            assertEquals(2, packet.readInt());
+            assertEquals("TRADE", string(packet));
+            assertEquals("HELPER", string(packet));
+            assertEquals(2, packet.readInt());
+            assertEquals("welcome_chair", string(packet));
+            assertEquals(0, packet.readInt());
+            assertEquals("HABBO_CLUB", string(packet));
+            assertEquals(2, packet.readInt());
+            assertFalse(packet.isReadable());
+        } finally {
+            packet.release();
+        }
+    }
+
+    @Test
+    void wiredAvailabilityUsesTheAirCodeWhileKeepingTheConfiguredLookupName() {
+        var wired = mock(com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement.class);
+        when(wired.getAchievementCode()).thenReturn("WF_MyGame");
+        var room = mock(com.eu.habbo.habbohotel.rooms.Room.class);
+        when(room.getFloorItems()).thenReturn(Set.of(wired));
+        ByteBuf packet = new com.eu.habbo.messages.outgoing.wired.WiredEnvironmentComposer(room)
+                .compose()
+                .get();
+        try {
+            packet.skipBytes(6);
+            assertFalse(packet.readBoolean());
+            assertEquals(1, packet.readInt());
+            assertEquals("MyGame", string(packet));
+            assertFalse(packet.isReadable());
+            assertEquals("WF_MyGame", wired.getAchievementCode());
+        } finally {
+            packet.release();
+        }
+    }
+
+    private static void readRecord(ByteBuf packet, int id, String name) {
+        assertEquals(id, packet.readInt());
+        assertEquals(1, packet.readInt());
+        assertEquals("ACH_" + name + "1", string(packet));
+        assertEquals(0, packet.readInt());
+        assertEquals(10, packet.readInt());
+        assertEquals(7, packet.readInt());
+        assertEquals(5, packet.readInt());
+        assertEquals(0, packet.readInt());
+        assertFalse(packet.readBoolean());
+        assertEquals("identity", string(packet));
+        assertEquals("group", string(packet));
+        assertEquals(1, packet.readInt());
+        assertEquals(1, packet.readInt());
+    }
+
+    private static Achievement achievement(int id, String name, int state) throws Exception {
+        ResultSet set = mock(ResultSet.class);
+        when(set.getInt("id")).thenReturn(id);
+        when(set.getString("name")).thenReturn(name);
+        when(set.getString("category")).thenReturn("identity");
+        when(set.getInt("level")).thenReturn(1);
+        when(set.getInt("progress_needed")).thenReturn(10);
+        when(set.getInt("reward_amount")).thenReturn(7);
+        when(set.getInt("reward_type")).thenReturn(5);
+        when(set.getInt("points")).thenReturn(19);
+        when(set.getShort("state")).thenReturn((short) state);
+        when(set.getInt("display_method")).thenReturn(1);
+        when(set.getString("subcategory")).thenReturn("group");
+        return new Achievement(set);
+    }
+
+    private static Habbo habbo() {
+        Habbo habbo = mock(Habbo.class);
+        when(habbo.getHabboStats()).thenReturn(mock(HabboStats.class));
+        return habbo;
+    }
+
+    private static String string(ByteBuf packet) {
+        return packet.readCharSequence(packet.readUnsignedShort(), StandardCharsets.UTF_8)
+                .toString();
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/handshake/AchievementLoginTrackingTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/handshake/AchievementLoginTrackingTest.java
@@ -1,0 +1,16 @@
+package com.eu.habbo.messages.incoming.handshake;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class AchievementLoginTrackingTest {
+    @Test
+    void countsConsecutiveCalendarDaysWithoutRecountingReconnects() {
+        int midnight = 20000 * 86400;
+        assertEquals(8, UsernameEvent.loginStreak(7, midnight - 1, midnight + 1));
+        assertEquals(7, UsernameEvent.loginStreak(7, midnight + 1, midnight + 40000));
+        assertEquals(1, UsernameEvent.loginStreak(7, midnight - 86401, midnight));
+        assertEquals(1, UsernameEvent.loginStreak(0, 0, midnight));
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/ModifyUserSubscriptionGuardTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/ModifyUserSubscriptionGuardTest.java
@@ -1,13 +1,17 @@
 package com.eu.habbo.messages.rcon;
 
-import org.junit.jupiter.api.Test;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboStats;
+import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
+import org.junit.jupiter.api.Test;
 
 class ModifyUserSubscriptionGuardTest {
     @Test
@@ -21,18 +25,28 @@ class ModifyUserSubscriptionGuardTest {
 
     @Test
     void parsesInvalidDurationCeilingsAsDefault() {
-        assertEquals(ModifyUserSubscription.DEFAULT_MAX_DURATION_SECONDS, ModifyUserSubscription.parseMaxDuration(null));
+        assertEquals(
+                ModifyUserSubscription.DEFAULT_MAX_DURATION_SECONDS, ModifyUserSubscription.parseMaxDuration(null));
         assertEquals(ModifyUserSubscription.DEFAULT_MAX_DURATION_SECONDS, ModifyUserSubscription.parseMaxDuration("0"));
         assertEquals(60, ModifyUserSubscription.parseMaxDuration("60"));
     }
 
     @Test
     void clampsPartialRemovalToRemainingSubscriptionTime() throws Exception {
-        String source = Files.readString(Path.of("src/main/java/com/eu/habbo/messages/rcon/ModifyUserSubscription.java"));
+        var constructor = HabboInfo.class.getDeclaredConstructor(int.class, int.class);
+        constructor.setAccessible(true);
+        HabboInfo info = constructor.newInstance(42, 0);
+        HabboStats stats = mock(HabboStats.class, CALLS_REAL_METHODS);
+        var owner = HabboStats.class.getDeclaredField("habboInfo");
+        owner.setAccessible(true);
+        owner.set(stats, info);
+        Subscription subscription = mock(Subscription.class);
+        stats.subscriptions = java.util.Set.of(subscription);
+        when(subscription.getSubscriptionType()).thenReturn(Subscription.HABBO_CLUB);
+        when(subscription.isActive()).thenReturn(true);
+        when(subscription.getRemaining()).thenReturn(5);
 
-        assertTrue(source.contains("Math.min(json.duration, s.getRemaining())"),
-                "Partial subscription removal must not drive duration below the remaining time");
-        assertTrue(source.contains("rcon.subscription.max_duration_seconds"),
-                "RCON subscription duration ceiling must be configurable");
+        assertEquals(subscription, stats.removeSubscription(Subscription.HABBO_CLUB, 86400));
+        verify(subscription).addDuration(-5);
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/messages/rcon/SubscriptionRewardCoordinationTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/rcon/SubscriptionRewardCoordinationTest.java
@@ -1,0 +1,132 @@
+package com.eu.habbo.messages.rcon;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eu.habbo.Emulator;
+import com.eu.habbo.core.ConfigurationManager;
+import com.eu.habbo.core.TextsManager;
+import com.eu.habbo.habbohotel.GameEnvironment;
+import com.eu.habbo.habbohotel.commands.SubscriptionCommand;
+import com.eu.habbo.habbohotel.gameclients.GameClient;
+import com.eu.habbo.habbohotel.users.Habbo;
+import com.eu.habbo.habbohotel.users.HabboInfo;
+import com.eu.habbo.habbohotel.users.HabboManager;
+import com.eu.habbo.habbohotel.users.HabboStats;
+import com.eu.habbo.habbohotel.users.subscriptions.Subscription;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionManager;
+import com.eu.habbo.habbohotel.users.subscriptions.SubscriptionScheduler;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class SubscriptionRewardCoordinationTest {
+    enum Mutation {
+        RCON,
+        COMMAND,
+        EXPIRY
+    }
+
+    @ParameterizedTest
+    @EnumSource(Mutation.class)
+    void durationChangesWaitForTheCommittedReward(Mutation mutation) throws Exception {
+        var constructor = HabboInfo.class.getDeclaredConstructor(int.class, int.class);
+        constructor.setAccessible(true);
+        HabboInfo info = constructor.newInstance(42, 0);
+        info.setUsername("reward_user");
+        var lockField = HabboInfo.class.getDeclaredField("ledgerMutationLock");
+        lockField.setAccessible(true);
+        Object mutationLock = lockField.get(info);
+        Habbo habbo = mock(Habbo.class);
+        HabboStats stats = mock(HabboStats.class);
+        Subscription subscription = mock(Subscription.class);
+        AtomicInteger remaining = new AtomicInteger(-1);
+        var ownerField = HabboStats.class.getDeclaredField("habboInfo");
+        ownerField.setAccessible(true);
+        ownerField.set(stats, info);
+        doCallRealMethod().when(stats).removeSubscription(anyString(), anyInt());
+        when(habbo.getHabboInfo()).thenReturn(info);
+        when(habbo.getHabboStats()).thenReturn(stats);
+        when(stats.getSubscription(Subscription.HABBO_CLUB)).thenReturn(subscription);
+        stats.subscriptions = Set.of(subscription);
+        when(subscription.isActive()).thenReturn(true);
+        when(subscription.getRemaining()).thenAnswer(ignored -> remaining.get());
+        HabboManager manager = mock(HabboManager.class);
+        when(manager.getHabboInfo(42)).thenReturn(info);
+        when(manager.getHabbo(42)).thenReturn(habbo);
+        when(manager.getHabbo("reward_user")).thenReturn(habbo);
+        when(manager.getOnlineHabbos()).thenReturn(new ConcurrentHashMap<>(java.util.Map.of(42, habbo)));
+        SubscriptionManager subscriptions = new SubscriptionManager();
+        subscriptions.types.put(Subscription.HABBO_CLUB, Subscription.class);
+        GameEnvironment environment = mock(GameEnvironment.class);
+        when(environment.getHabboManager()).thenReturn(manager);
+        when(environment.getSubscriptionManager()).thenReturn(subscriptions);
+        TextsManager texts = mock(TextsManager.class);
+        when(texts.getValue(anyString(), anyString())).thenAnswer(call -> call.getArgument(1));
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        Thread worker = new Thread(() -> {
+            try (var emulator = mockStatic(Emulator.class)) {
+                emulator.when(Emulator::getGameEnvironment).thenReturn(environment);
+                emulator.when(Emulator::getConfig).thenReturn(mock(ConfigurationManager.class));
+                emulator.when(Emulator::getTexts).thenReturn(texts);
+                started.countDown();
+                switch (mutation) {
+                    case RCON -> {
+                        var payload = new ModifyUserSubscription.JSON();
+                        payload.user_id = 42;
+                        payload.type = Subscription.HABBO_CLUB;
+                        payload.action = "remove";
+                        var message = new ModifyUserSubscription();
+                        message.handle(null, payload);
+                        assertEquals(RCONMessage.STATUS_OK, message.status);
+                    }
+                    case COMMAND -> {
+                        GameClient client = mock(GameClient.class);
+                        when(client.getHabbo()).thenReturn(habbo);
+                        mock(SubscriptionCommand.class, CALLS_REAL_METHODS)
+                                .handle(client, new String[] {"sub", "reward_user", Subscription.HABBO_CLUB, "remove"});
+                    }
+                    case EXPIRY -> {
+                        SubscriptionScheduler scheduler = mock(SubscriptionScheduler.class, CALLS_REAL_METHODS);
+                        scheduler.setDisposed(true);
+                        scheduler.run();
+                    }
+                }
+            } catch (Throwable exception) {
+                failure.set(exception);
+            }
+        });
+        worker.setDaemon(true);
+        synchronized (mutationLock) {
+            worker.start();
+            org.junit.jupiter.api.Assertions.assertTrue(started.await(5, TimeUnit.SECONDS));
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (worker.isAlive() && worker.getState() != Thread.State.BLOCKED && System.nanoTime() < deadline)
+                Thread.onSpinWait();
+            assertEquals(Thread.State.BLOCKED, worker.getState());
+            remaining.set(172800);
+        }
+        worker.join(5000);
+        assertFalse(worker.isAlive());
+        assertNull(failure.get());
+        verify(subscription, never()).onExpired();
+        verify(subscription, never()).setActive(false);
+        if (mutation != Mutation.EXPIRY) verify(subscription).addDuration(-172800);
+    }
+}

--- a/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
+++ b/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
@@ -2369,10 +2369,13 @@ CONSTRUCTOR public com.eu.habbo.habbohotel.items.interactions.wired.effects.Wire
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#execute(com.eu.habbo.habbohotel.rooms.RoomUnit,com.eu.habbo.habbohotel.rooms.Room,java.lang.Object[]):boolean throws -
 METHOD-ANNOTATION com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#execute(com.eu.habbo.habbohotel.rooms.RoomUnit,com.eu.habbo.habbohotel.rooms.Room,java.lang.Object[]):boolean throws - java.lang.Deprecated[forRemoval=false, since=]
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#execute(com.eu.habbo.habbohotel.wired.core.WiredContext):void throws -
+METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#getAchievementCode(-):java.lang.String throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#getType(-):com.eu.habbo.habbohotel.wired.WiredEffectType throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#getWiredData(-):java.lang.String throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#loadWiredData(java.sql.ResultSet,com.eu.habbo.habbohotel.rooms.Room):void throws java.sql.SQLException
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#onPickUp(-):void throws -
+METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#onPickUp(com.eu.habbo.habbohotel.rooms.Room):void throws -
+METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#onPlace(com.eu.habbo.habbohotel.rooms.Room):void throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#requiresTriggeringUser(-):boolean throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#saveData(com.eu.habbo.habbohotel.items.interactions.wired.WiredSettings,com.eu.habbo.habbohotel.gameclients.GameClient):boolean throws -
 METHOD public com.eu.habbo.habbohotel.items.interactions.wired.effects.WiredEffectGiveAchievement#serializeWiredData(com.eu.habbo.messages.ServerMessage,com.eu.habbo.habbohotel.rooms.Room):void throws -
@@ -6621,6 +6624,10 @@ CONSTRUCTOR public com.eu.habbo.messages.outgoing.wired.WiredEffectDataComposer(
 METHOD protected com.eu.habbo.messages.outgoing.wired.WiredEffectDataComposer#composeInternal(-):com.eu.habbo.messages.ServerMessage throws -
 METHOD public com.eu.habbo.messages.outgoing.wired.WiredEffectDataComposer#getEffect(-):com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect throws -
 METHOD public com.eu.habbo.messages.outgoing.wired.WiredEffectDataComposer#getRoom(-):com.eu.habbo.habbohotel.rooms.Room throws -
+
+TYPE public final com.eu.habbo.messages.outgoing.wired.WiredEnvironmentComposer extends com.eu.habbo.messages.outgoing.MessageComposer
+CONSTRUCTOR public com.eu.habbo.messages.outgoing.wired.WiredEnvironmentComposer(com.eu.habbo.habbohotel.rooms.Room) throws -
+METHOD protected com.eu.habbo.messages.outgoing.wired.WiredEnvironmentComposer#composeInternal(-):com.eu.habbo.messages.ServerMessage throws -
 
 TYPE public com.eu.habbo.messages.outgoing.wired.WiredExtraDataComposer extends com.eu.habbo.messages.outgoing.MessageComposer
 CONSTRUCTOR public com.eu.habbo.messages.outgoing.wired.WiredExtraDataComposer(com.eu.habbo.habbohotel.items.interactions.InteractionWiredExtra,com.eu.habbo.habbohotel.rooms.Room) throws -

--- a/protocol/packet-field-contracts.json
+++ b/protocol/packet-field-contracts.json
@@ -19581,7 +19581,7 @@
         "className": "RoomUnitChatWhisperComposer",
         "path": "packages/communication/src/messages/outgoing/room/unit/chat/RoomUnitChatWhisperComposer.ts"
       },
-      "reason": "Java analyzer: Packet fields delegated to external constructor RoomChatMessage inside handle; TypeScript analyzer: Outgoing value recipientName + \u0027 \u0027 + message has no statically resolvable wire type"
+      "reason": "Java analyzer: Packet fields delegated to external constructor RoomChatMessage inside handle; TypeScript analyzer: Outgoing value recipientName + ' ' + message has no statically resolvable wire type"
     },
     {
       "name": "RELEASE_ISSUES",
@@ -20525,7 +20525,7 @@
         "className": "ClientHelloMessageComposer",
         "path": "packages/communication/src/messages/outgoing/handshake/ClientHelloMessageComposer.ts"
       },
-      "reason": "TypeScript analyzer: Outgoing value `NITRO-${OctaneVersion.RENDERER_VERSION.replaceAll(\u0027.\u0027, \u0027-\u0027)}` has no statically resolvable wire type"
+      "reason": "TypeScript analyzer: Outgoing value `NITRO-${OctaneVersion.RENDERER_VERSION.replaceAll('.', '-')}` has no statically resolvable wire type"
     },
     {
       "name": "SNOWWAR_LOAD_STAGE_READY",
@@ -21325,7 +21325,7 @@
         "className": "AchievementsParser",
         "path": "packages/communication/src/messages/parser/inventory/achievements/AchievementsParser.ts"
       },
-      "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Packet fields delegated to external constructor AchievementData inside parse"
+      "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
     },
     {
       "name": "GROUP_FORUM_UPDATE_MESSAGE",
@@ -21581,7 +21581,7 @@
         "className": "TalentLevelUpMessageParser",
         "path": "packages/communication/src/messages/parser/talent/TalentLevelUpMessageParser.ts"
       },
-      "reason": "Java analyzer: Data-dependent packet operations in IfStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in IfStatement inside parse"
+      "reason": "Java analyzer: Data-dependent packet operations in IfStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
     },
     {
       "name": "CLUB_GIFT_SELECTED",
@@ -25164,6 +25164,22 @@
         "symbol": "REWARD_TRACKS",
         "className": "RewardTracksMessageParser",
         "path": "packages/communication/src/messages/parser/quest/RewardTracksMessageParser.ts"
+      },
+      "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
+    },
+    {
+      "name": "WIRED_ENVIRONMENT",
+      "direction": "server_to_client",
+      "header": 5111,
+      "java": {
+        "symbol": "WiredEnvironmentComposer",
+        "className": "WiredEnvironmentComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/wired/WiredEnvironmentComposer.java"
+      },
+      "typescript": {
+        "symbol": "WIRED_ENVIRONMENT",
+        "className": "WiredEnvironmentParser",
+        "path": "packages/communication/src/messages/parser/roomevents/WiredEnvironmentParser.ts"
       },
       "reason": "Java analyzer: Data-dependent packet operations in ForEachStmt inside composeInternal; TypeScript analyzer: Data-dependent packet operations in ForStatement inside parse"
     }


### PR DESCRIPTION
## Why

Achievement jumps could skip rewards, while talent rewards could be repeated or partially saved. Persist earned rewards and tracking together, and provide the states used by the latest AIR achievements window.

## Testing

- [ ] Start against a disposable hotel database and use [Octane](https://github.com/duckietm/Octane/pull/489) with [Renderer](https://github.com/duckietm/Octane-Renderer/pull/223).
- [ ] Earn several achievement levels at once, reconnect, and confirm every currency reward, the score and highest badge persist once.
- [ ] Complete a configured talent milestone and confirm its furniture, perks and Club time are granted once.
