### PR TITLE
feat(wired): a box you just placed opens its own window

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -543,6 +543,7 @@ import com.eu.habbo.messages.incoming.wired.WiredFeatureCapabilitiesEvent;
 import com.eu.habbo.messages.incoming.wired.WiredFurniRuntimeStateRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredMenuPermissionsSaveEvent;
 import com.eu.habbo.messages.incoming.wired.WiredMonitorRequestEvent;
+import com.eu.habbo.messages.incoming.wired.WiredOpenEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomLogsPageEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomSettingsRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomSettingsSaveEvent;
@@ -1316,6 +1317,7 @@ public class PacketManager {
         this.registerHandler(Incoming.WiredUserInspectMoveEvent, WiredUserInspectMoveEvent.class);
         this.registerHandler(Incoming.WiredFurniRuntimeStateRequestEvent, WiredFurniRuntimeStateRequestEvent.class);
         this.registerHandler(Incoming.WiredFeatureCapabilitiesEvent, WiredFeatureCapabilitiesEvent.class);
+        this.registerHandler(Incoming.WiredOpenEvent, WiredOpenEvent.class);
         this.registerHandler(Incoming.WiredUserSelectedEvent, WiredUserSelectedEvent.class);
         this.registerHandler(Incoming.WiredMenuPermissionsSaveEvent, WiredMenuPermissionsSaveEvent.class);
         this.registerHandler(Incoming.WiredRoomStateActionEvent, WiredRoomStateActionEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -505,6 +505,8 @@ public class Incoming {
     public static final int WiredUserInspectMoveEvent = 10027;
     public static final int WiredFurniRuntimeStateRequestEvent = 10028;
     public static final int WiredFeatureCapabilitiesEvent = 10029;
+
+    public static final int WiredOpenEvent = 768;
     // AIR 13 wired leftovers, all on their official ids.
     public static final int WiredUserSelectedEvent = 3122;
     public static final int WiredMenuPermissionsSaveEvent = 1936;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RoomPlaceItemEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/items/RoomPlaceItemEvent.java
@@ -26,6 +26,7 @@ import com.eu.habbo.messages.outgoing.catalog.BuildersClubSubscriptionStatusComp
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertComposer;
 import com.eu.habbo.messages.outgoing.generic.alerts.BubbleAlertKeys;
 import com.eu.habbo.messages.outgoing.inventory.RemoveHabboItemComposer;
+import com.eu.habbo.messages.outgoing.wired.WiredOpenComposer;
 
 public class RoomPlaceItemEvent extends MessageHandler {
     @Override
@@ -158,6 +159,12 @@ public class RoomPlaceItemEvent extends MessageHandler {
                 this.client.sendResponse(
                         new BubbleAlertComposer(BubbleAlertKeys.FURNITURE_PLACEMENT_ERROR.key, error.errorCode));
                 return;
+            }
+
+            // A wired box you just put down is a box you are about to configure: the official client
+            // opens its window straight away rather than making you click what you just placed.
+            if (item instanceof InteractionWired && room.canInspectWired(this.client.getHabbo())) {
+                this.client.sendResponse(new WiredOpenComposer(item));
             }
         } else {
             if (values.length < 4) return;

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/wired/WiredOpenEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/wired/WiredOpenEvent.java
@@ -1,0 +1,44 @@
+package com.eu.habbo.messages.incoming.wired;
+
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredCondition;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredEffect;
+import com.eu.habbo.habbohotel.items.interactions.InteractionWiredTrigger;
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.users.HabboItem;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.wired.WiredConditionDataComposer;
+import com.eu.habbo.messages.outgoing.wired.WiredEffectDataComposer;
+import com.eu.habbo.messages.outgoing.wired.WiredTriggerDataComposer;
+
+/**
+ * The client asking for the wired box it was told to open. It is the second half of a conversation
+ * the server starts: placing a wired box announces it, and this is the client coming back for the
+ * settings to fill the window with.
+ *
+ * <p>The rights are checked here as well as there, because a packet can arrive on its own.
+ */
+public class WiredOpenEvent extends MessageHandler {
+    @Override
+    public int getRatelimit() {
+        return 250;
+    }
+
+    @Override
+    public void handle() throws Exception {
+        Room room = this.client.getHabbo().getHabboInfo().getCurrentRoom();
+
+        if (room == null || !room.canInspectWired(this.client.getHabbo())) return;
+
+        HabboItem item = room.getHabboItem(this.packet.readInt());
+
+        if (item == null) return;
+
+        if (item instanceof InteractionWiredTrigger trigger) {
+            this.client.sendResponse(new WiredTriggerDataComposer(trigger, room));
+        } else if (item instanceof InteractionWiredEffect effect) {
+            this.client.sendResponse(new WiredEffectDataComposer(effect, room));
+        } else if (item instanceof InteractionWiredCondition condition) {
+            this.client.sendResponse(new WiredConditionDataComposer(condition, room));
+        }
+    }
+}

--- a/Emulator/src/test/java/com/eu/habbo/messages/incoming/wired/WiredOpenContractTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/messages/incoming/wired/WiredOpenContractTest.java
@@ -1,0 +1,54 @@
+package com.eu.habbo.messages.incoming.wired;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Placing a wired box and being handed its window is a conversation with two halves, and neither of
+ * them existed: the server never announced the box, and the client's answer had no handler.
+ */
+class WiredOpenContractTest {
+    private static String source(String path) throws Exception {
+        return Files.readString(Path.of("src/main/java/" + path));
+    }
+
+    @Test
+    void puttingDownAWiredBoxAnnouncesIt() throws Exception {
+        String place = source("com/eu/habbo/messages/incoming/rooms/items/RoomPlaceItemEvent.java");
+
+        assertTrue(place.contains("new WiredOpenComposer(item)"));
+        assertTrue(place.contains("item instanceof InteractionWired && room.canInspectWired(this.client.getHabbo())"));
+        // Only once the furniture is actually down.
+        assertTrue(place.indexOf("room.placeFloorFurniAt(item, tile, rotation")
+                < place.indexOf("new WiredOpenComposer(item)"));
+    }
+
+    @Test
+    void theAnswerIsRegisteredOnTheHeaderTheClientUses() throws Exception {
+        String incoming = source("com/eu/habbo/messages/incoming/Incoming.java");
+        String registry = source("com/eu/habbo/messages/PacketManager.java");
+
+        assertTrue(incoming.contains("WiredOpenEvent = 768"));
+        assertTrue(registry.contains("Incoming.WiredOpenEvent, WiredOpenEvent.class"));
+    }
+
+    @Test
+    void theWindowIsFilledWithWhateverKindOfBoxItIs() throws Exception {
+        String handler = source("com/eu/habbo/messages/incoming/wired/WiredOpenEvent.java");
+
+        assertTrue(handler.contains("new WiredTriggerDataComposer(trigger, room)"));
+        assertTrue(handler.contains("new WiredEffectDataComposer(effect, room)"));
+        assertTrue(handler.contains("new WiredConditionDataComposer(condition, room)"));
+    }
+
+    @Test
+    void aPacketThatArrivesOnItsOwnIsStillChecked() throws Exception {
+        String handler = source("com/eu/habbo/messages/incoming/wired/WiredOpenEvent.java");
+
+        assertTrue(handler.contains("if (room == null || !room.canInspectWired(this.client.getHabbo())) return;"));
+        assertTrue(handler.indexOf("canInspectWired") < handler.indexOf("room.getHabboItem("));
+    }
+}

--- a/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
+++ b/Emulator/src/test/resources/wired-compatibility/public-surface-v1.txt
@@ -6553,6 +6553,11 @@ CONSTRUCTOR public com.eu.habbo.messages.incoming.wired.WiredMonitorRequestEvent
 METHOD public com.eu.habbo.messages.incoming.wired.WiredMonitorRequestEvent#getRatelimit(-):int throws -
 METHOD public com.eu.habbo.messages.incoming.wired.WiredMonitorRequestEvent#handle(-):void throws java.lang.Exception
 
+TYPE public com.eu.habbo.messages.incoming.wired.WiredOpenEvent extends com.eu.habbo.messages.incoming.MessageHandler
+CONSTRUCTOR public com.eu.habbo.messages.incoming.wired.WiredOpenEvent(-) throws -
+METHOD public com.eu.habbo.messages.incoming.wired.WiredOpenEvent#getRatelimit(-):int throws -
+METHOD public com.eu.habbo.messages.incoming.wired.WiredOpenEvent#handle(-):void throws java.lang.Exception
+
 TYPE public com.eu.habbo.messages.incoming.wired.WiredRoomLogsPageEvent extends com.eu.habbo.messages.incoming.MessageHandler
 CONSTRUCTOR public com.eu.habbo.messages.incoming.wired.WiredRoomLogsPageEvent(-) throws -
 METHOD public com.eu.habbo.messages.incoming.wired.WiredRoomLogsPageEvent#getRatelimit(-):int throws -

--- a/protocol/packet-field-contracts.json
+++ b/protocol/packet-field-contracts.json
@@ -20253,6 +20253,28 @@
           "name": "ownerId"
         }
       ]
+    },
+    {
+      "name": "WIRED_OPEN",
+      "direction": "client_to_server",
+      "header": 768,
+      "java": {
+        "symbol": "WiredOpenEvent",
+        "className": "WiredOpenEvent",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/wired/WiredOpenEvent.java"
+      },
+      "typescript": {
+        "symbol": "WIRED_OPEN",
+        "className": "OpenMessageComposer",
+        "path": "packages/communication/src/messages/outgoing/roomevents/OpenMessageComposer.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "stuffId"
+        }
+      ]
     }
   ],
   "unpaired": [
@@ -20454,14 +20476,6 @@
       "header": 742,
       "symbol": "GET_CATALOG_PAGE_EXPIRATION",
       "path": "packages/communication/src/messages/outgoing/catalog/GetCatalogPageExpirationComposer.ts",
-      "reason": "Header is registered only by the Octane Renderer packet registry"
-    },
-    {
-      "direction": "client_to_server",
-      "side": "typescript",
-      "header": 768,
-      "symbol": "WIRED_OPEN",
-      "path": "packages/communication/src/messages/outgoing/roomevents/OpenMessageComposer.ts",
       "reason": "Header is registered only by the Octane Renderer packet registry"
     },
     {


### PR DESCRIPTION
Putting down a wired box and then having to click it is a step the official
client does not ask for: it opens the window as soon as the box is down.

Both packets that carry that conversation existed and neither end was
connected. `WiredOpen` (1830) had a composer nobody instantiated, and the
client's answer — `WIRED_OPEN` (768), which it sends the moment it receives
the first — had no handler at all. The chain was dead from both sides, so
neither half was doing anything.

Now placing a wired box announces it, and the answer fills the window with
whatever kind of box it is: trigger, effect or condition, through the same
composers the click path already uses.

The rights are checked on the answer as well as on the placement, because a
packet can always arrive on its own.

Four tests pin it, and the wired plugin surface baseline is regenerated:
the diff is five added lines and nothing removed, which is what adding a
handler looks like.
