### PR TITLE
Raid protection for rooms

### DIFF
--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -68,7 +68,9 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     private RoomRollerManager rollerManager;
     private RoomMessagingManager messagingManager;
     private RoomCycleManager cycleManager;
-    private RoomVariableManagers variableManagers;
+    private RoomUserVariableManager userVariableManager;
+    private RoomFurniVariableManager furniVariableManager;
+    private RoomVariableManager roomVariableManager;
 
     public static final Comparator<Room> SORT_SCORE = (o1, o2) -> o2.getScore() - o1.getScore();
     public static final Comparator<Room> SORT_ID = (o1, o2) -> o2.getId() - o1.getId();
@@ -387,7 +389,9 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         this.rollerManager = new RoomRollerManager(this);
         this.messagingManager = new RoomMessagingManager(this);
         this.cycleManager = new RoomCycleManager(this);
-        this.variableManagers = new RoomVariableManagers(this, this.dependencies);
+        this.userVariableManager = new RoomUserVariableManager(this);
+        this.furniVariableManager = new RoomFurniVariableManager(this);
+        this.roomVariableManager = new RoomVariableManager(this);
     }
 
     // ==================== MANAGER GETTERS ====================
@@ -470,19 +474,15 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     }
 
     public RoomUserVariableManager getUserVariableManager() {
-        return this.variableManagers.user();
+        return this.userVariableManager;
     }
 
     public RoomFurniVariableManager getFurniVariableManager() {
-        return this.variableManagers.furni();
+        return this.furniVariableManager;
     }
 
     public RoomVariableManager getRoomVariableManager() {
-        return this.variableManagers.room();
-    }
-
-    public RoomArrayVariableManager getArrayVariableManager() {
-        return this.variableManagers.array();
+        return this.roomVariableManager;
     }
 
     /**

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -10,7 +10,6 @@ import com.eu.habbo.habbohotel.users.DanceType;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.core.WiredMovementPhysics;
-import com.eu.habbo.habbohotel.rooms.raidprotection.RaidProtectionSettings;
 import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.rooms.HideDoorbellComposer;
@@ -69,9 +68,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     private RoomRollerManager rollerManager;
     private RoomMessagingManager messagingManager;
     private RoomCycleManager cycleManager;
-    private RoomUserVariableManager userVariableManager;
-    private RoomFurniVariableManager furniVariableManager;
-    private RoomVariableManager roomVariableManager;
+    private RoomVariableManagers variableManagers;
 
     public static final Comparator<Room> SORT_SCORE = (o1, o2) -> o2.getScore() - o1.getScore();
     public static final Comparator<Room> SORT_ID = (o1, o2) -> o2.getId() - o1.getId();
@@ -390,9 +387,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         this.rollerManager = new RoomRollerManager(this);
         this.messagingManager = new RoomMessagingManager(this);
         this.cycleManager = new RoomCycleManager(this);
-        this.userVariableManager = new RoomUserVariableManager(this);
-        this.furniVariableManager = new RoomFurniVariableManager(this);
-        this.roomVariableManager = new RoomVariableManager(this);
+        this.variableManagers = new RoomVariableManagers(this, this.dependencies);
     }
 
     // ==================== MANAGER GETTERS ====================
@@ -475,15 +470,19 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     }
 
     public RoomUserVariableManager getUserVariableManager() {
-        return this.userVariableManager;
+        return this.variableManagers.user();
     }
 
     public RoomFurniVariableManager getFurniVariableManager() {
-        return this.furniVariableManager;
+        return this.variableManagers.furni();
     }
 
     public RoomVariableManager getRoomVariableManager() {
-        return this.roomVariableManager;
+        return this.variableManagers.room();
+    }
+
+    public RoomArrayVariableManager getArrayVariableManager() {
+        return this.variableManagers.array();
     }
 
     /**
@@ -1676,13 +1675,13 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
     public void talk(Habbo habbo, RoomChatMessage roomChatMessage, RoomChatType chatType) {
         this.chatManager.talk(habbo, roomChatMessage, chatType);
-        this.scoreRaidProtection(habbo, roomChatMessage);
+        this.raidProtection.onTalk(habbo, roomChatMessage);
     }
 
     public void talk(
             final Habbo habbo, final RoomChatMessage roomChatMessage, RoomChatType chatType, boolean ignoreWired) {
         this.chatManager.talk(habbo, roomChatMessage, chatType, ignoreWired);
-        this.scoreRaidProtection(habbo, roomChatMessage);
+        this.raidProtection.onTalk(habbo, roomChatMessage);
     }
 
     public Set<RoomTile> getLockedTiles() {
@@ -1880,34 +1879,8 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         return this.wiredAccess.save(inspectMask, modifyMask, timezone);
     }
 
-    public boolean canManageRaidProtection(Habbo habbo) {
-        return this.raidProtection.canManage(habbo);
-    }
-
-    public RaidProtectionSettings getRaidProtectionSettings() {
-        return this.raidProtection.settings();
-    }
-
-    public int getLastRaidAtSeconds() {
-        return this.raidProtection.lastRaidAtSeconds();
-    }
-
-    public boolean isRaidIncidentActive() {
-        return this.raidProtection.incidentActive();
-    }
-
-    /** Returns one of the RoomRaidProtectionService result codes the client understands. */
-    public int saveRaidProtectionSettings(Habbo habbo, RaidProtectionSettings settings) {
-        return this.raidProtection.save(habbo, settings);
-    }
-
-    /** Feeds a chat message to raid protection. Commands and wired output are not people talking. */
-    private void scoreRaidProtection(Habbo habbo, RoomChatMessage roomChatMessage) {
-        if (roomChatMessage == null || roomChatMessage.isCommand) {
-            return;
-        }
-
-        this.raidProtection.onTalk(habbo, roomChatMessage.getMessage());
+    public RoomRaidProtectionService getRaidProtection() {
+        return this.raidProtection;
     }
 
     public void giveRights(Habbo habbo) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/Room.java
@@ -10,6 +10,7 @@ import com.eu.habbo.habbohotel.users.DanceType;
 import com.eu.habbo.habbohotel.users.Habbo;
 import com.eu.habbo.habbohotel.users.HabboItem;
 import com.eu.habbo.habbohotel.wired.core.WiredMovementPhysics;
+import com.eu.habbo.habbohotel.rooms.raidprotection.RaidProtectionSettings;
 import com.eu.habbo.messages.ISerialize;
 import com.eu.habbo.messages.ServerMessage;
 import com.eu.habbo.messages.outgoing.rooms.HideDoorbellComposer;
@@ -126,6 +127,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
     private final RoomPersistence persistence;
     private final RoomRepository repository;
     private final RoomWiredAccessService wiredAccess;
+    private final RoomRaidProtectionService raidProtection;
     private final RoomWiredVisibilityService wiredVisibility = new RoomWiredVisibilityService(this);
     private final RoomWiredRuntime wiredRuntime = new RoomWiredRuntime(this);
     private final RoomUserCountPersistence userCountPersistence;
@@ -257,6 +259,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         this.persistence = new RoomPersistence(this.dependencies.database());
         this.repository = new RoomRepository(this.dependencies.database());
         this.wiredAccess = new RoomWiredAccessService(this, this.repository);
+        this.raidProtection = new RoomRaidProtectionService(this, this.repository, this.dependencies.unixTime());
         this.id = id;
         this.ownerId = ownerId;
         this.userCountPersistence = this.createUserCountPersistence();
@@ -281,6 +284,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
         this.persistence = new RoomPersistence(this.dependencies.database());
         this.repository = new RoomRepository(this.dependencies.database());
         this.wiredAccess = new RoomWiredAccessService(this, this.repository);
+        this.raidProtection = new RoomRaidProtectionService(this, this.repository, this.dependencies.unixTime());
         RoomSnapshot.Initial initial = RoomSnapshot.readInitial(set);
         this.id = initial.id();
         this.ownerId = initial.ownerId();
@@ -1519,6 +1523,7 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
     public void addHabbo(Habbo habbo) {
         this.unitManager.addHabbo(habbo);
+        this.raidProtection.onArrival(habbo);
     }
 
     public void kickHabbo(Habbo habbo, boolean alert) {
@@ -1671,11 +1676,13 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
     public void talk(Habbo habbo, RoomChatMessage roomChatMessage, RoomChatType chatType) {
         this.chatManager.talk(habbo, roomChatMessage, chatType);
+        this.scoreRaidProtection(habbo, roomChatMessage);
     }
 
     public void talk(
             final Habbo habbo, final RoomChatMessage roomChatMessage, RoomChatType chatType, boolean ignoreWired) {
         this.chatManager.talk(habbo, roomChatMessage, chatType, ignoreWired);
+        this.scoreRaidProtection(habbo, roomChatMessage);
     }
 
     public Set<RoomTile> getLockedTiles() {
@@ -1871,6 +1878,36 @@ public class Room implements Comparable<Room>, ISerialize, Runnable {
 
     public boolean saveWiredSettings(int inspectMask, int modifyMask, String timezone) {
         return this.wiredAccess.save(inspectMask, modifyMask, timezone);
+    }
+
+    public boolean canManageRaidProtection(Habbo habbo) {
+        return this.raidProtection.canManage(habbo);
+    }
+
+    public RaidProtectionSettings getRaidProtectionSettings() {
+        return this.raidProtection.settings();
+    }
+
+    public int getLastRaidAtSeconds() {
+        return this.raidProtection.lastRaidAtSeconds();
+    }
+
+    public boolean isRaidIncidentActive() {
+        return this.raidProtection.incidentActive();
+    }
+
+    /** Returns one of the RoomRaidProtectionService result codes the client understands. */
+    public int saveRaidProtectionSettings(Habbo habbo, RaidProtectionSettings settings) {
+        return this.raidProtection.save(habbo, settings);
+    }
+
+    /** Feeds a chat message to raid protection. Commands and wired output are not people talking. */
+    private void scoreRaidProtection(Habbo habbo, RoomChatMessage roomChatMessage) {
+        if (roomChatMessage == null || roomChatMessage.isCommand) {
+            return;
+        }
+
+        this.raidProtection.onTalk(habbo, roomChatMessage.getMessage());
     }
 
     public void giveRights(Habbo habbo) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDependencies.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomDependencies.java
@@ -3,21 +3,32 @@ package com.eu.habbo.habbohotel.rooms;
 import com.eu.habbo.Emulator;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Objects;
+import java.util.function.IntSupplier;
 
-record RoomDependencies(ConnectionProvider database, PersistenceScheduler persistence) {
+record RoomDependencies(ConnectionProvider database, PersistenceScheduler persistence, IntSupplier unixTime) {
 
     RoomDependencies {
         Objects.requireNonNull(database, "database");
         Objects.requireNonNull(persistence, "persistence");
+        Objects.requireNonNull(unixTime, "unixTime");
     }
 
     RoomDependencies(ConnectionProvider database) {
-        this(database, Runnable::run);
+        this(database, Runnable::run, RoomDependencies::currentUnixTime);
+    }
+
+    RoomDependencies(ConnectionProvider database, PersistenceScheduler persistence) {
+        this(database, persistence, RoomDependencies::currentUnixTime);
     }
 
     static RoomDependencies runtime() {
         return new RoomDependencies(() -> Emulator.getDatabase().getDataSource().getConnection());
+    }
+
+    private static int currentUnixTime() {
+        return Math.toIntExact(Instant.now().getEpochSecond());
     }
 
     @FunctionalInterface

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -57,6 +57,7 @@ import com.eu.habbo.messages.outgoing.rooms.items.RoomFloorItemsComposer;
 import com.eu.habbo.messages.outgoing.rooms.items.RoomWallItemsComposer;
 import com.eu.habbo.messages.outgoing.rooms.pets.RoomPetComposer;
 import com.eu.habbo.messages.outgoing.rooms.promotions.RoomPromotionMessageComposer;
+import com.eu.habbo.messages.outgoing.rooms.raidprotection.RaidProtectionCapabilityComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUnitIdleComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserDanceComposer;
 import com.eu.habbo.messages.outgoing.rooms.users.RoomUserEffectComposer;
@@ -936,6 +937,10 @@ public class RoomManager {
 
         habbo.getClient().sendResponse(new RoomPaneComposer(room, room.isOwner(habbo)));
 
+        // AIR 15 raid protection: the capability is per room, and the client discards it on leaving.
+        habbo.getClient()
+                .sendResponse(new RaidProtectionCapabilityComposer(room.getId(), room.canManageRaidProtection(habbo)));
+
         habbo.getClient().sendResponse(new RoomThicknessComposer(room));
 
         habbo.getClient()
@@ -1661,6 +1666,11 @@ public class RoomManager {
 
     public void banUserFromRoom(Habbo rights, int userId, int roomId, RoomBanTypes length) {
         this.roomModerationService.banUser(rights, userId, roomId, length);
+    }
+
+    /** Bans for an arbitrary number of seconds, for callers whose duration is not a preset. */
+    public void banUserFromRoom(Habbo rights, int userId, int roomId, int durationSeconds) {
+        this.roomModerationService.banUser(rights, userId, roomId, durationSeconds);
     }
 
     public void registerGameType(Class<? extends Game> gameClass) {

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomManager.java
@@ -939,7 +939,8 @@ public class RoomManager {
 
         // AIR 15 raid protection: the capability is per room, and the client discards it on leaving.
         habbo.getClient()
-                .sendResponse(new RaidProtectionCapabilityComposer(room.getId(), room.canManageRaidProtection(habbo)));
+                .sendResponse(new RaidProtectionCapabilityComposer(
+                        room.getId(), room.getRaidProtection().canManage(habbo)));
 
         habbo.getClient().sendResponse(new RoomThicknessComposer(room));
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomModerationService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomModerationService.java
@@ -30,6 +30,14 @@ final class RoomModerationService {
     }
 
     void banUser(Habbo rights, int userId, int roomId, RoomManager.RoomBanTypes length) {
+        this.banUser(rights, userId, roomId, length.duration);
+    }
+
+    /**
+     * Bans for an arbitrary number of seconds. Raid protection needs this: the client offers ten ban
+     * lengths, and only two of them line up with {@link RoomManager.RoomBanTypes}.
+     */
+    void banUser(Habbo rights, int userId, int roomId, int durationSeconds) {
         Room room = this.rooms.apply(roomId);
         if (room == null) {
             return;
@@ -47,7 +55,7 @@ final class RoomModerationService {
             return;
         }
 
-        RoomBan roomBan = new RoomBan(roomId, userId, name, this.unixTime.getAsInt() + length.duration);
+        RoomBan roomBan = new RoomBan(roomId, userId, name, this.unixTime.getAsInt() + durationSeconds);
         this.banStore.accept(roomBan);
         room.addRoomBan(roomBan);
 

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRaidProtectionService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRaidProtectionService.java
@@ -17,15 +17,15 @@ import org.slf4j.LoggerFactory;
  * <p>Shaped after {@link RoomWiredAccessService}: settings load lazily on first use, a save updates
  * memory immediately and persists off the room thread, and a failed write rolls the memory back.
  */
-final class RoomRaidProtectionService {
+public final class RoomRaidProtectionService {
     /** The save succeeded; the client closes its window on this code. */
-    static final int RESULT_OK = 0;
+    public static final int RESULT_OK = 0;
 
     /** The user may not manage this room's protection. */
-    static final int RESULT_NOT_AUTHORIZED = 1;
+    public static final int RESULT_NOT_AUTHORIZED = 1;
 
     /** At least one value was outside the set the client offers. */
-    static final int RESULT_INVALID = 2;
+    public static final int RESULT_INVALID = 2;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RoomRaidProtectionService.class);
 
@@ -49,22 +49,22 @@ final class RoomRaidProtectionService {
         this.unixTime = unixTime;
     }
 
-    RaidProtectionSettings settings() {
+    public RaidProtectionSettings settings() {
         this.ensureLoaded();
         return this.settings;
     }
 
-    int lastRaidAtSeconds() {
+    public int lastRaidAtSeconds() {
         this.ensureLoaded();
         return this.lastRaidAtSeconds;
     }
 
-    boolean incidentActive() {
+    public boolean incidentActive() {
         return this.incidentActive;
     }
 
     /** The room's owner, plus hotel staff who can already kick and ban from the moderation tool. */
-    boolean canManage(Habbo habbo) {
+    public boolean canManage(Habbo habbo) {
         if (habbo == null) {
             return false;
         }
@@ -72,7 +72,7 @@ final class RoomRaidProtectionService {
         return this.room.isOwner(habbo) || habbo.hasPermission(Permission.ACC_SUPPORTTOOL);
     }
 
-    int save(Habbo habbo, RaidProtectionSettings requested) {
+    public int save(Habbo habbo, RaidProtectionSettings requested) {
         if (!this.canManage(habbo)) {
             return RESULT_NOT_AUTHORIZED;
         }
@@ -104,7 +104,7 @@ final class RoomRaidProtectionService {
      * Scores a user walking in. Someone with rights in the room is never part of a raid, so their
      * arrival is not counted at all.
      */
-    void onArrival(Habbo habbo) {
+    public void onArrival(Habbo habbo) {
         if (habbo == null || !this.isWatching() || this.room.hasRights(habbo)) {
             return;
         }
@@ -113,18 +113,25 @@ final class RoomRaidProtectionService {
         this.evaluate();
     }
 
-    /** Scores a chat message. Only a recent arrival's message counts; see the monitor. */
-    void onTalk(Habbo habbo, String message) {
+    /**
+     * Scores a chat message. Commands and wired output are not people talking, and only a recent
+     * arrival's message counts at all; see the monitor.
+     */
+    public void onTalk(Habbo habbo, RoomChatMessage roomChatMessage) {
+        if (roomChatMessage == null || roomChatMessage.isCommand) {
+            return;
+        }
+
         if (habbo == null || !this.isWatching() || this.room.hasRights(habbo)) {
             return;
         }
 
-        this.monitor.recordMessage(habbo.getHabboInfo().getId(), message, this.now());
+        this.monitor.recordMessage(habbo.getHabboInfo().getId(), roomChatMessage.getMessage(), this.now());
         this.evaluate();
     }
 
     /** Drops the live score, for a room that is unloading. */
-    void reset() {
+    public void reset() {
         this.monitor.reset();
         this.incidentActive = false;
         this.guardUntilSeconds = 0L;

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRaidProtectionService.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRaidProtectionService.java
@@ -1,0 +1,241 @@
+package com.eu.habbo.habbohotel.rooms;
+
+import com.eu.habbo.habbohotel.permissions.Permission;
+import com.eu.habbo.habbohotel.rooms.raidprotection.RaidProtectionMonitor;
+import com.eu.habbo.habbohotel.rooms.raidprotection.RaidProtectionSettings;
+import com.eu.habbo.habbohotel.users.Habbo;
+import java.sql.SQLException;
+import java.util.Set;
+import java.util.function.IntSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Raid protection for one room: the stored settings, the live score, and the action taken when the
+ * score says a raid is under way.
+ *
+ * <p>Shaped after {@link RoomWiredAccessService}: settings load lazily on first use, a save updates
+ * memory immediately and persists off the room thread, and a failed write rolls the memory back.
+ */
+final class RoomRaidProtectionService {
+    /** The save succeeded; the client closes its window on this code. */
+    static final int RESULT_OK = 0;
+
+    /** The user may not manage this room's protection. */
+    static final int RESULT_NOT_AUTHORIZED = 1;
+
+    /** At least one value was outside the set the client offers. */
+    static final int RESULT_INVALID = 2;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoomRaidProtectionService.class);
+
+    private final Room room;
+    private final RoomRepository repository;
+    private final IntSupplier unixTime;
+    private final RaidProtectionMonitor monitor = new RaidProtectionMonitor();
+    private final Object lock = new Object();
+
+    private volatile boolean loaded;
+    private RaidProtectionSettings settings;
+    private int lastRaidAtSeconds;
+    private volatile boolean incidentActive;
+
+    /** Epoch second the raised guard sensitivity stops applying; 0 when no guard is running. */
+    private volatile long guardUntilSeconds;
+
+    RoomRaidProtectionService(Room room, RoomRepository repository, IntSupplier unixTime) {
+        this.room = room;
+        this.repository = repository;
+        this.unixTime = unixTime;
+    }
+
+    RaidProtectionSettings settings() {
+        this.ensureLoaded();
+        return this.settings;
+    }
+
+    int lastRaidAtSeconds() {
+        this.ensureLoaded();
+        return this.lastRaidAtSeconds;
+    }
+
+    boolean incidentActive() {
+        return this.incidentActive;
+    }
+
+    /** The room's owner, plus hotel staff who can already kick and ban from the moderation tool. */
+    boolean canManage(Habbo habbo) {
+        if (habbo == null) {
+            return false;
+        }
+
+        return this.room.isOwner(habbo) || habbo.hasPermission(Permission.ACC_SUPPORTTOOL);
+    }
+
+    int save(Habbo habbo, RaidProtectionSettings requested) {
+        if (!this.canManage(habbo)) {
+            return RESULT_NOT_AUTHORIZED;
+        }
+
+        // The client refuses out-of-range values before sending; a modified one would not.
+        if (requested == null || !requested.isValid()) {
+            return RESULT_INVALID;
+        }
+
+        this.ensureLoaded();
+
+        synchronized (this.lock) {
+            RaidProtectionSettings previous = this.settings;
+            this.settings = requested;
+
+            if (!requested.isEnabled()) {
+                this.monitor.reset();
+                this.incidentActive = false;
+                this.guardUntilSeconds = 0L;
+            }
+
+            this.room.threading().run(() -> this.persist(requested, previous));
+        }
+
+        return RESULT_OK;
+    }
+
+    /**
+     * Scores a user walking in. Someone with rights in the room is never part of a raid, so their
+     * arrival is not counted at all.
+     */
+    void onArrival(Habbo habbo) {
+        if (habbo == null || !this.isWatching() || this.room.hasRights(habbo)) {
+            return;
+        }
+
+        this.monitor.recordArrival(habbo.getHabboInfo().getId(), this.now());
+        this.evaluate();
+    }
+
+    /** Scores a chat message. Only a recent arrival's message counts; see the monitor. */
+    void onTalk(Habbo habbo, String message) {
+        if (habbo == null || !this.isWatching() || this.room.hasRights(habbo)) {
+            return;
+        }
+
+        this.monitor.recordMessage(habbo.getHabboInfo().getId(), message, this.now());
+        this.evaluate();
+    }
+
+    /** Drops the live score, for a room that is unloading. */
+    void reset() {
+        this.monitor.reset();
+        this.incidentActive = false;
+        this.guardUntilSeconds = 0L;
+    }
+
+    private boolean isWatching() {
+        return this.settings().isEnabled();
+    }
+
+    private void evaluate() {
+        long now = this.now();
+        Set<Integer> contributors = this.monitor.evaluate(this.effectiveSensitivity(now), now);
+
+        if (contributors == null || contributors.isEmpty()) {
+            return;
+        }
+
+        RaidProtectionSettings current = this.settings();
+        this.incidentActive = true;
+        this.lastRaidAtSeconds = (int) now;
+
+        if (current.isGuardEnabled()) {
+            this.guardUntilSeconds = now + current.getGuardDurationSeconds();
+        }
+
+        this.room.threading().run(() -> this.recordRaid(this.room.getId(), (int) now));
+
+        for (int userId : contributors) {
+            this.act(current, userId);
+        }
+    }
+
+    /** While the guard is running after an incident, the room watches at the guard's sensitivity. */
+    private int effectiveSensitivity(long now) {
+        RaidProtectionSettings current = this.settings();
+
+        if (current.isGuardEnabled() && now < this.guardUntilSeconds) {
+            return current.getGuardSensitivity();
+        }
+
+        return current.getDetectionSensitivity();
+    }
+
+    private void act(RaidProtectionSettings current, int userId) {
+        Habbo habbo = this.room.getHabbo(userId);
+
+        if (current.getActionType() == RaidProtectionSettings.ACTION_TEMPORARY_BAN) {
+            this.room
+                    .gameEnvironment()
+                    .getRoomManager()
+                    .banUserFromRoom(null, userId, this.room.getId(), current.getBanDurationSeconds());
+            return;
+        }
+
+        if (habbo != null) {
+            this.room.kickHabbo(habbo, true);
+        }
+    }
+
+    private long now() {
+        return this.unixTime.getAsInt();
+    }
+
+    private void ensureLoaded() {
+        if (this.loaded) {
+            return;
+        }
+
+        synchronized (this.lock) {
+            if (this.loaded) {
+                return;
+            }
+
+            this.settings = RaidProtectionSettings.defaults(this.room.getId());
+            this.lastRaidAtSeconds = 0;
+
+            try {
+                RoomRepository.RaidProtection stored = this.repository.findRaidProtection(this.room.getId());
+
+                if (stored.settings().isValid()) {
+                    this.settings = stored.settings();
+                }
+
+                this.lastRaidAtSeconds = stored.lastRaidAtSeconds();
+            } catch (SQLException exception) {
+                LOGGER.error("Caught SQL exception while loading raid protection settings", exception);
+            }
+
+            this.loaded = true;
+        }
+    }
+
+    private void persist(RaidProtectionSettings saved, RaidProtectionSettings previous) {
+        try {
+            this.repository.saveRaidProtection(saved);
+        } catch (SQLException exception) {
+            synchronized (this.lock) {
+                if (this.settings == saved) {
+                    this.settings = previous;
+                }
+            }
+
+            LOGGER.error("Caught SQL exception while saving raid protection settings", exception);
+        }
+    }
+
+    private void recordRaid(int roomId, int atSeconds) {
+        try {
+            this.repository.recordRaid(roomId, atSeconds);
+        } catch (SQLException exception) {
+            LOGGER.error("Caught SQL exception while recording a raid", exception);
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRepository.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/RoomRepository.java
@@ -1,5 +1,6 @@
 package com.eu.habbo.habbohotel.rooms;
 
+import com.eu.habbo.habbohotel.rooms.raidprotection.RaidProtectionSettings;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -26,6 +27,19 @@ final class RoomRepository {
             + "WHERE user_id = ? AND room_id = ? "
             + "ORDER BY timestamp DESC LIMIT 1";
     private static final String RECORD_VOTE_SQL = "INSERT INTO room_votes (user_id, room_id) VALUES (?, ?)";
+    private static final String FIND_RAID_PROTECTION_SQL = "SELECT enabled, detection_sensitivity, action_type, "
+            + "ban_duration_seconds, guard_enabled, guard_duration_seconds, guard_sensitivity, last_raid_at "
+            + "FROM room_raid_protection WHERE room_id = ? LIMIT 1";
+    private static final String SAVE_RAID_PROTECTION_SQL = "INSERT INTO room_raid_protection "
+            + "(room_id, enabled, detection_sensitivity, action_type, ban_duration_seconds, "
+            + "guard_enabled, guard_duration_seconds, guard_sensitivity) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE "
+            + "enabled = VALUES(enabled), detection_sensitivity = VALUES(detection_sensitivity), "
+            + "action_type = VALUES(action_type), ban_duration_seconds = VALUES(ban_duration_seconds), "
+            + "guard_enabled = VALUES(guard_enabled), guard_duration_seconds = VALUES(guard_duration_seconds), "
+            + "guard_sensitivity = VALUES(guard_sensitivity)";
+    private static final String RECORD_RAID_SQL =
+            "UPDATE room_raid_protection SET last_raid_at = ? WHERE room_id = ? LIMIT 1";
 
     private final RoomDependencies.ConnectionProvider database;
 
@@ -118,10 +132,62 @@ final class RoomRepository {
         }
     }
 
+    RaidProtection findRaidProtection(int roomId) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement = connection.prepareStatement(FIND_RAID_PROTECTION_SQL)) {
+            statement.setInt(1, roomId);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return new RaidProtection(
+                            new RaidProtectionSettings(
+                                    roomId,
+                                    resultSet.getBoolean("enabled"),
+                                    resultSet.getInt("detection_sensitivity"),
+                                    resultSet.getInt("action_type"),
+                                    resultSet.getInt("ban_duration_seconds"),
+                                    resultSet.getBoolean("guard_enabled"),
+                                    resultSet.getInt("guard_duration_seconds"),
+                                    resultSet.getInt("guard_sensitivity")),
+                            resultSet.getInt("last_raid_at"));
+                }
+            }
+        }
+
+        return new RaidProtection(RaidProtectionSettings.defaults(roomId), 0);
+    }
+
+    void saveRaidProtection(RaidProtectionSettings settings) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement = connection.prepareStatement(SAVE_RAID_PROTECTION_SQL)) {
+            statement.setInt(1, settings.getRoomId());
+            statement.setBoolean(2, settings.isEnabled());
+            statement.setInt(3, settings.getDetectionSensitivity());
+            statement.setInt(4, settings.getActionType());
+            statement.setInt(5, settings.getBanDurationSeconds());
+            statement.setBoolean(6, settings.isGuardEnabled());
+            statement.setInt(7, settings.getGuardDurationSeconds());
+            statement.setInt(8, settings.getGuardSensitivity());
+            statement.executeUpdate();
+        }
+    }
+
+    void recordRaid(int roomId, int atSeconds) throws SQLException {
+        try (Connection connection = this.database.openConnection();
+                PreparedStatement statement = connection.prepareStatement(RECORD_RAID_SQL)) {
+            statement.setInt(1, atSeconds);
+            statement.setInt(2, roomId);
+            statement.executeUpdate();
+        }
+    }
+
     record WiredSettings(int inspectMask, int modifyMask, String timezone) {
 
         static WiredSettings defaults() {
             return new WiredSettings(Room.WIRED_ACCESS_DEFAULT_INSPECT_MASK, Room.WIRED_ACCESS_DEFAULT_MODIFY_MASK, "");
         }
     }
+
+    /** The stored settings plus the one piece of history the client shows next to them. */
+    record RaidProtection(RaidProtectionSettings settings, int lastRaidAtSeconds) {}
 }

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/raidprotection/RaidProtectionMonitor.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/raidprotection/RaidProtectionMonitor.java
@@ -1,0 +1,163 @@
+package com.eu.habbo.habbohotel.rooms.raidprotection;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Scores what is happening in one room over a short sliding window and says when it looks like a
+ * raid.
+ *
+ * <p>The official client only ever transmits a sensitivity of 0, 1 or 2: what those three levels
+ * measure is not described anywhere in it, so this is our definition. A raid is a burst of arrivals
+ * that starts talking, which is why arrivals and chat feed one shared score instead of two
+ * independent rules — a busy room trips neither on its own.
+ *
+ * <p>The class holds no {@code Room} or {@code Habbo}: it takes user ids and message text so it can
+ * be unit tested directly. Deciding which arrivals count (a friend of the owner does not) belongs
+ * to the caller.
+ */
+public final class RaidProtectionMonitor {
+    /** How far back the score looks, in seconds. */
+    public static final int WINDOW_SECONDS = 30;
+
+    /** How long after arriving a user's messages still count as a newcomer's, in seconds. */
+    public static final int RECENT_ARRIVAL_SECONDS = 60;
+
+    static final int SCORE_ARRIVAL = 1;
+
+    static final int SCORE_NEWCOMER_MESSAGE = 2;
+
+    static final int SCORE_ECHOED_MESSAGE = 3;
+
+    private static final int THRESHOLD_LOW = 25;
+
+    private static final int THRESHOLD_MEDIUM = 15;
+
+    private static final int THRESHOLD_HIGH = 8;
+
+    private final Deque<ScoredEvent> events = new ArrayDeque<>();
+
+    /** Arrival times, so a message can be told from a newcomer's. Pruned with the window. */
+    private final java.util.Map<Integer, Long> arrivals = new java.util.HashMap<>();
+
+    /** The score a room must reach at the given sensitivity for an incident to fire. */
+    public static int thresholdFor(int sensitivity) {
+        return switch (sensitivity) {
+            case RaidProtectionSettings.SENSITIVITY_LOW -> THRESHOLD_LOW;
+            case RaidProtectionSettings.SENSITIVITY_HIGH -> THRESHOLD_HIGH;
+            default -> THRESHOLD_MEDIUM;
+        };
+    }
+
+    /**
+     * Records a user entering the room. The caller passes only arrivals that should count: someone
+     * with rights in the room, or a friend of the owner, is not part of a raid.
+     */
+    public void recordArrival(int userId, long nowSeconds) {
+        this.prune(nowSeconds);
+        this.arrivals.put(userId, nowSeconds);
+        this.events.addLast(new ScoredEvent(userId, nowSeconds, SCORE_ARRIVAL));
+    }
+
+    /**
+     * Records a chat message. It scores only when it comes from someone who arrived within the last
+     * {@link #RECENT_ARRIVAL_SECONDS}, and scores higher when a different user already said the
+     * same thing inside the window — the signature of a coordinated flood.
+     */
+    public void recordMessage(int userId, String message, long nowSeconds) {
+        this.prune(nowSeconds);
+
+        Long arrivedAt = this.arrivals.get(userId);
+
+        if (arrivedAt == null || (nowSeconds - arrivedAt) > RECENT_ARRIVAL_SECONDS) {
+            return;
+        }
+
+        String normalized = normalize(message);
+        int score = SCORE_NEWCOMER_MESSAGE;
+
+        if (!normalized.isEmpty() && this.isEchoOfAnotherUser(userId, normalized)) {
+            score += SCORE_ECHOED_MESSAGE;
+        }
+
+        this.events.addLast(new ScoredEvent(userId, nowSeconds, score, normalized));
+    }
+
+    /**
+     * The score currently inside the window. Exposed for diagnostics and tests; the decision itself
+     * is {@link #evaluate(int, long)}.
+     */
+    public int currentScore(long nowSeconds) {
+        this.prune(nowSeconds);
+
+        int total = 0;
+
+        for (ScoredEvent event : this.events) {
+            total += event.score();
+        }
+
+        return total;
+    }
+
+    /**
+     * Returns the users to act on when the window has reached the threshold for this sensitivity,
+     * or {@code null} when it has not.
+     *
+     * <p>Firing clears the window, so one burst produces one incident rather than an incident on
+     * every message that follows it.
+     */
+    public Set<Integer> evaluate(int sensitivity, long nowSeconds) {
+        if (this.currentScore(nowSeconds) < thresholdFor(sensitivity)) {
+            return null;
+        }
+
+        Set<Integer> contributors = new LinkedHashSet<>();
+
+        for (ScoredEvent event : this.events) {
+            contributors.add(event.userId());
+        }
+
+        this.events.clear();
+
+        return contributors;
+    }
+
+    /** Forgets everything, for a room that is closing or has just had its protection turned off. */
+    public void reset() {
+        this.events.clear();
+        this.arrivals.clear();
+    }
+
+    private boolean isEchoOfAnotherUser(int userId, String normalized) {
+        for (ScoredEvent event : this.events) {
+            if (event.userId() != userId && normalized.equals(event.message())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void prune(long nowSeconds) {
+        long cutoff = nowSeconds - WINDOW_SECONDS;
+
+        while (!this.events.isEmpty() && this.events.peekFirst().atSeconds() < cutoff) {
+            this.events.removeFirst();
+        }
+
+        this.arrivals.entrySet().removeIf(entry -> entry.getValue() < (nowSeconds - RECENT_ARRIVAL_SECONDS));
+    }
+
+    private static String normalize(String message) {
+        return (message == null) ? "" : message.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private record ScoredEvent(int userId, long atSeconds, int score, String message) {
+        ScoredEvent(int userId, long atSeconds, int score) {
+            this(userId, atSeconds, score, "");
+        }
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/raidprotection/RaidProtectionSettings.java
+++ b/Emulator/src/main/java/com/eu/habbo/habbohotel/rooms/raidprotection/RaidProtectionSettings.java
@@ -1,0 +1,118 @@
+package com.eu.habbo.habbohotel.rooms.raidprotection;
+
+/**
+ * Per-room raid protection configuration.
+ *
+ * <p>The client validates every field against a fixed set of values before sending them, and
+ * refuses anything outside it. The server repeats the check in {@link #isValid()} because a
+ * modified client would not.
+ *
+ * <p>{@code incidentActive} is deliberately absent from persistence: it answers "is a raid
+ * happening right now", which is runtime state owned by {@link RaidProtectionMonitor}.
+ */
+public final class RaidProtectionSettings {
+    public static final int SENSITIVITY_LOW = 0;
+
+    public static final int SENSITIVITY_MEDIUM = 1;
+
+    public static final int SENSITIVITY_HIGH = 2;
+
+    public static final int ACTION_KICK = 0;
+
+    public static final int ACTION_TEMPORARY_BAN = 1;
+
+    /** The ban lengths the client offers, in seconds: 5 minutes through 7 days. */
+    private static final int[] BAN_DURATIONS = {300, 900, 1800, 3600, 10800, 21600, 43200, 86400, 259200, 604800};
+
+    /** The guard lengths the client offers, in seconds: 5 minutes through 3 hours. */
+    private static final int[] GUARD_DURATIONS = {300, 900, 1800, 3600, 10800};
+
+    private final int roomId;
+    private final boolean enabled;
+    private final int detectionSensitivity;
+    private final int actionType;
+    private final int banDurationSeconds;
+    private final boolean guardEnabled;
+    private final int guardDurationSeconds;
+    private final int guardSensitivity;
+
+    public RaidProtectionSettings(
+            int roomId,
+            boolean enabled,
+            int detectionSensitivity,
+            int actionType,
+            int banDurationSeconds,
+            boolean guardEnabled,
+            int guardDurationSeconds,
+            int guardSensitivity) {
+        this.roomId = roomId;
+        this.enabled = enabled;
+        this.detectionSensitivity = detectionSensitivity;
+        this.actionType = actionType;
+        this.banDurationSeconds = banDurationSeconds;
+        this.guardEnabled = guardEnabled;
+        this.guardDurationSeconds = guardDurationSeconds;
+        this.guardSensitivity = guardSensitivity;
+    }
+
+    /** The settings a room that has never been configured starts from: off, medium, kick. */
+    public static RaidProtectionSettings defaults(int roomId) {
+        return new RaidProtectionSettings(
+                roomId, false, SENSITIVITY_MEDIUM, ACTION_KICK, 3600, false, 1800, SENSITIVITY_HIGH);
+    }
+
+    /** Whether every field is one the client could legitimately have produced. */
+    public boolean isValid() {
+        return isSensitivity(this.detectionSensitivity)
+                && isSensitivity(this.guardSensitivity)
+                && (this.actionType == ACTION_KICK || this.actionType == ACTION_TEMPORARY_BAN)
+                && contains(BAN_DURATIONS, this.banDurationSeconds)
+                && contains(GUARD_DURATIONS, this.guardDurationSeconds);
+    }
+
+    private static boolean isSensitivity(int value) {
+        return value >= SENSITIVITY_LOW && value <= SENSITIVITY_HIGH;
+    }
+
+    private static boolean contains(int[] allowed, int value) {
+        for (int candidate : allowed) {
+            if (candidate == value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public int getRoomId() {
+        return this.roomId;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public int getDetectionSensitivity() {
+        return this.detectionSensitivity;
+    }
+
+    public int getActionType() {
+        return this.actionType;
+    }
+
+    public int getBanDurationSeconds() {
+        return this.banDurationSeconds;
+    }
+
+    public boolean isGuardEnabled() {
+        return this.guardEnabled;
+    }
+
+    public int getGuardDurationSeconds() {
+        return this.guardDurationSeconds;
+    }
+
+    public int getGuardSensitivity() {
+        return this.guardSensitivity;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -543,6 +543,8 @@ import com.eu.habbo.messages.incoming.wired.WiredFeatureCapabilitiesEvent;
 import com.eu.habbo.messages.incoming.wired.WiredFurniRuntimeStateRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredMenuPermissionsSaveEvent;
 import com.eu.habbo.messages.incoming.wired.WiredMonitorRequestEvent;
+import com.eu.habbo.messages.incoming.rooms.raidprotection.RaidProtectionSettingsRequestEvent;
+import com.eu.habbo.messages.incoming.rooms.raidprotection.RaidProtectionSettingsSaveEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomLogsPageEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomSettingsRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomSettingsSaveEvent;
@@ -1320,6 +1322,9 @@ public class PacketManager {
         this.registerHandler(Incoming.WiredMenuPermissionsSaveEvent, WiredMenuPermissionsSaveEvent.class);
         this.registerHandler(Incoming.WiredRoomStateActionEvent, WiredRoomStateActionEvent.class);
         this.registerHandler(Incoming.WiredRoomLogsPageEvent, WiredRoomLogsPageEvent.class);
+        this.registerHandler(
+                Incoming.RaidProtectionSettingsRequestEvent, RaidProtectionSettingsRequestEvent.class);
+        this.registerHandler(Incoming.RaidProtectionSettingsSaveEvent, RaidProtectionSettingsSaveEvent.class);
         this.registerHandler(Incoming.WiredVariableHoldersPageEvent, WiredVariableHoldersPageEvent.class);
         this.registerHandler(Incoming.WiredVariableHoldersRequestEvent, WiredVariableHoldersRequestEvent.class);
         this.registerHandler(Incoming.WiredVariableHashesEvent, WiredVariableHashesEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/PacketManager.java
@@ -450,6 +450,8 @@ import com.eu.habbo.messages.incoming.rooms.pets.ToggleMonsterplantBreedableEven
 import com.eu.habbo.messages.incoming.rooms.promotions.BuyRoomPromotionEvent;
 import com.eu.habbo.messages.incoming.rooms.promotions.RequestPromotionRoomsEvent;
 import com.eu.habbo.messages.incoming.rooms.promotions.UpdateRoomPromotionEvent;
+import com.eu.habbo.messages.incoming.rooms.raidprotection.RaidProtectionSettingsRequestEvent;
+import com.eu.habbo.messages.incoming.rooms.raidprotection.RaidProtectionSettingsSaveEvent;
 import com.eu.habbo.messages.incoming.rooms.users.ClickUserEvent;
 import com.eu.habbo.messages.incoming.rooms.users.IgnoreRoomUserEvent;
 import com.eu.habbo.messages.incoming.rooms.users.IgnoreUserIdEvent;
@@ -543,8 +545,6 @@ import com.eu.habbo.messages.incoming.wired.WiredFeatureCapabilitiesEvent;
 import com.eu.habbo.messages.incoming.wired.WiredFurniRuntimeStateRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredMenuPermissionsSaveEvent;
 import com.eu.habbo.messages.incoming.wired.WiredMonitorRequestEvent;
-import com.eu.habbo.messages.incoming.rooms.raidprotection.RaidProtectionSettingsRequestEvent;
-import com.eu.habbo.messages.incoming.rooms.raidprotection.RaidProtectionSettingsSaveEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomLogsPageEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomSettingsRequestEvent;
 import com.eu.habbo.messages.incoming.wired.WiredRoomSettingsSaveEvent;
@@ -1322,8 +1322,7 @@ public class PacketManager {
         this.registerHandler(Incoming.WiredMenuPermissionsSaveEvent, WiredMenuPermissionsSaveEvent.class);
         this.registerHandler(Incoming.WiredRoomStateActionEvent, WiredRoomStateActionEvent.class);
         this.registerHandler(Incoming.WiredRoomLogsPageEvent, WiredRoomLogsPageEvent.class);
-        this.registerHandler(
-                Incoming.RaidProtectionSettingsRequestEvent, RaidProtectionSettingsRequestEvent.class);
+        this.registerHandler(Incoming.RaidProtectionSettingsRequestEvent, RaidProtectionSettingsRequestEvent.class);
         this.registerHandler(Incoming.RaidProtectionSettingsSaveEvent, RaidProtectionSettingsSaveEvent.class);
         this.registerHandler(Incoming.WiredVariableHoldersPageEvent, WiredVariableHoldersPageEvent.class);
         this.registerHandler(Incoming.WiredVariableHoldersRequestEvent, WiredVariableHoldersRequestEvent.class);

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/Incoming.java
@@ -722,4 +722,8 @@ public class Incoming {
     // AIR 13 self donation tool (official id 2499) and community goal vote (official id 3536)
     public static final int SelfDonationEvent = 2499;
     public static final int CommunityGoalVoteEvent = 3536;
+    // AIR 15 raid protection. The request keeps its official id 206; the save's official 2687 is
+    // already SetStackHelperAdjacentHeightEvent, so it uses the custom features range.
+    public static final int RaidProtectionSettingsRequestEvent = 206;
+    public static final int RaidProtectionSettingsSaveEvent = 9346;
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsRequestEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsRequestEvent.java
@@ -16,12 +16,14 @@ public class RaidProtectionSettingsRequestEvent extends MessageHandler {
         int roomId = this.packet.readInt();
         Room room = currentRoom();
 
-        if (room == null || room.getId() != roomId || !room.canManageRaidProtection(this.client.getHabbo())) {
+        if (room == null || room.getId() != roomId || !room.getRaidProtection().canManage(this.client.getHabbo())) {
             return;
         }
 
         this.client.sendResponse(new RaidProtectionSettingsComposer(
-                room.getRaidProtectionSettings(), room.isRaidIncidentActive(), room.getLastRaidAtSeconds()));
+                room.getRaidProtection().settings(),
+                room.getRaidProtection().incidentActive(),
+                room.getRaidProtection().lastRaidAtSeconds()));
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsRequestEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsRequestEvent.java
@@ -1,0 +1,31 @@
+package com.eu.habbo.messages.incoming.rooms.raidprotection;
+
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.raidprotection.RaidProtectionSettingsComposer;
+
+/**
+ * Official AIR 15 raid protection settings request (206): the user opened the panel for a room.
+ *
+ * <p>The requested room must be the one the user is standing in, which is what the client itself
+ * enforces before sending.
+ */
+public class RaidProtectionSettingsRequestEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        int roomId = this.packet.readInt();
+        Room room = currentRoom();
+
+        if (room == null || room.getId() != roomId || !room.canManageRaidProtection(this.client.getHabbo())) {
+            return;
+        }
+
+        this.client.sendResponse(new RaidProtectionSettingsComposer(
+                room.getRaidProtectionSettings(), room.isRaidIncidentActive(), room.getLastRaidAtSeconds()));
+    }
+
+    @Override
+    public int getRatelimit() {
+        return 500;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsSaveEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsSaveEvent.java
@@ -1,0 +1,56 @@
+package com.eu.habbo.messages.incoming.rooms.raidprotection;
+
+import com.eu.habbo.habbohotel.rooms.Room;
+import com.eu.habbo.habbohotel.rooms.raidprotection.RaidProtectionSettings;
+import com.eu.habbo.messages.incoming.MessageHandler;
+import com.eu.habbo.messages.outgoing.rooms.raidprotection.RaidProtectionSaveResultComposer;
+
+/**
+ * Official AIR 15 raid protection save.
+ *
+ * <p>The official header for this packet is 2687, which this emulator already uses for
+ * {@code SetStackHelperAdjacentHeightEvent}, so it lives in the custom features range instead.
+ *
+ * <p>The trailing {@code confirmed} flag is the client's own two-step: turning the protection on
+ * opens a confirmation dialog and the same packet is sent again with the flag set. The server does
+ * not need it to decide anything, and reads it only to consume the field.
+ */
+public class RaidProtectionSettingsSaveEvent extends MessageHandler {
+    @Override
+    public void handle() throws Exception {
+        int roomId = this.packet.readInt();
+        boolean enabled = this.packet.readBoolean();
+        int detectionSensitivity = this.packet.readInt();
+        int actionType = this.packet.readInt();
+        int banDurationSeconds = this.packet.readInt();
+        boolean guardEnabled = this.packet.readBoolean();
+        int guardDurationSeconds = this.packet.readInt();
+        int guardSensitivity = this.packet.readInt();
+        this.packet.readBoolean();
+
+        Room room = currentRoom();
+
+        if (room == null || room.getId() != roomId) {
+            return;
+        }
+
+        RaidProtectionSettings requested = new RaidProtectionSettings(
+                roomId,
+                enabled,
+                detectionSensitivity,
+                actionType,
+                banDurationSeconds,
+                guardEnabled,
+                guardDurationSeconds,
+                guardSensitivity);
+        int result = room.saveRaidProtectionSettings(this.client.getHabbo(), requested);
+
+        this.client.sendResponse(new RaidProtectionSaveResultComposer(
+                result, room.getRaidProtectionSettings(), room.isRaidIncidentActive(), room.getLastRaidAtSeconds()));
+    }
+
+    @Override
+    public int getRatelimit() {
+        return 500;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsSaveEvent.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsSaveEvent.java
@@ -43,10 +43,13 @@ public class RaidProtectionSettingsSaveEvent extends MessageHandler {
                 guardEnabled,
                 guardDurationSeconds,
                 guardSensitivity);
-        int result = room.saveRaidProtectionSettings(this.client.getHabbo(), requested);
+        int result = room.getRaidProtection().save(this.client.getHabbo(), requested);
 
         this.client.sendResponse(new RaidProtectionSaveResultComposer(
-                result, room.getRaidProtectionSettings(), room.isRaidIncidentActive(), room.getLastRaidAtSeconds()));
+                result,
+                room.getRaidProtection().settings(),
+                room.getRaidProtection().incidentActive(),
+                room.getRaidProtection().lastRaidAtSeconds()));
     }
 
     @Override

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/Outgoing.java
@@ -814,4 +814,8 @@ public class Outgoing {
     public static final int TreasureHuntUpdateComposer = 3368;
     // AIR 13 self donation tool result: the official id is free on our outgoing table.
     public static final int SelfDonationResultComposer = 2920;
+    // AIR 15 raid protection: all three official ids are free on our outgoing table.
+    public static final int RaidProtectionCapabilityComposer = 734;
+    public static final int RaidProtectionSettingsComposer = 3553;
+    public static final int RaidProtectionSaveResultComposer = 3620;
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionCapabilityComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionCapabilityComposer.java
@@ -1,0 +1,30 @@
+package com.eu.habbo.messages.outgoing.rooms.raidprotection;
+
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+/**
+ * Official AIR 15 raid protection capability (734): whether this user may manage the room's raid
+ * protection.
+ *
+ * <p>The client keys the capability on the room and throws it away as soon as the user leaves, so
+ * this is sent on entering a room rather than once per session.
+ */
+public class RaidProtectionCapabilityComposer extends MessageComposer {
+    private final int roomId;
+    private final boolean canManage;
+
+    public RaidProtectionCapabilityComposer(int roomId, boolean canManage) {
+        this.roomId = roomId;
+        this.canManage = canManage;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.RaidProtectionCapabilityComposer);
+        this.response.appendInt(this.roomId);
+        this.response.appendBoolean(this.canManage);
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSaveResultComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSaveResultComposer.java
@@ -13,6 +13,10 @@ import com.eu.habbo.messages.outgoing.Outgoing;
  * not twice.
  *
  * <p>The client closes the panel on result code 0 and leaves it open on anything else.
+ *
+ * <p>The nine snapshot appends are written out here rather than borrowed from
+ * {@link RaidProtectionSettingsComposer}: the packet contract extractor reads composeInternal
+ * statically and cannot follow a call into another class.
  */
 public class RaidProtectionSaveResultComposer extends MessageComposer {
     private final int resultCode;
@@ -33,8 +37,15 @@ public class RaidProtectionSaveResultComposer extends MessageComposer {
         this.response.init(Outgoing.RaidProtectionSaveResultComposer);
         this.response.appendInt(this.settings.getRoomId());
         this.response.appendInt(this.resultCode);
-        RaidProtectionSettingsComposer.appendAfterRoomId(
-                this.response, this.settings, this.incidentActive, this.lastRaidAtSeconds);
+        this.response.appendBoolean(this.settings.isEnabled());
+        this.response.appendInt(this.settings.getDetectionSensitivity());
+        this.response.appendInt(this.settings.getActionType());
+        this.response.appendInt(this.settings.getBanDurationSeconds());
+        this.response.appendBoolean(this.settings.isGuardEnabled());
+        this.response.appendInt(this.settings.getGuardDurationSeconds());
+        this.response.appendInt(this.settings.getGuardSensitivity());
+        this.response.appendBoolean(this.incidentActive);
+        this.response.appendInt(this.lastRaidAtSeconds);
         return this.response;
     }
 }

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSaveResultComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSaveResultComposer.java
@@ -1,0 +1,40 @@
+package com.eu.habbo.messages.outgoing.rooms.raidprotection;
+
+import com.eu.habbo.habbohotel.rooms.raidprotection.RaidProtectionSettings;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+/**
+ * Official AIR 15 raid protection save result (3620).
+ *
+ * <p>The field order is not the obvious one: the client reads the room id, then the result code,
+ * then resumes the settings snapshot from its <em>second</em> field. The room id is written once,
+ * not twice.
+ *
+ * <p>The client closes the panel on result code 0 and leaves it open on anything else.
+ */
+public class RaidProtectionSaveResultComposer extends MessageComposer {
+    private final int resultCode;
+    private final RaidProtectionSettings settings;
+    private final boolean incidentActive;
+    private final int lastRaidAtSeconds;
+
+    public RaidProtectionSaveResultComposer(
+            int resultCode, RaidProtectionSettings settings, boolean incidentActive, int lastRaidAtSeconds) {
+        this.resultCode = resultCode;
+        this.settings = settings;
+        this.incidentActive = incidentActive;
+        this.lastRaidAtSeconds = lastRaidAtSeconds;
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.RaidProtectionSaveResultComposer);
+        this.response.appendInt(this.settings.getRoomId());
+        this.response.appendInt(this.resultCode);
+        RaidProtectionSettingsComposer.appendAfterRoomId(
+                this.response, this.settings, this.incidentActive, this.lastRaidAtSeconds);
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSettingsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSettingsComposer.java
@@ -1,0 +1,49 @@
+package com.eu.habbo.messages.outgoing.rooms.raidprotection;
+
+import com.eu.habbo.habbohotel.rooms.raidprotection.RaidProtectionSettings;
+import com.eu.habbo.messages.ServerMessage;
+import com.eu.habbo.messages.outgoing.MessageComposer;
+import com.eu.habbo.messages.outgoing.Outgoing;
+
+/**
+ * Official AIR 15 raid protection settings (3553): the room's stored configuration plus the two
+ * pieces of state the panel shows next to it.
+ *
+ * <p>The field order is the client's {@code RaidProtectionSettingsSnapshot.readFromMessage}. The
+ * same ten fields, minus the leading room id, are appended by {@link
+ * RaidProtectionSaveResultComposer}.
+ */
+public class RaidProtectionSettingsComposer extends MessageComposer {
+    private final RaidProtectionSettings settings;
+    private final boolean incidentActive;
+    private final int lastRaidAtSeconds;
+
+    public RaidProtectionSettingsComposer(
+            RaidProtectionSettings settings, boolean incidentActive, int lastRaidAtSeconds) {
+        this.settings = settings;
+        this.incidentActive = incidentActive;
+        this.lastRaidAtSeconds = lastRaidAtSeconds;
+    }
+
+    /** Appends the snapshot without the room id, which both composers write themselves. */
+    static void appendAfterRoomId(
+            ServerMessage response, RaidProtectionSettings settings, boolean incidentActive, int lastRaidAtSeconds) {
+        response.appendBoolean(settings.isEnabled());
+        response.appendInt(settings.getDetectionSensitivity());
+        response.appendInt(settings.getActionType());
+        response.appendInt(settings.getBanDurationSeconds());
+        response.appendBoolean(settings.isGuardEnabled());
+        response.appendInt(settings.getGuardDurationSeconds());
+        response.appendInt(settings.getGuardSensitivity());
+        response.appendBoolean(incidentActive);
+        response.appendInt(lastRaidAtSeconds);
+    }
+
+    @Override
+    protected ServerMessage composeInternal() {
+        this.response.init(Outgoing.RaidProtectionSettingsComposer);
+        this.response.appendInt(this.settings.getRoomId());
+        appendAfterRoomId(this.response, this.settings, this.incidentActive, this.lastRaidAtSeconds);
+        return this.response;
+    }
+}

--- a/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSettingsComposer.java
+++ b/Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSettingsComposer.java
@@ -9,9 +9,9 @@ import com.eu.habbo.messages.outgoing.Outgoing;
  * Official AIR 15 raid protection settings (3553): the room's stored configuration plus the two
  * pieces of state the panel shows next to it.
  *
- * <p>The field order is the client's {@code RaidProtectionSettingsSnapshot.readFromMessage}. The
- * same ten fields, minus the leading room id, are appended by {@link
- * RaidProtectionSaveResultComposer}.
+ * <p>The field order is the client's {@code RaidProtectionSettingsSnapshot.readFromMessage}.
+ * {@link RaidProtectionSaveResultComposer} repeats these appends rather than calling in here: the
+ * packet contract extractor reads composeInternal statically and refuses a delegated serializer.
  */
 public class RaidProtectionSettingsComposer extends MessageComposer {
     private final RaidProtectionSettings settings;
@@ -25,25 +25,19 @@ public class RaidProtectionSettingsComposer extends MessageComposer {
         this.lastRaidAtSeconds = lastRaidAtSeconds;
     }
 
-    /** Appends the snapshot without the room id, which both composers write themselves. */
-    static void appendAfterRoomId(
-            ServerMessage response, RaidProtectionSettings settings, boolean incidentActive, int lastRaidAtSeconds) {
-        response.appendBoolean(settings.isEnabled());
-        response.appendInt(settings.getDetectionSensitivity());
-        response.appendInt(settings.getActionType());
-        response.appendInt(settings.getBanDurationSeconds());
-        response.appendBoolean(settings.isGuardEnabled());
-        response.appendInt(settings.getGuardDurationSeconds());
-        response.appendInt(settings.getGuardSensitivity());
-        response.appendBoolean(incidentActive);
-        response.appendInt(lastRaidAtSeconds);
-    }
-
     @Override
     protected ServerMessage composeInternal() {
         this.response.init(Outgoing.RaidProtectionSettingsComposer);
         this.response.appendInt(this.settings.getRoomId());
-        appendAfterRoomId(this.response, this.settings, this.incidentActive, this.lastRaidAtSeconds);
+        this.response.appendBoolean(this.settings.isEnabled());
+        this.response.appendInt(this.settings.getDetectionSensitivity());
+        this.response.appendInt(this.settings.getActionType());
+        this.response.appendInt(this.settings.getBanDurationSeconds());
+        this.response.appendBoolean(this.settings.isGuardEnabled());
+        this.response.appendInt(this.settings.getGuardDurationSeconds());
+        this.response.appendInt(this.settings.getGuardSensitivity());
+        this.response.appendBoolean(this.incidentActive);
+        this.response.appendInt(this.lastRaidAtSeconds);
         return this.response;
     }
 }

--- a/Emulator/src/main/resources/db/migration/V20260911213000__room_raid_protection.sql
+++ b/Emulator/src/main/resources/db/migration/V20260911213000__room_raid_protection.sql
@@ -1,0 +1,21 @@
+-- Per-room raid protection settings.
+--
+-- One row per configured room; a room without a row uses the defaults in
+-- RaidProtectionSettings.defaults(). Every column mirrors a field the official client sends, except
+-- incident_active, which answers "is a raid happening right now" and is runtime state rather than a
+-- setting: it lives in RaidProtectionMonitor and is deliberately not persisted.
+--
+-- last_raid_at is epoch seconds, 0 for a room that has never been raided.
+
+CREATE TABLE IF NOT EXISTS `room_raid_protection` (
+    `room_id` INT(11) NOT NULL,
+    `enabled` TINYINT(1) NOT NULL DEFAULT 0,
+    `detection_sensitivity` TINYINT(4) NOT NULL DEFAULT 1,
+    `action_type` TINYINT(4) NOT NULL DEFAULT 0,
+    `ban_duration_seconds` INT(11) NOT NULL DEFAULT 3600,
+    `guard_enabled` TINYINT(1) NOT NULL DEFAULT 0,
+    `guard_duration_seconds` INT(11) NOT NULL DEFAULT 1800,
+    `guard_sensitivity` TINYINT(4) NOT NULL DEFAULT 2,
+    `last_raid_at` INT(11) NOT NULL DEFAULT 0,
+    PRIMARY KEY (`room_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_general_ci;

--- a/Emulator/src/main/resources/db/runtime-schema-contract.json
+++ b/Emulator/src/main/resources/db/runtime-schema-contract.json
@@ -127,6 +127,7 @@
     "room_models_custom": ["door_dir", "door_x", "door_y", "heightmap", "id", "name"],
     "room_mutes": ["ends", "room_id", "user_id"],
     "room_promotions": ["category", "description", "end_timestamp", "room_id", "start_timestamp", "title"],
+    "room_raid_protection": ["action_type", "ban_duration_seconds", "detection_sensitivity", "enabled", "guard_duration_seconds", "guard_enabled", "guard_sensitivity", "last_raid_at", "room_id"],
     "room_rights": ["room_id", "user_id"],
     "room_templates": ["category", "description", "door_dir", "door_x", "door_y", "enabled", "heightmap", "model", "moodlight_data", "name", "override_model", "paper_floor", "paper_landscape", "paper_wall", "password", "room_description", "sort_order", "state", "template_id", "thickness_floor", "thickness_wall", "thumbnail", "title", "trade_mode", "users_max"],
     "room_templates_items": ["extra_data", "id", "item_id", "rot", "template_id", "wall_pos", "wired_data", "x", "y", "z"],

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomFacadeArchitectureTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/RoomFacadeArchitectureTest.java
@@ -16,9 +16,12 @@ class RoomFacadeArchitectureTest {
         String source = Files.readString(ROOM_SOURCE);
 
         // 2170: the AIR 13 wired settings added three one-line delegations (roll back, timezone
-        // read, three-argument save). Raise this only for delegations, never for logic.
+        // read, three-argument save).
+        // 2177: AIR 15 raid protection added the service field, its two constructor lines, the
+        // arrival and chat hooks and one accessor. The rule it enforces (a command is not someone
+        // talking) lives in the service, not here. Raise this only for delegations, never for logic.
         assertTrue(
-                source.lines().count() <= 2170,
+                source.lines().count() <= 2177,
                 "Keep Room.java below the post-extraction compatibility-facade ceiling");
         assertFalse(source.contains("prepareStatement("), "Database statements belong in collaborators");
         assertFalse(source.matches("(?s).*\"(?:SELECT|INSERT|UPDATE|DELETE) .*"));

--- a/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/raidprotection/RaidProtectionMonitorTest.java
+++ b/Emulator/src/test/java/com/eu/habbo/habbohotel/rooms/raidprotection/RaidProtectionMonitorTest.java
@@ -1,0 +1,147 @@
+package com.eu.habbo.habbohotel.rooms.raidprotection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RaidProtectionMonitorTest {
+    private static final long NOW = 1_757_600_000L;
+
+    @Test
+    @DisplayName("a room filling up quietly never trips, even at the highest sensitivity")
+    void quietArrivalsDoNotTrip() {
+        RaidProtectionMonitor monitor = new RaidProtectionMonitor();
+
+        for (int userId = 1; userId <= 7; userId++) {
+            monitor.recordArrival(userId, NOW);
+        }
+
+        assertNull(monitor.evaluate(RaidProtectionSettings.SENSITIVITY_HIGH, NOW));
+    }
+
+    @Test
+    @DisplayName("arrivals that immediately start talking trip the highest sensitivity")
+    void arrivalsThatTalkTrip() {
+        RaidProtectionMonitor monitor = new RaidProtectionMonitor();
+
+        for (int userId = 1; userId <= 3; userId++) {
+            monitor.recordArrival(userId, NOW);
+            monitor.recordMessage(userId, "hello " + userId, NOW + 1);
+        }
+
+        assertEquals(9, monitor.currentScore(NOW + 1));
+
+        Set<Integer> contributors = monitor.evaluate(RaidProtectionSettings.SENSITIVITY_HIGH, NOW + 1);
+
+        assertNotNull(contributors);
+        assertEquals(Set.of(1, 2, 3), contributors);
+    }
+
+    @Test
+    @DisplayName("the same text from a second user scores extra")
+    void echoedTextScoresExtra() {
+        RaidProtectionMonitor monitor = new RaidProtectionMonitor();
+
+        monitor.recordArrival(1, NOW);
+        monitor.recordArrival(2, NOW);
+        monitor.recordMessage(1, "JOIN OUR ROOM", NOW + 1);
+        monitor.recordMessage(2, "join our room", NOW + 2);
+
+        // Two arrivals, one newcomer message, one echoed newcomer message.
+        assertEquals(2 + 2 + 5, monitor.currentScore(NOW + 2));
+    }
+
+    @Test
+    @DisplayName("a message from someone who was already in the room does not score")
+    void residentMessagesDoNotScore() {
+        RaidProtectionMonitor monitor = new RaidProtectionMonitor();
+
+        monitor.recordMessage(99, "anyone here?", NOW);
+
+        assertEquals(0, monitor.currentScore(NOW));
+    }
+
+    @Test
+    @DisplayName("a newcomer stops being one once the arrival window has passed")
+    void newcomerWindowExpires() {
+        RaidProtectionMonitor monitor = new RaidProtectionMonitor();
+        long later = NOW + RaidProtectionMonitor.RECENT_ARRIVAL_SECONDS + 1;
+
+        monitor.recordArrival(1, NOW);
+        monitor.recordMessage(1, "still here", later);
+
+        assertEquals(0, monitor.currentScore(later));
+    }
+
+    @Test
+    @DisplayName("events older than the window stop counting")
+    void windowSlides() {
+        RaidProtectionMonitor monitor = new RaidProtectionMonitor();
+
+        for (int userId = 1; userId <= 8; userId++) {
+            monitor.recordArrival(userId, NOW);
+        }
+
+        assertEquals(8, monitor.currentScore(NOW));
+        assertEquals(0, monitor.currentScore(NOW + RaidProtectionMonitor.WINDOW_SECONDS + 1));
+    }
+
+    @Test
+    @DisplayName("the three sensitivities are three thresholds, the highest being the easiest to trip")
+    void thresholdsAreOrdered() {
+        int low = RaidProtectionMonitor.thresholdFor(RaidProtectionSettings.SENSITIVITY_LOW);
+        int medium = RaidProtectionMonitor.thresholdFor(RaidProtectionSettings.SENSITIVITY_MEDIUM);
+        int high = RaidProtectionMonitor.thresholdFor(RaidProtectionSettings.SENSITIVITY_HIGH);
+
+        assertTrue(low > medium);
+        assertTrue(medium > high);
+    }
+
+    @Test
+    @DisplayName("one burst produces one incident, not an incident per message after it")
+    void firingClearsTheWindow() {
+        RaidProtectionMonitor monitor = new RaidProtectionMonitor();
+
+        for (int userId = 1; userId <= 3; userId++) {
+            monitor.recordArrival(userId, NOW);
+            monitor.recordMessage(userId, "raid", NOW + 1);
+        }
+
+        assertNotNull(monitor.evaluate(RaidProtectionSettings.SENSITIVITY_HIGH, NOW + 1));
+        assertNull(monitor.evaluate(RaidProtectionSettings.SENSITIVITY_HIGH, NOW + 1));
+    }
+
+    @Test
+    @DisplayName("settings outside the values the client offers are refused")
+    void invalidSettingsAreRefused() {
+        assertTrue(RaidProtectionSettings.defaults(7).isValid());
+
+        RaidProtectionSettings badDuration = new RaidProtectionSettings(
+                7,
+                true,
+                RaidProtectionSettings.SENSITIVITY_HIGH,
+                RaidProtectionSettings.ACTION_TEMPORARY_BAN,
+                42,
+                false,
+                1800,
+                RaidProtectionSettings.SENSITIVITY_HIGH);
+        RaidProtectionSettings badSensitivity = new RaidProtectionSettings(
+                7,
+                true,
+                9,
+                RaidProtectionSettings.ACTION_KICK,
+                3600,
+                false,
+                1800,
+                RaidProtectionSettings.SENSITIVITY_HIGH);
+
+        assertFalse(badDuration.isValid());
+        assertFalse(badSensitivity.isValid());
+    }
+}

--- a/protocol/packet-field-contracts.json
+++ b/protocol/packet-field-contracts.json
@@ -20253,6 +20253,256 @@
           "name": "ownerId"
         }
       ]
+    },
+    {
+      "name": "RAID_PROTECTION_SETTINGS_REQUEST",
+      "direction": "client_to_server",
+      "header": 206,
+      "java": {
+        "symbol": "RaidProtectionSettingsRequestEvent",
+        "className": "RaidProtectionSettingsRequestEvent",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsRequestEvent.java"
+      },
+      "typescript": {
+        "symbol": "RAID_PROTECTION_SETTINGS_REQUEST",
+        "className": "RaidProtectionSettingsRequestComposer",
+        "path": "packages/communication/src/messages/outgoing/roomsettings/RaidProtectionSettingsRequestComposer.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "roomId"
+        }
+      ]
+    },
+    {
+      "name": "RAID_PROTECTION_SETTINGS_SAVE",
+      "direction": "client_to_server",
+      "header": 9346,
+      "java": {
+        "symbol": "RaidProtectionSettingsSaveEvent",
+        "className": "RaidProtectionSettingsSaveEvent",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/incoming/rooms/raidprotection/RaidProtectionSettingsSaveEvent.java"
+      },
+      "typescript": {
+        "symbol": "RAID_PROTECTION_SETTINGS_SAVE",
+        "className": "RaidProtectionSettingsSaveComposer",
+        "path": "packages/communication/src/messages/outgoing/roomsettings/RaidProtectionSettingsSaveComposer.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "roomId"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "detectionSensitivity"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "actionType"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "banDurationSeconds"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "guardEnabled"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "guardDurationSeconds"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "guardSensitivity"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "confirmed"
+        }
+      ]
+    },
+    {
+      "name": "RAID_PROTECTION_CAPABILITY",
+      "direction": "server_to_client",
+      "header": 734,
+      "java": {
+        "symbol": "RaidProtectionCapabilityComposer",
+        "className": "RaidProtectionCapabilityComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionCapabilityComposer.java"
+      },
+      "typescript": {
+        "symbol": "RAID_PROTECTION_CAPABILITY",
+        "className": "RaidProtectionCapabilityParser",
+        "path": "packages/communication/src/messages/parser/roomsettings/RaidProtectionCapabilityParser.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "roomId"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "canManage"
+        }
+      ]
+    },
+    {
+      "name": "RAID_PROTECTION_SETTINGS",
+      "direction": "server_to_client",
+      "header": 3553,
+      "java": {
+        "symbol": "RaidProtectionSettingsComposer",
+        "className": "RaidProtectionSettingsComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSettingsComposer.java"
+      },
+      "typescript": {
+        "symbol": "RAID_PROTECTION_SETTINGS",
+        "className": "RaidProtectionSettingsParser",
+        "path": "packages/communication/src/messages/parser/roomsettings/RaidProtectionSettingsParser.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "roomId"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "detectionSensitivity"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "actionType"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "banDurationSeconds"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "guardEnabled"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "guardDurationSeconds"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "guardSensitivity"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "incidentActive"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "lastRaidAtEpochSeconds"
+        }
+      ]
+    },
+    {
+      "name": "RAID_PROTECTION_SAVE_RESULT",
+      "direction": "server_to_client",
+      "header": 3620,
+      "java": {
+        "symbol": "RaidProtectionSaveResultComposer",
+        "className": "RaidProtectionSaveResultComposer",
+        "path": "Emulator/src/main/java/com/eu/habbo/messages/outgoing/rooms/raidprotection/RaidProtectionSaveResultComposer.java"
+      },
+      "typescript": {
+        "symbol": "RAID_PROTECTION_SAVE_RESULT",
+        "className": "RaidProtectionSaveResultParser",
+        "path": "packages/communication/src/messages/parser/roomsettings/RaidProtectionSaveResultParser.ts"
+      },
+      "fields": [
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "roomId"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "resultCode"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "enabled"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "detectionSensitivity"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "actionType"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "banDurationSeconds"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "guardEnabled"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "guardDurationSeconds"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "guardSensitivity"
+        },
+        {
+          "kind": "scalar",
+          "type": "boolean",
+          "name": "incidentActive"
+        },
+        {
+          "kind": "scalar",
+          "type": "int",
+          "name": "lastRaidAtEpochSeconds"
+        }
+      ]
     }
   ],
   "unpaired": [
@@ -21584,7 +21834,7 @@
         "className": "RoomUnitChatWhisperComposer",
         "path": "packages/communication/src/messages/outgoing/room/unit/chat/RoomUnitChatWhisperComposer.ts"
       },
-      "reason": "Java analyzer: Packet fields delegated to external constructor RoomChatMessage inside handle; TypeScript analyzer: Outgoing value recipientName + \u0027 \u0027 + message has no statically resolvable wire type"
+      "reason": "Java analyzer: Packet fields delegated to external constructor RoomChatMessage inside handle; TypeScript analyzer: Outgoing value recipientName + ' ' + message has no statically resolvable wire type"
     },
     {
       "name": "RELEASE_ISSUES",


### PR DESCRIPTION
Server side of the AIR 15 room raid protection panel.

The client ships the panel but only ever transmits a sensitivity of 0, 1 or 2 — what those levels measure is not in it. Here one sliding window over 30 seconds scores arrivals and the chat those arrivals produce, so a room that is merely busy trips nothing and a coordinated flood trips quickly.

- `room_raid_protection` holds the eight settings plus the last raid. Whether a raid is happening *right now* is runtime state and is deliberately not persisted.
- The action hits only the users who scored inside the window, never everyone in the room. Anyone with rights in the room is never counted, on arrival or in chat.
- `RoomManager.banUserFromRoom` gained an arbitrary-seconds overload: the client offers ten ban lengths and `RoomBanTypes` has three. The existing signature is untouched.
- Settings coming from the client are revalidated server side against the allowed value sets.
- Headers: 206 and the three server ones keep their official ids; the save's official 2687 is already `SetStackHelperAdjacentHeightEvent`, so it takes **9346** from the custom features range.

Pairs with Octane-Renderer#225 — `protocol/packet-field-contracts.json` is byte-identical to that branch.

Nine tests cover the three thresholds, the sliding window, the echo bonus and the rejection of out-of-range settings. `MigrationRunnerIT` skips without Docker on my machine, so the migration is covered by the schema contract rather than by an executed run.
