### PR TITLE
feat(hotel): maintenance says when it is back instead of just closing

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/MaintenanceMode.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/MaintenanceMode.java
@@ -8,6 +8,11 @@ public final class MaintenanceMode {
     public static final String KEY_MESSAGE = "hotel.maintenance.message";
     public static final String KEY_MIN_RANK = "hotel.maintenance.min_rank";
 
+    /** When the hotel is expected back, so the client can say so instead of "later". */
+    public static final String KEY_REOPEN_HOUR = "hotel.maintenance.reopen_hour";
+
+    public static final String KEY_REOPEN_MINUTE = "hotel.maintenance.reopen_minute";
+
     public static final String DEFAULT_MESSAGE =
             "The hotel is currently undergoing maintenance. Please try again later.";
     public static final int DEFAULT_MIN_RANK = 5;
@@ -27,6 +32,35 @@ public final class MaintenanceMode {
 
     public static int getMinRank() {
         return Emulator.getConfig().getInt(KEY_MIN_RANK, DEFAULT_MIN_RANK);
+    }
+
+    /** The hour the hotel says it will be back, or -1 when nobody has said. */
+    public static int getReopenHour() {
+        return Emulator.getConfig().getInt(KEY_REOPEN_HOUR, -1);
+    }
+
+    public static int getReopenMinute() {
+        return Math.max(0, Math.min(59, Emulator.getConfig().getInt(KEY_REOPEN_MINUTE, 0)));
+    }
+
+    /** Whether there is a time worth telling anybody. */
+    public static boolean hasReopenTime() {
+        int hour = getReopenHour();
+
+        return hour >= 0 && hour <= 23;
+    }
+
+    /** Sets when the hotel is expected back; an hour outside the clock clears it. */
+    public static synchronized void setReopenTime(int hour, int minute) {
+        ConfigurationManager config = Emulator.getConfig();
+        config.register(KEY_REOPEN_HOUR, "-1");
+        config.register(KEY_REOPEN_MINUTE, "0");
+
+        boolean valid = hour >= 0 && hour <= 23;
+
+        config.update(KEY_REOPEN_HOUR, Integer.toString(valid ? hour : -1));
+        config.update(KEY_REOPEN_MINUTE, Integer.toString(valid ? Math.max(0, Math.min(59, minute)) : 0));
+        config.saveToDatabase();
     }
 
     public static boolean canLogin(int rankId) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MaintenanceCommand.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/commands/MaintenanceCommand.java
@@ -4,6 +4,8 @@ import com.eu.habbo.Emulator;
 import com.eu.habbo.habbohotel.MaintenanceMode;
 import com.eu.habbo.habbohotel.gameclients.GameClient;
 import com.eu.habbo.habbohotel.rooms.RoomChatMessageBubbles;
+import com.eu.habbo.messages.outgoing.generic.alerts.HotelClosesAndWillOpenAtComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.HotelWillCloseInMinutesAndBackInComposer;
 
 public class MaintenanceCommand extends Command {
     public MaintenanceCommand() {
@@ -12,6 +14,24 @@ public class MaintenanceCommand extends Command {
                 Emulator.getTexts()
                         .getValue("commands.keys.cmd_maintenance", "maintenance;maintenancemode")
                         .split(";"));
+    }
+
+    private static int parseOr(String value, int fallback) {
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException exception) {
+            return fallback;
+        }
+    }
+
+    private static int parsePositive(String[] params, int index, int fallback) {
+        int value = params.length > index ? parseOr(params[index], fallback) : fallback;
+
+        return Math.max(1, value);
+    }
+
+    private static String clockOf() {
+        return String.format("%02d:%02d", MaintenanceMode.getReopenHour(), MaintenanceMode.getReopenMinute());
     }
 
     @Override
@@ -36,6 +56,54 @@ public class MaintenanceCommand extends Command {
         }
 
         String action = params[1].toLowerCase();
+
+        // "warn 10 30": the hotel closes in ten minutes and is back in thirty. It is the only way
+        // players hear about it before the door shuts.
+        if (action.equals("warn")) {
+            int closeInMinutes = parsePositive(params, 2, 5);
+            int reopenInMinutes = parsePositive(params, 3, 30);
+
+            Emulator.getGameServer()
+                    .getGameClientManager()
+                    .sendBroadcastResponse(
+                            new HotelWillCloseInMinutesAndBackInComposer(closeInMinutes, reopenInMinutes).compose());
+
+            gameClient
+                    .getHabbo()
+                    .whisper(
+                            Emulator.getTexts()
+                                    .getValue(
+                                            "commands.succes.cmd_maintenance.warn",
+                                            "Told everyone the hotel closes in %close% minutes, back in %reopen%.")
+                                    .replace("%close%", Integer.toString(closeInMinutes))
+                                    .replace("%reopen%", Integer.toString(reopenInMinutes)),
+                            RoomChatMessageBubbles.ALERT);
+            return true;
+        }
+
+        // "at 14:30": when the hotel says it will be back, which the closed notices carry.
+        if (action.equals("at")) {
+            String[] clock = params.length > 2 ? params[2].split(":") : new String[0];
+            int hour = clock.length > 0 ? parseOr(clock[0], -1) : -1;
+            int minute = clock.length > 1 ? parseOr(clock[1], 0) : 0;
+
+            MaintenanceMode.setReopenTime(hour, minute);
+
+            gameClient
+                    .getHabbo()
+                    .whisper(
+                            MaintenanceMode.hasReopenTime()
+                                    ? Emulator.getTexts()
+                                            .getValue("commands.succes.cmd_maintenance.at", "Back at %time%.")
+                                            .replace("%time%", clockOf())
+                                    : Emulator.getTexts()
+                                            .getValue(
+                                                    "commands.succes.cmd_maintenance.at.cleared",
+                                                    "The hotel no longer says when it will be back."),
+                            RoomChatMessageBubbles.ALERT);
+            return true;
+        }
+
         boolean enable;
 
         if (action.equals("on") || action.equals("enable") || action.equals("1")) {
@@ -62,6 +130,16 @@ public class MaintenanceCommand extends Command {
         }
 
         MaintenanceMode.setEnabled(enable, message);
+
+        // Whoever is already inside keeps playing - maintenance only shuts the door - but they are
+        // told it closed and when it is back, which is the whole point of the notice.
+        if (enable && MaintenanceMode.hasReopenTime()) {
+            Emulator.getGameServer()
+                    .getGameClientManager()
+                    .sendBroadcastResponse(new HotelClosesAndWillOpenAtComposer(
+                                    MaintenanceMode.getReopenHour(), MaintenanceMode.getReopenMinute(), false)
+                            .compose());
+        }
 
         String key = enable ? "commands.succes.cmd_maintenance.on" : "commands.succes.cmd_maintenance.off";
         String fallback = enable

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java
@@ -27,6 +27,7 @@ import com.eu.habbo.messages.outgoing.commands.AvailableCommandsComposer;
 import com.eu.habbo.messages.outgoing.gamecenter.GameCenterAccountInfoComposer;
 import com.eu.habbo.messages.outgoing.gamecenter.GameCenterGameListComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.GenericAlertComposer;
+import com.eu.habbo.messages.outgoing.generic.alerts.HotelClosedAndOpensComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.MessagesForYouComposer;
 import com.eu.habbo.messages.outgoing.habboway.nux.NewUserExperienceNotCompleteComposer;
 import com.eu.habbo.messages.outgoing.habboway.nux.NewUserIdentityComposer;
@@ -197,6 +198,7 @@ public class SecureLoginEvent extends MessageHandler {
                             "[Maintenance] Rejected resumed session for user id={} (rank below hotel.maintenance.min_rank)",
                             habbo.getHabboInfo().getId());
                     this.client.sendResponse(new GenericAlertComposer(MaintenanceMode.getMessage()));
+                    sendReopenNotice(this.client);
                     Emulator.getGameServer().getGameClientManager().forceDisposeClient(this.client);
                     return;
                 }
@@ -254,6 +256,7 @@ public class SecureLoginEvent extends MessageHandler {
                                     "[Maintenance] Rejected login for user id={} (rank below hotel.maintenance.min_rank)",
                                     this.client.getHabbo().getHabboInfo().getId());
                             this.client.sendResponse(new GenericAlertComposer(MaintenanceMode.getMessage()));
+                            sendReopenNotice(this.client);
                             Emulator.getGameServer().getGameClientManager().disposeClient(this.client);
                             return;
                         }
@@ -554,5 +557,16 @@ public class SecureLoginEvent extends MessageHandler {
         } else {
             Emulator.getGameServer().getGameClientManager().disposeClient(this.client);
         }
+    }
+
+    /**
+     * Turned away by maintenance. The message says why; this says when to come back, and the client
+     * has a window for exactly that. Without a time configured there is nothing honest to add.
+     */
+    private static void sendReopenNotice(com.eu.habbo.habbohotel.gameclients.GameClient client) {
+        if (!MaintenanceMode.hasReopenTime()) return;
+
+        client.sendResponse(
+                new HotelClosedAndOpensComposer(MaintenanceMode.getReopenHour(), MaintenanceMode.getReopenMinute()));
     }
 }

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/MaintenanceNoticeContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/MaintenanceNoticeContractTest.java
@@ -1,0 +1,64 @@
+package com.eu.habbo.habbohotel;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Maintenance used to close the door without a word. The three notices the client already knew how
+ * to draw are what turn it from abrupt into something a player can plan around.
+ */
+class MaintenanceNoticeContractTest {
+    private static String source(String path) throws Exception {
+        return Files.readString(Path.of("src/main/java/" + path));
+    }
+
+    @Test
+    void theHotelCanSayWhenItWillBeBack() throws Exception {
+        String mode = source("com/eu/habbo/habbohotel/MaintenanceMode.java");
+
+        assertTrue(mode.contains("hotel.maintenance.reopen_hour"));
+        assertTrue(mode.contains("hotel.maintenance.reopen_minute"));
+        // An hour outside the clock means nobody has said, and nothing is announced.
+        assertTrue(mode.contains("return hour >= 0 && hour <= 23;"));
+    }
+
+    @Test
+    void theWarningReachesEverybodyBeforeTheDoorShuts() throws Exception {
+        String command = source("com/eu/habbo/habbohotel/commands/MaintenanceCommand.java");
+
+        assertTrue(command.contains("if (action.equals(\"warn\"))"));
+        assertTrue(command.contains("new HotelWillCloseInMinutesAndBackInComposer(closeInMinutes, reopenInMinutes)"));
+        assertTrue(command.contains("sendBroadcastResponse"));
+    }
+
+    @Test
+    void switchingItOnTellsThePlayersAlreadyInside() throws Exception {
+        String command = source("com/eu/habbo/habbohotel/commands/MaintenanceCommand.java");
+
+        assertTrue(command.contains("if (enable && MaintenanceMode.hasReopenTime())"));
+        assertTrue(command.contains("new HotelClosesAndWillOpenAtComposer("));
+        // They keep playing: maintenance only shuts the door to new logins.
+        assertTrue(command.contains("MaintenanceMode.getReopenMinute(), false)"));
+    }
+
+    @Test
+    void aRefusedLoginIsToldWhenToComeBack() throws Exception {
+        String login = source("com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java");
+
+        assertTrue(login.contains("sendReopenNotice(this.client);"));
+        assertTrue(login.contains("new HotelClosedAndOpensComposer("));
+        assertTrue(login.contains("if (!MaintenanceMode.hasReopenTime()) return;"));
+    }
+
+    @Test
+    void nothingIsAnnouncedWhenNobodySaidWhenItIsBack() throws Exception {
+        String command = source("com/eu/habbo/habbohotel/commands/MaintenanceCommand.java");
+        String login = source("com/eu/habbo/messages/incoming/handshake/SecureLoginEvent.java");
+
+        assertTrue(command.indexOf("hasReopenTime()") < command.indexOf("new HotelClosesAndWillOpenAtComposer("));
+        assertTrue(login.indexOf("hasReopenTime()") < login.indexOf("new HotelClosedAndOpensComposer("));
+    }
+}

--- a/Emulator/src/test/resources/architecture/frozen-violations.tsv
+++ b/Emulator/src/test/resources/architecture/frozen-violations.tsv
@@ -67,7 +67,7 @@ U|com/eu/habbo/database/compat/LegacySqlBridge.java|CALL|getGameEnvironment|1
 U|com/eu/habbo/database/compat/LegacyTableRenameTranslator.java|CALL|getConfig|1
 U|com/eu/habbo/gui/EmulatorDashboard.java|FIELD|version|1
 U|com/eu/habbo/habbohotel/GameEnvironment.java|CALL|getThreading|5
-U|com/eu/habbo/habbohotel/MaintenanceMode.java|CALL|getConfig|4
+U|com/eu/habbo/habbohotel/MaintenanceMode.java|CALL|getConfig|7
 U|com/eu/habbo/habbohotel/achievements/AchievementManager.java|CALL|getDatabase|5
 U|com/eu/habbo/habbohotel/achievements/AchievementManager.java|CALL|getGameEnvironment|5
 U|com/eu/habbo/habbohotel/achievements/AchievementManager.java|CALL|getPluginManager|4
@@ -237,7 +237,8 @@ U|com/eu/habbo/habbohotel/commands/ListPrefixesCommand.java|CALL|getGameEnvironm
 U|com/eu/habbo/habbohotel/commands/ListPrefixesCommand.java|CALL|getTexts|5
 U|com/eu/habbo/habbohotel/commands/MachineBanCommand.java|CALL|getGameEnvironment|2
 U|com/eu/habbo/habbohotel/commands/MachineBanCommand.java|CALL|getTexts|5
-U|com/eu/habbo/habbohotel/commands/MaintenanceCommand.java|CALL|getTexts|6
+U|com/eu/habbo/habbohotel/commands/MaintenanceCommand.java|CALL|getGameServer|2
+U|com/eu/habbo/habbohotel/commands/MaintenanceCommand.java|CALL|getTexts|9
 U|com/eu/habbo/habbohotel/commands/MassBadgeCommand.java|CALL|getGameEnvironment|1
 U|com/eu/habbo/habbohotel/commands/MassBadgeCommand.java|CALL|getTexts|3
 U|com/eu/habbo/habbohotel/commands/MassCreditsCommand.java|CALL|getGameEnvironment|1


### PR DESCRIPTION
Maintenance mode shut the door with a single line and no warning at all.

The client has had three windows for this since AIR 13 and the emulator
never sent any of them: `HotelWillCloseInMinutesAndBackIn` (1350),
`HotelClosesAndWillOpenAt` (2771) and `HotelClosedAndOpens` (3728). They
sat in `Outgoing.java` with nobody instantiating them.

The hotel can now name the time it expects to be back, and that time is
what the notices carry:

- `:maintenance warn 10 30` tells everybody the hotel closes in ten
  minutes and is back in thirty, so players can finish what they are doing
- `:maintenance at 14:30` records when it reopens
- `:maintenance on` then tells everybody already inside that it closed and
  when it is back; they keep playing, because maintenance only shuts the
  door to new logins
- somebody turned away at that door is told the same, instead of being
  left to guess

With no time configured nothing is announced: there would be nothing
honest to say.

Five tests pin each of those, including that nothing goes out when the
time is unset.
